### PR TITLE
Indicate in torrent list grid if the torrents state is error

### DIFF
--- a/src/app/pages/main/grid/grid.lib.ts
+++ b/src/app/pages/main/grid/grid.lib.ts
@@ -609,11 +609,16 @@ export function getGridOptions(
     columnDefs: getGridColDefs(uiFormatService, translateService),
     getRowId: (params: GetRowIdParams<Torrent, any>) => params.data.hash,
     rowClassRules: {
-      'bb-row-paused': (params: RowClassParams<Torrent, any>): boolean =>
+      'text-secondary bg-secondary-subtle bb-row-paused': (
+        params: RowClassParams<Torrent, any>,
+      ): boolean =>
         params.data?.state === 'pausedDL' ||
         params.data?.state === 'pausedUP' ||
         params.data?.state === 'stoppedDL' ||
         params.data?.state === 'stoppedUP',
+
+      'text-danger bg-danger-subtle': (params: RowClassParams<Torrent, any>): boolean =>
+        params.data?.state === 'error',
     },
     rowSelection: {
       mode: 'multiRow',

--- a/src/styles/themes/aurora/_dark.scss
+++ b/src/styles/themes/aurora/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $au-dark-primary: #a5b4ff;
@@ -124,5 +125,30 @@ $au-dark-surface: #121a33;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: #{$au-dark-primary};
     --bs-popover-body-color: #{$au-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $au-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $au-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $au-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $au-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $au-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $au-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $au-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $au-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $au-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $au-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $au-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $au-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $au-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $au-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $au-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $au-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $au-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $au-dark-info, 40%)};
   }
 }

--- a/src/styles/themes/aurora/_light.scss
+++ b/src/styles/themes/aurora/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $au-light-primary: #2d3a8c;
@@ -124,5 +125,30 @@ $au-light-surface: #ffffff;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: #{$au-light-body-color};
     --bs-popover-body-color: #{$au-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $au-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $au-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $au-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $au-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $au-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $au-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $au-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $au-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $au-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $au-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $au-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $au-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $au-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $au-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $au-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $au-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $au-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $au-light-info, 60%)};
   }
 }

--- a/src/styles/themes/bitbutler/_dark.scss
+++ b/src/styles/themes/bitbutler/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $bb-dark-primary: #e4d7c5;
@@ -124,6 +125,31 @@ $bb-dark-surface: #1c1c1e;
     --bs-popover-header-bg: #2a2a2c;
     --bs-popover-header-color: #{$bb-dark-primary};
     --bs-popover-body-color: #{$bb-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $bb-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $bb-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $bb-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $bb-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $bb-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $bb-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $bb-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $bb-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $bb-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $bb-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $bb-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $bb-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $bb-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $bb-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $bb-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $bb-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $bb-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $bb-dark-info, 40%)};
   }
 }
 

--- a/src/styles/themes/bitbutler/_light.scss
+++ b/src/styles/themes/bitbutler/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $bb-light-primary: #4a4a4f;
@@ -123,5 +124,30 @@ $bb-light-surface: #f0e6d8;
     --bs-popover-header-bg: #f0f0f0;
     --bs-popover-header-color: #{$bb-light-body-color};
     --bs-popover-body-color: #{$bb-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $bb-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $bb-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $bb-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $bb-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $bb-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $bb-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $bb-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $bb-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $bb-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $bb-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $bb-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $bb-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $bb-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $bb-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $bb-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $bb-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $bb-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $bb-light-info, 60%)};
   }
 }

--- a/src/styles/themes/crimson-ember/_dark.scss
+++ b/src/styles/themes/crimson-ember/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $bb-dark-primary: #c3110c;
@@ -122,5 +123,30 @@ $bb-dark-surface: #280905;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: var(--bs-card-cap-color);
     --bs-popover-body-color: #{$bb-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $bb-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $bb-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $bb-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $bb-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $bb-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $bb-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $bb-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $bb-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $bb-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $bb-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $bb-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $bb-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $bb-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $bb-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $bb-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $bb-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $bb-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $bb-dark-info, 40%)};
   }
 }

--- a/src/styles/themes/crimson-ember/_light.scss
+++ b/src/styles/themes/crimson-ember/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $bb-light-primary: #d94a45;
@@ -123,5 +124,30 @@ $bb-light-surface: #f9e8e6;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: #{$bb-light-body-color};
     --bs-popover-body-color: #{$bb-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $bb-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $bb-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $bb-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $bb-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $bb-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $bb-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $bb-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $bb-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $bb-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $bb-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $bb-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $bb-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $bb-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $bb-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $bb-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $bb-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $bb-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $bb-light-info, 60%)};
   }
 }

--- a/src/styles/themes/deep-sea/_dark.scss
+++ b/src/styles/themes/deep-sea/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $deep-sea-dark-primary: #7ab2b2;
@@ -124,6 +125,31 @@ $deep-sea-dark-surface: #06242e; // Slightly lighter surface
     --bs-popover-header-bg: #07313f;
     --bs-popover-header-color: #{$deep-sea-dark-primary};
     --bs-popover-body-color: #{$deep-sea-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $deep-sea-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $deep-sea-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $deep-sea-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $deep-sea-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $deep-sea-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $deep-sea-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $deep-sea-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $deep-sea-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $deep-sea-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $deep-sea-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $deep-sea-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $deep-sea-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $deep-sea-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $deep-sea-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $deep-sea-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $deep-sea-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $deep-sea-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $deep-sea-dark-info, 40%)};
   }
 }
 

--- a/src/styles/themes/deep-sea/_light.scss
+++ b/src/styles/themes/deep-sea/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $deep-sea-light-primary: #09637e;
@@ -123,5 +124,30 @@ $deep-sea-light-surface: #ffffff;
     --bs-popover-header-bg: #dcedf0;
     --bs-popover-header-color: #{$deep-sea-light-primary};
     --bs-popover-body-color: #{$deep-sea-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $deep-sea-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $deep-sea-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $deep-sea-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $deep-sea-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $deep-sea-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $deep-sea-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $deep-sea-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $deep-sea-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $deep-sea-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $deep-sea-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $deep-sea-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $deep-sea-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $deep-sea-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $deep-sea-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $deep-sea-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $deep-sea-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $deep-sea-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $deep-sea-light-info, 60%)};
   }
 }

--- a/src/styles/themes/mint-green/_dark.scss
+++ b/src/styles/themes/mint-green/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $bb-dark-primary: #a3b18a;
@@ -124,5 +125,30 @@ $bb-dark-surface: #243e39;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: var(--bs-card-cap-color);
     --bs-popover-body-color: #{$bb-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $bb-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $bb-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $bb-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $bb-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $bb-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $bb-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $bb-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $bb-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $bb-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $bb-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $bb-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $bb-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $bb-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $bb-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $bb-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $bb-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $bb-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $bb-dark-info, 40%)};
   }
 }

--- a/src/styles/themes/mint-green/_light.scss
+++ b/src/styles/themes/mint-green/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $bb-light-primary: #588157;
@@ -123,5 +124,30 @@ $bb-light-surface: #e8eae8;
     --bs-popover-header-bg: #f0f0f0;
     --bs-popover-header-color: #{$bb-light-body-color};
     --bs-popover-body-color: #{$bb-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $bb-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $bb-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $bb-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $bb-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $bb-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $bb-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $bb-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $bb-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $bb-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $bb-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $bb-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $bb-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $bb-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $bb-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $bb-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $bb-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $bb-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $bb-light-info, 60%)};
   }
 }

--- a/src/styles/themes/ocean-breeze/_dark.scss
+++ b/src/styles/themes/ocean-breeze/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $ob-dark-primary: #b3e5fc;
@@ -124,6 +125,31 @@ $ob-dark-surface: #1a3a5e;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: var(--bs-card-cap-color);
     --bs-popover-body-color: #{$ob-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $ob-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $ob-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $ob-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $ob-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $ob-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $ob-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $ob-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $ob-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $ob-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $ob-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $ob-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $ob-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $ob-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $ob-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $ob-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $ob-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $ob-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $ob-dark-info, 40%)};
   }
 }
 

--- a/src/styles/themes/ocean-breeze/_light.scss
+++ b/src/styles/themes/ocean-breeze/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $ob-light-primary: #0277bd;
@@ -123,5 +124,30 @@ $ob-light-surface: #e1f5fe;
     --bs-popover-header-bg: #f0f0f0;
     --bs-popover-header-color: #{$ob-light-body-color};
     --bs-popover-body-color: #{$ob-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $ob-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $ob-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $ob-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $ob-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $ob-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $ob-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $ob-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $ob-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $ob-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $ob-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $ob-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $ob-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $ob-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $ob-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $ob-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $ob-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $ob-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $ob-light-info, 60%)};
   }
 }

--- a/src/styles/themes/pumpkin-spice/_dark.scss
+++ b/src/styles/themes/pumpkin-spice/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $ps-dark-primary: #f5b041;
@@ -124,5 +125,30 @@ $ps-dark-surface: #2b2014;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: var(--bs-card-cap-color);
     --bs-popover-body-color: #{$ps-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $ps-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $ps-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $ps-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $ps-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $ps-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $ps-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $ps-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $ps-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $ps-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $ps-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $ps-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $ps-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $ps-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $ps-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $ps-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $ps-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $ps-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $ps-dark-info, 40%)};
   }
 }

--- a/src/styles/themes/pumpkin-spice/_light.scss
+++ b/src/styles/themes/pumpkin-spice/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $ps-light-primary: #d35400;
@@ -123,5 +124,30 @@ $ps-light-surface: #fff8f0;
     --bs-popover-header-bg: #f0f0f0;
     --bs-popover-header-color: #{$ps-light-body-color};
     --bs-popover-body-color: #{$ps-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $ps-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $ps-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $ps-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $ps-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $ps-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $ps-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $ps-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $ps-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $ps-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $ps-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $ps-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $ps-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $ps-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $ps-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $ps-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $ps-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $ps-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $ps-light-info, 60%)};
   }
 }

--- a/src/styles/themes/purple-haze/_dark.scss
+++ b/src/styles/themes/purple-haze/_dark.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $ph-dark-primary: #d1c4e9;
@@ -124,6 +125,31 @@ $ph-dark-surface: #2c2c44;
     --bs-popover-header-bg: var(--bs-card-cap-bg);
     --bs-popover-header-color: var(--bs-card-cap-color);
     --bs-popover-body-color: #{$ph-dark-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(black, $ph-dark-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(black, $ph-dark-primary, 40%)};
+    --bs-primary-text-emphasis: #{color.mix(white, $ph-dark-primary, 40%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(black, $ph-dark-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(black, $ph-dark-secondary, 40%)};
+    --bs-secondary-text-emphasis: #{color.mix(white, $ph-dark-secondary, 40%)};
+
+    --bs-success-bg-subtle: #{color.mix(black, $ph-dark-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(black, $ph-dark-success, 40%)};
+    --bs-success-text-emphasis: #{color.mix(white, $ph-dark-success, 40%)};
+
+    --bs-danger-bg-subtle: #{color.mix(black, $ph-dark-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(black, $ph-dark-danger, 40%)};
+    --bs-danger-text-emphasis: #{color.mix(white, $ph-dark-danger, 40%)};
+
+    --bs-warning-bg-subtle: #{color.mix(black, $ph-dark-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(black, $ph-dark-warning, 40%)};
+    --bs-warning-text-emphasis: #{color.mix(white, $ph-dark-warning, 40%)};
+
+    --bs-info-bg-subtle: #{color.mix(black, $ph-dark-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(black, $ph-dark-info, 40%)};
+    --bs-info-text-emphasis: #{color.mix(white, $ph-dark-info, 40%)};
   }
 }
 

--- a/src/styles/themes/purple-haze/_light.scss
+++ b/src/styles/themes/purple-haze/_light.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:string';
 
 $ph-light-primary: #6a1b9a;
@@ -123,5 +124,30 @@ $ph-light-surface: #ede7f6;
     --bs-popover-header-bg: #f0f0f0;
     --bs-popover-header-color: #{$ph-light-body-color};
     --bs-popover-body-color: #{$ph-light-body-color};
+
+    // Subtle bg/border/text variants derived from theme colors
+    --bs-primary-bg-subtle: #{color.mix(white, $ph-light-primary, 80%)};
+    --bs-primary-border-subtle: #{color.mix(white, $ph-light-primary, 60%)};
+    --bs-primary-text-emphasis: #{color.mix(black, $ph-light-primary, 60%)};
+
+    --bs-secondary-bg-subtle: #{color.mix(white, $ph-light-secondary, 80%)};
+    --bs-secondary-border-subtle: #{color.mix(white, $ph-light-secondary, 60%)};
+    --bs-secondary-text-emphasis: #{color.mix(black, $ph-light-secondary, 60%)};
+
+    --bs-success-bg-subtle: #{color.mix(white, $ph-light-success, 80%)};
+    --bs-success-border-subtle: #{color.mix(white, $ph-light-success, 60%)};
+    --bs-success-text-emphasis: #{color.mix(black, $ph-light-success, 60%)};
+
+    --bs-danger-bg-subtle: #{color.mix(white, $ph-light-danger, 80%)};
+    --bs-danger-border-subtle: #{color.mix(white, $ph-light-danger, 60%)};
+    --bs-danger-text-emphasis: #{color.mix(black, $ph-light-danger, 60%)};
+
+    --bs-warning-bg-subtle: #{color.mix(white, $ph-light-warning, 80%)};
+    --bs-warning-border-subtle: #{color.mix(white, $ph-light-warning, 60%)};
+    --bs-warning-text-emphasis: #{color.mix(black, $ph-light-warning, 60%)};
+
+    --bs-info-bg-subtle: #{color.mix(white, $ph-light-info, 80%)};
+    --bs-info-border-subtle: #{color.mix(white, $ph-light-info, 60%)};
+    --bs-info-text-emphasis: #{color.mix(black, $ph-light-info, 60%)};
   }
 }


### PR DESCRIPTION
## Issue ID

Fixes #25 

## Description

<img width="991" height="297" alt="image" src="https://github.com/user-attachments/assets/8df6b2f3-168e-4eed-86b5-7e08e26b392e" />

 - when the state of the torrent is error, the whole row is highligted in red
 - when the state is paused or stopped, the torrent is highlighted with a new color addition to lower opacity
 - subtle color variants are added to the theme files