### PR TITLE
Button bar button tooltip translation fix

### DIFF
--- a/src/app/pages/main/button-bar/button-bar.html
+++ b/src/app/pages/main/button-bar/button-bar.html
@@ -15,7 +15,7 @@
           [class.bb-tool--warning]="e.variant === 'warning'"
           [class.bb-tool--danger]="e.variant === 'danger'"
           (click)="onClick(e.id)"
-          [ngbTooltip]="e.label"
+          [ngbTooltip]="e.label | translate"
           placement="bottom"
           container="body"
           [disableTooltip]="!compact"


### PR DESCRIPTION
## 🔗 Issue ID

Fixes #3: [BUG]: tooltip texts are not translated properly 

## 📖 Description

<img width="464" height="146" alt="image" src="https://github.com/user-attachments/assets/361f996a-d475-4b13-b79a-69fc5d7bdb69" />

Now the button bar tooltips show the translated text instead of their translation keys.