### PR TITLE
Changing settings switches to one-liners in Add Torrent view

### DIFF
--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -44,7 +44,14 @@
         "rename": "Átnevezés",
         "skip-hash-checking": "Hash-ellenőrzés kihagyása",
         "paused": "Hozzáadás felfüggesztett állapotban",
-        "root-folder": "Gyökérmappa",
+        "root-folder": {
+          "title": "Gyökérmappa",
+          "option": {
+            "default": "Alapértelmezett",
+            "create-root-folder": "Gyökérmappa létrehozása",
+            "do-not-create-root-folder": "Ne hozzon létre gyökérmappát"
+          }
+        },
         "auto-tmm": "Automatikus Torrentkezelés (TMM) használata",
         "sequential-download": "Sorrendi letöltés engedélyezése",
         "first-last-piece-prio": "Első és utolsó szelet priorizálása",
@@ -59,6 +66,15 @@
         "limits": "Korlátok"
       },
       "popover": {
+        "root-folder": {
+          "title": "Gyökérmappa",
+          "description": {
+            "line1": "Meghatározza, hogy a torrent fájljai egy gyűjtőmappába kerüljenek, vagy közvetlenül a letöltési mentési útvonalra.",
+            "line2": "<strong>Alapértelmezett:</strong> A qBittorrent globális beállításaiban megadott értéket használja.",
+            "line3": "<strong>Gyökérmappa létrehozása:</strong> Mindenképpen létrehoz egy (a torrent neve alapján elnevezett) mappát a letöltési könyvtáron belül.",
+            "line4": "<strong>Ne hozzon létre gyökérmappát:</strong> A fájlokat közvetlenül a letöltési könyvtárba helyezi. Hasznos egyetlen fájlból álló torrentek esetén a felesleges almappák elkerüléséhez."
+          }
+        },
         "skip-hash-checking": {
           "title": "Hash-ellenőrzés kihagyása",
           "description": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -44,7 +44,14 @@
         "rename": "Rename",
         "skip-hash-checking": "Skip hash checking",
         "paused": "Add torrents in the paused state",
-        "root-folder": "Root Folder",
+        "root-folder": {
+          "title": "Root Folder",
+          "option": {
+            "default": "Default (unset)",
+            "create-root-folder": "Create root folder",
+            "do-not-create-root-folder": "Do not create root folder"
+          }
+        },
         "auto-tmm": "Use Auto TMM",
         "sequential-download": "Enable sequential download",
         "first-last-piece-prio": "Prioritize download first last piece",
@@ -59,6 +66,15 @@
         "limits": "Limits"
       },
       "popover": {
+        "root-folder": {
+          "title": "Root Folder",
+          "description": {
+            "line1": "Controls whether the torrent’s files are nested inside a main folder or placed directly in the download path.",
+            "line2": "<strong>Default (unset):</strong> Uses the global setting defined in your qBittorrent options.",
+            "line3": "<strong>Create root folder:</strong> Forces the creation of a containing folder (based on the torrent's name) inside your download directory.",
+            "line4": "<strong>Do not create root folder:</strong> Places the contents directly into the download directory. This is useful for single-file torrents to avoid unnecessary subfolders."
+          }
+        },
         "skip-hash-checking": {
           "title": "Skip hash checking",
           "description": {

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -28,6 +28,7 @@
               (addForm.controls.file.touched || addForm.controls.file.dirty)
             "
             readonly
+            (click)="fileInput.click()"
           />
           <label for="file_browser">{{
             'components.add-torrent.add-form.file-browser' | translate
@@ -106,7 +107,32 @@
 
     <div class="container-fluid px-0">
       <div class="row">
-        <div class="col-6">
+        <div class="col-11">
+          <div class="form-floating mb-3">
+            <ng-select
+              id="root_folder"
+              formControlName="root_folder"
+              [items]="rootFolderOptions"
+              bindValue="value"
+              bindLabel="label"
+              [clearable]="false"
+              [searchable]="false"
+            ></ng-select>
+            <label for="root_folder">{{
+              'components.add-torrent.add-form.root-folder.title' | translate
+            }}</label>
+          </div>
+        </div>
+
+        <div class="col-1 d-flex align-items-center mb-3">
+          <bb-popover
+            [subject]="'components.add-torrent.popover.root-folder.title' | translate"
+            [description]="rootFolder"
+            placement="left"
+          ></bb-popover>
+        </div>
+
+        <div class="col-12">
           <div class="form-check form-switch mb-3">
             <input
               class="form-check-input"
@@ -121,11 +147,12 @@
             <bb-popover
               [subject]="'components.add-torrent.popover.skip-hash-checking.title' | translate"
               [description]="skipChecking"
+              placement="right"
             ></bb-popover>
           </div>
         </div>
 
-        <div class="col-6">
+        <div class="col-12">
           <div class="form-check form-switch mb-3">
             <input
               class="form-check-input"
@@ -140,29 +167,12 @@
             <bb-popover
               [subject]="'components.add-torrent.popover.paused-state.title' | translate"
               [description]="pausedState"
-              placement="left"
+              placement="right"
             ></bb-popover>
           </div>
         </div>
 
         <div class="col-12">
-          <div class="form-floating mb-3">
-            <ng-select
-              id="root_folder"
-              formControlName="root_folder"
-              [items]="rootFolderOptions"
-              bindValue="value"
-              bindLabel="label"
-              [clearable]="false"
-              [searchable]="false"
-            ></ng-select>
-            <label for="root_folder">{{
-              'components.add-torrent.add-form.root-folder' | translate
-            }}</label>
-          </div>
-        </div>
-
-        <div class="col-6">
           <div class="form-check form-switch mb-3">
             <input
               class="form-check-input"
@@ -177,11 +187,12 @@
             <bb-popover
               [subject]="'components.add-torrent.popover.auto-tmm.title' | translate"
               [description]="autoTMM"
+              placement="right"
             ></bb-popover>
           </div>
         </div>
 
-        <div class="col-6">
+        <div class="col-12">
           <div class="form-check form-switch mb-3">
             <input
               class="form-check-input"
@@ -197,11 +208,12 @@
               [subject]="'components.add-torrent.popover.sequential-download.title' | translate"
               [description]="sequentialDownload"
               placement="left"
+              placement="right"
             ></bb-popover>
           </div>
         </div>
 
-        <div class="col-6">
+        <div class="col-12">
           <div class="form-check form-switch mb-3">
             <input
               class="form-check-input"
@@ -216,6 +228,7 @@
             <bb-popover
               [subject]="'components.add-torrent.popover.first-last-piece-prio.title' | translate"
               [description]="firstLastPiece"
+              placement="right"
             ></bb-popover>
           </div>
         </div>
@@ -335,6 +348,21 @@
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>
+
+<ng-template #rootFolder>
+  <p>{{ 'components.add-torrent.popover.root-folder.description.line1' | translate }}</p>
+  <ul class="mb-0">
+    <li
+      [innerHTML]="'components.add-torrent.popover.root-folder.description.line2' | translate"
+    ></li>
+    <li
+      [innerHTML]="'components.add-torrent.popover.root-folder.description.line3' | translate"
+    ></li>
+    <li
+      [innerHTML]="'components.add-torrent.popover.root-folder.description.line4' | translate"
+    ></li>
+  </ul>
+</ng-template>
 
 <ng-template #skipChecking>
   <p>

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -22,7 +22,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { AutofocusDirective } from '../../directives/autofocus';
 import { RootFolderMode } from '../../models/add-torrent.model';
 import type { SelectedTorrentInput } from '../../models/command.model';
@@ -93,6 +93,7 @@ export class AddTorrent implements OnInit {
   private readonly typeaheadService = inject(TypeaheadService);
   private readonly qbService = inject(QbService);
   private readonly openFilesService = inject(OpenFilesService);
+  private readonly translateService = inject(TranslateService);
 
   public pending = this.openFilesService.pendingDrafts;
   public queueCount = computed(() => this.pending().length);
@@ -128,9 +129,24 @@ export class AddTorrent implements OnInit {
   });
 
   public rootFolderOptions = [
-    { value: 'unset', label: 'Default (unset)' },
-    { value: 'true', label: 'Create root folder' },
-    { value: 'false', label: 'Do not create root folder' },
+    {
+      value: 'unset',
+      label: this.translateService.instant(
+        'components.add-torrent.add-form.root-folder.option.default',
+      ),
+    },
+    {
+      value: 'true',
+      label: this.translateService.instant(
+        'components.add-torrent.add-form.root-folder.option.create-root-folder',
+      ),
+    },
+    {
+      value: 'false',
+      label: this.translateService.instant(
+        'components.add-torrent.add-form.root-folder.option.do-not-create-root-folder',
+      ),
+    },
   ];
 
   private noSlashValidator(): ValidatorFn {


### PR DESCRIPTION
## Issue ID

Fixes #16 

## Description

Settings switches got changed to one-liners so translations will not interfere with the page layout

<img width="845" height="468" alt="image" src="https://github.com/user-attachments/assets/6419c2e4-5de5-4287-b34b-fff3ee84d405" />

 - root folder option now has a popover with detailed description on what it does
 - root folder dropdown got translated properly