### PR TITLE
Handling share limits

### DIFF
--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -446,6 +446,12 @@
         "title": "Set Share Limits"
       }
     },
+    "share-limit": {
+      "ratio-limit": "Arány korlát",
+      "seeding-time-limit": "Seedelési időkorlát",
+      "inactive-seeding-time-limit": "Inaktív seedelési időkorlát",
+      "time-unit": "perc"
+    },
     "tag-select": {
       "label": "Címkék"
     },

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -453,19 +453,18 @@
       "seeding-time-limit": "Seedelési időkorlát",
       "inactive-seeding-time-limit": "Inaktív seedelési időkorlát",
       "time-unit": "perc",
-      "hint": "Hagyd üresen a mezőt a korlát nélküli módhoz (-1). Írd be -2-t a globális korlát használatához.",
       "popover": {
         "ratio-limit": {
           "title": "Arány korlát",
-          "description": "Seedelés leállítása, ha a feltöltés/letöltés arány eléri ezt az értéket."
+          "description": "Seedelés leállítása, ha a feltöltés/letöltés arány eléri ezt az értéket. Hagyd üresen a korlát nélküli módhoz (-1), vagy írd be -2-t a globális korlát használatához."
         },
         "seeding-time-limit": {
           "title": "Seedelési időkorlát",
-          "description": "Seedelés leállítása, miután a torrent ennyi percig seedelt."
+          "description": "Seedelés leállítása, miután a torrent ennyi percig seedelt. Hagyd üresen a korlát nélküli módhoz (-1), vagy írd be -2-t a globális korlát használatához."
         },
         "inactive-seeding-time-limit": {
           "title": "Inaktív seedelési időkorlát",
-          "description": "Seedelés leállítása, ha a torrent ennyi percig inaktív volt."
+          "description": "Seedelés leállítása, ha a torrent ennyi percig inaktív volt. Hagyd üresen a korlát nélküli módhoz (-1), vagy írd be -2-t a globális korlát használatához."
         }
       }
     },
@@ -882,6 +881,7 @@
       "add": "Hozzáadás",
       "cancel": "Mégse",
       "clear": "Törlés",
+      "clear-all": "Összes törlése",
       "today": "Ma",
       "connect": "Csatlakozás",
       "add-server": "Szerver hozzáadása",
@@ -891,8 +891,7 @@
       "save": "Mentés",
       "update": "Frissítés",
       "show": "Megjelenítés",
-      "edit": "Szerkesztés",
-      "reset": "Visszaállítás"
+      "edit": "Szerkesztés"
     },
     "form": {
       "feedback": {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -375,7 +375,9 @@
               "title": "Megjegyzés",
               "description": "A készítő által megadott opcionális szöveg (pl. forrásinfó)."
             }
-          }
+          },
+          "info": {},
+          "error": {}
         },
         "peers": {
           "grid-options": {
@@ -450,7 +452,22 @@
       "ratio-limit": "Arány korlát",
       "seeding-time-limit": "Seedelési időkorlát",
       "inactive-seeding-time-limit": "Inaktív seedelési időkorlát",
-      "time-unit": "perc"
+      "time-unit": "perc",
+      "hint": "Hagyd üresen a mezőt a korlát nélküli módhoz (-1). Írd be -2-t a globális korlát használatához.",
+      "popover": {
+        "ratio-limit": {
+          "title": "Arány korlát",
+          "description": "Seedelés leállítása, ha a feltöltés/letöltés arány eléri ezt az értéket."
+        },
+        "seeding-time-limit": {
+          "title": "Seedelési időkorlát",
+          "description": "Seedelés leállítása, miután a torrent ennyi percig seedelt."
+        },
+        "inactive-seeding-time-limit": {
+          "title": "Inaktív seedelési időkorlát",
+          "description": "Seedelés leállítása, ha a torrent ennyi percig inaktív volt."
+        }
+      }
     },
     "tag-select": {
       "label": "Címkék"
@@ -842,12 +859,7 @@
       }
     }
   },
-  "pipes": {
-    "ratio-limit-pipe": {
-      "global": "Globális",
-      "no-limit": "Nincs korlát"
-    }
-  },
+  "pipes": {},
   "services": {
     "menu-bar-command-handler": {
       "app-loader": {
@@ -879,7 +891,8 @@
       "save": "Mentés",
       "update": "Frissítés",
       "show": "Megjelenítés",
-      "edit": "Szerkesztés"
+      "edit": "Szerkesztés",
+      "reset": "Visszaállítás"
     },
     "form": {
       "feedback": {
@@ -930,6 +943,10 @@
         "6": "Szo",
         "7": "Va"
       }
+    },
+    "limit": {
+      "global": "Globális korlát",
+      "no-limit": "Nincs korlát"
     }
   },
   "language": {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -62,6 +62,7 @@
         "seeding-time-limit-unit": "perc"
       },
       "label": {
+        "general": "Általános",
         "settings": "Beállítások",
         "limits": "Korlátok",
         "files": "Fájlok"

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -441,6 +441,9 @@
         "button": {
           "view-on-github": "Megtekintés GitHubon"
         }
+      },
+      "limit-torrent-share": {
+        "title": "Set Share Limits"
       }
     },
     "tag-select": {
@@ -519,6 +522,7 @@
             "remove": "Eltávolítás",
             "limit-upload-rate": "Feltöltési sebesség korlátozása",
             "limit-download-rate": "Letöltési sebesség korlátozása",
+            "limit-torrent-share": "Megosztási korlátok beállítása",
             "enable-super-seeding": "Super seeding engedélyezése",
             "disable-super-seeding": "Super seeding tiltása",
             "force-recheck": "Kényszerített ellenőrzés",

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -257,12 +257,16 @@
           "clear-upload-limit": "Feltöltési korlát törlése",
           "wasted": "Kárba veszett",
           "share-ratio": "Megosztási arány",
-          "limit": "Korlát",
-          "change-share-ratio-limit": "Megosztási arány korlát módosítása",
-          "clear-share-ratio-limit": "Megosztási arány korlát törlése",
           "reannounce-in": "Újrajelentkezés",
           "force-reannounce": "Kényszerített újrajelentkezés",
           "last-seen-complete": "Utoljára teljesnek látva",
+          "ratio-limit": "Arány korlát",
+          "seeding-time-limit": "Seedelési idő korlát",
+          "inactive-seeding-time-limit": "Inaktív seedelési idő korlát",
+          "edit-share-limits": "Megosztási korlátok szerkesztése",
+          "clear-ratio-limit": "Arány korlát törlése",
+          "clear-seeding-time-limit": "Seedelési idő korlát törlése",
+          "clear-inactive-seeding-time-limit": "Inaktív seedelési idő korlát törlése",
           "total-size": "Teljes méret",
           "pieces": "Szeletek",
           "pieces-value": "szelet",
@@ -339,6 +343,18 @@
             "last-seen-complete": {
               "title": "Utoljára teljesnek látva",
               "description": "Amikor a kliens utoljára csatlakozott olyan peerhez, akinek megvolt a fájl 100%-a."
+            },
+            "ratio-limit": {
+              "title": "Arány korlát",
+              "description": "A feltöltési/letöltési arány, amelynél ez a torrent leáll a seedeléssel."
+            },
+            "seeding-time-limit": {
+              "title": "Seedelési idő korlát",
+              "description": "Mennyi ideig (percben) seedel ez a torrent a befejezés után."
+            },
+            "inactive-seeding-time-limit": {
+              "title": "Inaktív seedelési idő korlát",
+              "description": "Mennyi ideig (percben) maradhat inaktív ez a torrent seedelés közben, mielőtt leáll."
             },
             "total-size": {
               "title": "Teljes méret",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -257,12 +257,16 @@
           "clear-upload-limit": "Clear Upload Limit",
           "wasted": "Wasted",
           "share-ratio": "Share Ratio",
-          "limit": "Limit",
-          "change-share-ratio-limit": "Change Share Ratio Limit",
-          "clear-share-ratio-limit": "Clear Share Ratio Limit",
           "reannounce-in": "Reannounce In",
           "force-reannounce": "Force Reannounce",
           "last-seen-complete": "Last Seen Complete",
+          "ratio-limit": "Ratio Limit",
+          "seeding-time-limit": "Seeding Time Limit",
+          "inactive-seeding-time-limit": "Inactive Seeding Time Limit",
+          "edit-share-limits": "Edit Share Limits",
+          "clear-ratio-limit": "Clear Ratio Limit",
+          "clear-seeding-time-limit": "Clear Seeding Time Limit",
+          "clear-inactive-seeding-time-limit": "Clear Inactive Seeding Time Limit",
           "total-size": "Total Size",
           "pieces": "Pieces",
           "pieces-value": "pieces",
@@ -339,6 +343,18 @@
             "last-seen-complete": {
               "title": "Last Seen Complete",
               "description": "The last time this client was connected to a peer with 100% of the file."
+            },
+            "ratio-limit": {
+              "title": "Ratio Limit",
+              "description": "The upload/download ratio at which this torrent will stop seeding."
+            },
+            "seeding-time-limit": {
+              "title": "Seeding Time Limit",
+              "description": "How long (in minutes) this torrent will keep seeding after it completes."
+            },
+            "inactive-seeding-time-limit": {
+              "title": "Inactive Seeding Time Limit",
+              "description": "How long (in minutes) this torrent may remain idle while seeding before it is stopped."
             },
             "total-size": {
               "title": "Total Size",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -62,6 +62,7 @@
         "seeding-time-limit-unit": "minute"
       },
       "label": {
+        "general": "General",
         "settings": "Settings",
         "limits": "Limits",
         "files": "Files"

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -448,6 +448,12 @@
         "title": "Set Share Limits"
       }
     },
+    "share-limit": {
+      "ratio-limit": "Ratio Limit",
+      "seeding-time-limit": "Seeding Time Limit",
+      "inactive-seeding-time-limit": "Inactive Seeding Time Limit",
+      "time-unit": "min"
+    },
     "tag-select": {
       "label": "Tags"
     },
@@ -838,12 +844,7 @@
       }
     }
   },
-  "pipes": {
-    "ratio-limit-pipe": {
-      "global": "Global",
-      "no-limit": "No Limit"
-    }
-  },
+  "pipes": {},
   "services": {
     "menu-bar-command-handler": {
       "app-loader": {
@@ -926,6 +927,10 @@
         "6": "Sa",
         "7": "Su"
       }
+    },
+    "limit": {
+      "global": "Global",
+      "no-limit": "No Limit"
     }
   },
   "language": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -452,7 +452,22 @@
       "ratio-limit": "Ratio Limit",
       "seeding-time-limit": "Seeding Time Limit",
       "inactive-seeding-time-limit": "Inactive Seeding Time Limit",
-      "time-unit": "min"
+      "time-unit": "min",
+      "hint": "Leave a field empty to set no limit (-1). Enter -2 to use the global limit.",
+      "popover": {
+        "ratio-limit": {
+          "title": "Ratio Limit",
+          "description": "Stop seeding when the upload/download ratio reaches this value."
+        },
+        "seeding-time-limit": {
+          "title": "Seeding Time Limit",
+          "description": "Stop seeding after the torrent has been seeding for this many minutes."
+        },
+        "inactive-seeding-time-limit": {
+          "title": "Inactive Seeding Time Limit",
+          "description": "Stop seeding after the torrent has been inactive for this many minutes."
+        }
+      }
     },
     "tag-select": {
       "label": "Tags"
@@ -876,7 +891,8 @@
       "save": "Save",
       "update": "Update",
       "show": "Show",
-      "edit": "Edit"
+      "edit": "Edit",
+      "reset": "Reset"
     },
     "form": {
       "feedback": {
@@ -929,7 +945,7 @@
       }
     },
     "limit": {
-      "global": "Global",
+      "global": "Global Limit",
       "no-limit": "No Limit"
     }
   },

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -453,19 +453,18 @@
       "seeding-time-limit": "Seeding Time Limit",
       "inactive-seeding-time-limit": "Inactive Seeding Time Limit",
       "time-unit": "min",
-      "hint": "Leave a field empty to set no limit (-1). Enter -2 to use the global limit.",
       "popover": {
         "ratio-limit": {
           "title": "Ratio Limit",
-          "description": "Stop seeding when the upload/download ratio reaches this value."
+          "description": "Stop seeding when the upload/download ratio reaches this value. Leave empty for no limit (-1), or enter -2 to use the global limit."
         },
         "seeding-time-limit": {
           "title": "Seeding Time Limit",
-          "description": "Stop seeding after the torrent has been seeding for this many minutes."
+          "description": "Stop seeding after the torrent has been seeding for this many minutes. Leave empty for no limit (-1), or enter -2 to use the global limit."
         },
         "inactive-seeding-time-limit": {
           "title": "Inactive Seeding Time Limit",
-          "description": "Stop seeding after the torrent has been inactive for this many minutes."
+          "description": "Stop seeding after the torrent has been inactive for this many minutes. Leave empty for no limit (-1), or enter -2 to use the global limit."
         }
       }
     },
@@ -882,6 +881,7 @@
       "add": "Add",
       "cancel": "Cancel",
       "clear": "Clear",
+      "clear-all": "Clear",
       "today": "Today",
       "connect": "Connect",
       "add-server": "Add Server",
@@ -891,8 +891,7 @@
       "save": "Save",
       "update": "Update",
       "show": "Show",
-      "edit": "Edit",
-      "reset": "Reset"
+      "edit": "Edit"
     },
     "form": {
       "feedback": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -443,6 +443,9 @@
         "button": {
           "view-on-github": "View on GitHub"
         }
+      },
+      "limit-torrent-share": {
+        "title": "Set Share Limits"
       }
     },
     "tag-select": {
@@ -521,6 +524,7 @@
             "remove": "Remove",
             "limit-upload-rate": "Limit upload rate",
             "limit-download-rate": "Limit download rate",
+            "limit-torrent-share": "Set Share Limits",
             "enable-super-seeding": "Enable Super Seeding",
             "disable-super-seeding": "Disable Super Seeding",
             "force-recheck": "Force recheck",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -21,6 +21,7 @@ import { HumanizeDurationPipe } from './pipes/humanize-duration-pipe';
 import { LocalTimestampPipe } from './pipes/local-timestamp-pipe';
 import { RatioLimitPipe } from './pipes/ratio-limit-pipe';
 import { RatioPipe } from './pipes/ratio-pipe';
+import { TimeLimitPipe } from './pipes/time-limit-pipe';
 import { ThemeService } from './services/theme.service';
 
 export function markedOptionsFactory(): MarkedOptions {
@@ -78,6 +79,7 @@ export const appConfig: ApplicationConfig = {
     RatioPipe,
     LocalTimestampPipe,
     RatioLimitPipe,
+    TimeLimitPipe,
     provideAppInitializer(() => {
       const themeService = inject(ThemeService);
       return themeService.init();

--- a/src/app/app.const.ts
+++ b/src/app/app.const.ts
@@ -1,7 +1,6 @@
 import { GridOptions, iconSetQuartzLight, themeQuartz } from 'ag-grid-community';
 
 export const API_URL = '/api/v2';
-export const DEFAULT_DATE_FORMATTER = 'yyyy-MM-dd HH:mm:ss';
 
 const GRID_PARAMS_SHARED = {
   fontFamily: 'inherit',

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -14,289 +14,298 @@
 
 <div class="modal-body">
   <form [formGroup]="addForm" (submit)="handleSubmit($event)">
-    <div class="form-floating mb-3">
-      <div class="input-group mb-1">
-        <div class="form-floating">
+    <fieldset class="bb-fieldset mt-0">
+      <legend>{{ 'components.add-torrent.label.general' | translate }}</legend>
+
+      <div class="form-floating mb-3">
+        <div class="input-group mb-1">
+          <div class="form-floating">
+            <input
+              type="text"
+              class="form-control"
+              id="file_browser"
+              [placeholder]="'components.add-torrent.add-form.file-browser' | translate"
+              formControlName="file"
+              [class.is-invalid]="
+                addForm.controls.file.invalid &&
+                (addForm.controls.file.touched || addForm.controls.file.dirty)
+              "
+              readonly
+              (click)="fileInput.click()"
+            />
+            <label for="file_browser">{{
+              'components.add-torrent.add-form.file-browser' | translate
+            }}</label>
+          </div>
+
+          <button type="button" class="btn btn-outline-primary" (click)="fileInput.click()">
+            {{ 'general.button.browse' | translate }}
+          </button>
           <input
-            type="text"
-            class="form-control"
-            id="file_browser"
-            [placeholder]="'components.add-torrent.add-form.file-browser' | translate"
-            formControlName="file"
-            [class.is-invalid]="
-              addForm.controls.file.invalid &&
-              (addForm.controls.file.touched || addForm.controls.file.dirty)
-            "
-            readonly
-            (click)="fileInput.click()"
+            type="file"
+            #fileInput
+            hidden
+            accept=".torrent"
+            (change)="handleFileSelected($event)"
           />
-          <label for="file_browser">{{
-            'components.add-torrent.add-form.file-browser' | translate
-          }}</label>
         </div>
+      </div>
 
-        <button type="button" class="btn btn-outline-primary" (click)="fileInput.click()">
-          {{ 'general.button.browse' | translate }}
-        </button>
+      <div class="form-floating mb-3">
         <input
-          type="file"
-          #fileInput
-          hidden
-          accept=".torrent"
-          (change)="handleFileSelected($event)"
+          #savePathControl
+          type="text"
+          class="form-control"
+          id="savepath"
+          [placeholder]="'components.add-torrent.add-form.save-path' | translate"
+          formControlName="savepath"
+          [ngbTypeahead]="searchSavePaths"
+          [editable]="true"
+          [autofocus]="addForm.controls.file.value.length > 0"
+          [class.is-invalid]="addForm.controls.savepath.invalid && addForm.controls.savepath.dirty"
         />
+        <label for="savepath">{{ 'components.add-torrent.add-form.save-path' | translate }}</label>
+        @if (addForm.controls.savepath.invalid && addForm.controls.savepath.dirty) {
+          @if (addForm.controls.savepath.hasError('required')) {
+            <div class="invalid-feedback px-2">
+              {{ 'general.form.feedback.required' | translate }}
+            </div>
+          }
+        }
       </div>
-    </div>
 
-    <div class="form-floating mb-3">
-      <input
-        #savePathControl
-        type="text"
-        class="form-control"
-        id="savepath"
-        [placeholder]="'components.add-torrent.add-form.save-path' | translate"
-        formControlName="savepath"
-        [ngbTypeahead]="searchSavePaths"
-        [editable]="true"
-        [autofocus]="addForm.controls.file.value.length > 0"
-        [class.is-invalid]="addForm.controls.savepath.invalid && addForm.controls.savepath.dirty"
-      />
-      <label for="savepath">{{ 'components.add-torrent.add-form.save-path' | translate }}</label>
-      @if (addForm.controls.savepath.invalid && addForm.controls.savepath.dirty) {
-        @if (addForm.controls.savepath.hasError('required')) {
-          <div class="invalid-feedback px-2">
-            {{ 'general.form.feedback.required' | translate }}
-          </div>
+      <div class="form-floating mb-3">
+        <input
+          type="text"
+          class="form-control"
+          id="rename"
+          [placeholder]="'components.add-torrent.add-form.rename' | translate"
+          formControlName="rename"
+          [class.is-invalid]="addForm.controls.rename.invalid && addForm.controls.rename.dirty"
+        />
+        <label for="rename">{{ 'components.add-torrent.add-form.rename' | translate }}</label>
+        @if (addForm.controls.rename.invalid && addForm.controls.rename.dirty) {
+          @if (addForm.controls.rename.hasError('noSlash')) {
+            <div class="invalid-feedback px-2">
+              {{ 'general.form.feedback.no-slash' | translate }}
+            </div>
+          }
+          @if (addForm.controls.rename.hasError('required')) {
+            <div class="invalid-feedback px-2">
+              {{ 'general.form.feedback.required' | translate }}
+            </div>
+          }
         }
-      }
-    </div>
+      </div>
 
-    <div class="form-floating mb-3">
-      <input
-        type="text"
-        class="form-control"
-        id="rename"
-        [placeholder]="'components.add-torrent.add-form.rename' | translate"
-        formControlName="rename"
-        [class.is-invalid]="addForm.controls.rename.invalid && addForm.controls.rename.dirty"
-      />
-      <label for="rename">{{ 'components.add-torrent.add-form.rename' | translate }}</label>
-      @if (addForm.controls.rename.invalid && addForm.controls.rename.dirty) {
-        @if (addForm.controls.rename.hasError('noSlash')) {
-          <div class="invalid-feedback px-2">
-            {{ 'general.form.feedback.no-slash' | translate }}
+      <div class="mb-3">
+        <app-category-select formControlName="category"></app-category-select>
+      </div>
+
+      <div class="mb-3">
+        <app-tag-select formControlName="tags"></app-tag-select>
+      </div>
+    </fieldset>
+
+    <fieldset class="bb-fieldset">
+      <legend>{{ 'components.add-torrent.label.settings' | translate }}</legend>
+
+      <div class="container-fluid px-0">
+        <div class="row">
+          <div class="col-11">
+            <div class="form-floating mb-3">
+              <ng-select
+                id="root_folder"
+                formControlName="root_folder"
+                [items]="rootFolderOptions"
+                bindValue="value"
+                bindLabel="label"
+                [clearable]="false"
+                [searchable]="false"
+              ></ng-select>
+              <label for="root_folder">{{
+                'components.add-torrent.add-form.root-folder.title' | translate
+              }}</label>
+            </div>
           </div>
-        }
-        @if (addForm.controls.rename.hasError('required')) {
-          <div class="invalid-feedback px-2">
-            {{ 'general.form.feedback.required' | translate }}
-          </div>
-        }
-      }
-    </div>
 
-    <div class="mb-3">
-      <app-category-select formControlName="category"></app-category-select>
-    </div>
-
-    <div class="mb-3">
-      <app-tag-select formControlName="tags"></app-tag-select>
-    </div>
-
-    <div class="text-uppercase mb-3">{{ 'components.add-torrent.label.settings' | translate }}</div>
-
-    <div class="container-fluid px-0">
-      <div class="row">
-        <div class="col-11">
-          <div class="form-floating mb-3">
-            <ng-select
-              id="root_folder"
-              formControlName="root_folder"
-              [items]="rootFolderOptions"
-              bindValue="value"
-              bindLabel="label"
-              [clearable]="false"
-              [searchable]="false"
-            ></ng-select>
-            <label for="root_folder">{{
-              'components.add-torrent.add-form.root-folder.title' | translate
-            }}</label>
-          </div>
-        </div>
-
-        <div class="col-1 d-flex align-items-center mb-3">
-          <bb-popover
-            class="mt-2"
-            [subject]="'components.add-torrent.popover.root-folder.title' | translate"
-            [description]="rootFolder"
-            placement="left"
-          ></bb-popover>
-        </div>
-
-        <div class="col-12">
-          <div class="form-check form-switch mb-3">
-            <input
-              class="form-check-input"
-              type="checkbox"
-              role="switch"
-              id="skip_checking"
-              formControlName="skip_checking"
-            />
-            <label class="form-check-label" for="skip_checking">{{
-              'components.add-torrent.add-form.skip-hash-checking' | translate
-            }}</label>
+          <div class="col-1 d-flex align-items-center mb-3">
             <bb-popover
-              [subject]="'components.add-torrent.popover.skip-hash-checking.title' | translate"
-              [description]="skipChecking"
-              placement="right"
-            ></bb-popover>
-          </div>
-        </div>
-
-        <div class="col-12">
-          <div class="form-check form-switch mb-3">
-            <input
-              class="form-check-input"
-              type="checkbox"
-              role="switch"
-              id="paused"
-              formControlName="paused"
-            />
-            <label class="form-check-label" for="paused">{{
-              'components.add-torrent.add-form.paused' | translate
-            }}</label>
-            <bb-popover
-              [subject]="'components.add-torrent.popover.paused-state.title' | translate"
-              [description]="pausedState"
-              placement="right"
-            ></bb-popover>
-          </div>
-        </div>
-
-        <div class="col-12">
-          <div class="form-check form-switch mb-3">
-            <input
-              class="form-check-input"
-              type="checkbox"
-              role="switch"
-              id="autoTMM"
-              formControlName="autoTMM"
-            />
-            <label class="form-check-label" for="autoTMM">{{
-              'components.add-torrent.add-form.auto-tmm' | translate
-            }}</label>
-            <bb-popover
-              [subject]="'components.add-torrent.popover.auto-tmm.title' | translate"
-              [description]="autoTMM"
-              placement="right"
-            ></bb-popover>
-          </div>
-        </div>
-
-        <div class="col-12">
-          <div class="form-check form-switch mb-3">
-            <input
-              class="form-check-input"
-              type="checkbox"
-              role="switch"
-              id="sequentialDownload"
-              formControlName="sequentialDownload"
-            />
-            <label class="form-check-label" for="sequentialDownload">{{
-              'components.add-torrent.add-form.sequential-download' | translate
-            }}</label>
-            <bb-popover
-              [subject]="'components.add-torrent.popover.sequential-download.title' | translate"
-              [description]="sequentialDownload"
+              class="mt-2"
+              [subject]="'components.add-torrent.popover.root-folder.title' | translate"
+              [description]="rootFolder"
               placement="left"
-              placement="right"
             ></bb-popover>
           </div>
-        </div>
 
-        <div class="col-12">
-          <div class="form-check form-switch mb-3">
-            <input
-              class="form-check-input"
-              type="checkbox"
-              role="switch"
-              id="firstLastPiecePrio"
-              formControlName="firstLastPiecePrio"
-            />
-            <label class="form-check-label" for="firstLastPiecePrio">{{
-              'components.add-torrent.add-form.first-last-piece-prio' | translate
-            }}</label>
-            <bb-popover
-              [subject]="'components.add-torrent.popover.first-last-piece-prio.title' | translate"
-              [description]="firstLastPiece"
-              placement="right"
-            ></bb-popover>
+          <div class="col-12">
+            <div class="form-check form-switch mb-3">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                id="skip_checking"
+                formControlName="skip_checking"
+              />
+              <label class="form-check-label" for="skip_checking">{{
+                'components.add-torrent.add-form.skip-hash-checking' | translate
+              }}</label>
+              <bb-popover
+                [subject]="'components.add-torrent.popover.skip-hash-checking.title' | translate"
+                [description]="skipChecking"
+                placement="right"
+              ></bb-popover>
+            </div>
+          </div>
+
+          <div class="col-12">
+            <div class="form-check form-switch mb-3">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                id="paused"
+                formControlName="paused"
+              />
+              <label class="form-check-label" for="paused">{{
+                'components.add-torrent.add-form.paused' | translate
+              }}</label>
+              <bb-popover
+                [subject]="'components.add-torrent.popover.paused-state.title' | translate"
+                [description]="pausedState"
+                placement="right"
+              ></bb-popover>
+            </div>
+          </div>
+
+          <div class="col-12">
+            <div class="form-check form-switch mb-3">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                id="autoTMM"
+                formControlName="autoTMM"
+              />
+              <label class="form-check-label" for="autoTMM">{{
+                'components.add-torrent.add-form.auto-tmm' | translate
+              }}</label>
+              <bb-popover
+                [subject]="'components.add-torrent.popover.auto-tmm.title' | translate"
+                [description]="autoTMM"
+                placement="right"
+              ></bb-popover>
+            </div>
+          </div>
+
+          <div class="col-12">
+            <div class="form-check form-switch mb-3">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                id="sequentialDownload"
+                formControlName="sequentialDownload"
+              />
+              <label class="form-check-label" for="sequentialDownload">{{
+                'components.add-torrent.add-form.sequential-download' | translate
+              }}</label>
+              <bb-popover
+                [subject]="'components.add-torrent.popover.sequential-download.title' | translate"
+                [description]="sequentialDownload"
+                placement="right"
+              ></bb-popover>
+            </div>
+          </div>
+
+          <div class="col-12">
+            <div class="form-check form-switch mb-3">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                id="firstLastPiecePrio"
+                formControlName="firstLastPiecePrio"
+              />
+              <label class="form-check-label" for="firstLastPiecePrio">{{
+                'components.add-torrent.add-form.first-last-piece-prio' | translate
+              }}</label>
+              <bb-popover
+                [subject]="'components.add-torrent.popover.first-last-piece-prio.title' | translate"
+                [description]="firstLastPiece"
+                placement="right"
+              ></bb-popover>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </fieldset>
 
-    <div class="text-uppercase mb-3">{{ 'components.add-torrent.label.limits' | translate }}</div>
+    <fieldset class="bb-fieldset">
+      <legend>{{ 'components.add-torrent.label.limits' | translate }}</legend>
 
-    <div class="container px-0">
-      <div class="row">
-        <div class="col-6">
-          <div class="input-group mb-3">
-            <div class="form-floating">
-              <input
-                type="number"
-                class="form-control"
-                id="upLimitKbps"
-                [placeholder]="'components.add-torrent.add-form.up-limit' | translate"
-                formControlName="upLimitKbps"
-                min="0"
-              />
-              <label for="upLimitKbps">{{
-                'components.add-torrent.add-form.up-limit' | translate
-              }}</label>
+      <div class="container px-0">
+        <div class="row">
+          <div class="col-6">
+            <div class="input-group mb-3">
+              <div class="form-floating">
+                <input
+                  type="number"
+                  class="form-control"
+                  id="upLimitKbps"
+                  [placeholder]="'components.add-torrent.add-form.up-limit' | translate"
+                  formControlName="upLimitKbps"
+                  min="0"
+                />
+                <label for="upLimitKbps">{{
+                  'components.add-torrent.add-form.up-limit' | translate
+                }}</label>
+              </div>
+              <span class="input-group-text">KiB/s</span>
             </div>
-            <span class="input-group-text">KiB/s</span>
           </div>
-        </div>
 
-        <div class="col-6">
-          <div class="input-group mb-3">
-            <div class="form-floating">
-              <input
-                type="number"
-                class="form-control"
-                id="dlLimitKbps"
-                [placeholder]="'components.add-torrent.add-form.down-limit' | translate"
-                formControlName="dlLimitKbps"
-                min="0"
-              />
-              <label for="dlLimitKbps">{{
-                'components.add-torrent.add-form.down-limit' | translate
-              }}</label>
+          <div class="col-6">
+            <div class="input-group mb-3">
+              <div class="form-floating">
+                <input
+                  type="number"
+                  class="form-control"
+                  id="dlLimitKbps"
+                  [placeholder]="'components.add-torrent.add-form.down-limit' | translate"
+                  formControlName="dlLimitKbps"
+                  min="0"
+                />
+                <label for="dlLimitKbps">{{
+                  'components.add-torrent.add-form.down-limit' | translate
+                }}</label>
+              </div>
+              <span class="input-group-text">KiB/s</span>
             </div>
-            <span class="input-group-text">KiB/s</span>
           </div>
-        </div>
 
-        <div class="col-12">
-          <app-share-limit formControlName="shareLimits" [hideInactive]="true"></app-share-limit>
+          <div class="col-12">
+            <app-share-limit formControlName="shareLimits" [hideInactive]="true"></app-share-limit>
+          </div>
         </div>
       </div>
-    </div>
+    </fieldset>
 
     @if (showTree() && effectiveDraft() && effectiveDraft().torrent?.files?.length) {
-      <div class="text-uppercase mb-3">{{ 'components.add-torrent.label.files' | translate }}</div>
+      <fieldset class="bb-fieldset">
+        <legend>{{ 'components.add-torrent.label.files' | translate }}</legend>
 
-      <app-bb-file-tree
-        [files]="effectiveDraft()!.torrent!.files"
-        [expandAll]="false"
-        [showMeta]="true"
-        [allowEdit]="true"
-        [hideProgress]="true"
-        (saved)="onTreeSaved($event)"
-        (editModeChange)="treeInEditMode.set($event)"
-      >
-      </app-bb-file-tree>
+        <app-bb-file-tree
+          [files]="effectiveDraft()!.torrent!.files"
+          [expandAll]="false"
+          [showMeta]="true"
+          [allowEdit]="true"
+          [hideProgress]="true"
+          (saved)="onTreeSaved($event)"
+          (editModeChange)="treeInEditMode.set($event)"
+        >
+        </app-bb-file-tree>
+      </fieldset>
     }
 
     <button type="submit" hidden></button>

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -126,6 +126,7 @@
 
         <div class="col-1 d-flex align-items-center mb-3">
           <bb-popover
+            class="mt-2"
             [subject]="'components.add-torrent.popover.root-folder.title' | translate"
             [description]="rootFolder"
             placement="left"
@@ -277,39 +278,8 @@
           </div>
         </div>
 
-        <div class="col-6">
-          <div class="form-floating">
-            <input
-              type="number"
-              class="form-control"
-              id="ratioLimit"
-              [placeholder]="'components.add-torrent.add-form.ratio-limit' | translate"
-              formControlName="ratioLimit"
-            />
-            <label for="ratioLimit">{{
-              'components.add-torrent.add-form.ratio-limit' | translate
-            }}</label>
-          </div>
-        </div>
-
-        <div class="col-6">
-          <div class="input-group mb-3">
-            <div class="form-floating">
-              <input
-                type="number"
-                class="form-control"
-                id="seedingTimeLimit"
-                [placeholder]="'components.add-torrent.add-form.seeding-time-limit' | translate"
-                formControlName="seedingTimeLimit"
-              />
-              <label for="seedingTimeLimit">{{
-                'components.add-torrent.add-form.seeding-time-limit' | translate
-              }}</label>
-            </div>
-            <span class="input-group-text">{{
-              'components.add-torrent.add-form.seeding-time-limit-unit' | translate
-            }}</span>
-          </div>
+        <div class="col-12">
+          <app-share-limit formControlName="shareLimits" [hideInactive]="true"></app-share-limit>
         </div>
       </div>
     </div>

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -38,6 +38,7 @@ import { BbFileTree, FileTreeSaveEvent } from '../bb-file-tree/bb-file-tree';
 import { BbPopover } from '../bb-popover/bb-popover';
 import { CategorySelect } from '../category-select/category-select';
 import { TorrentExists } from '../modals/torrent-exists/torrent-exists';
+import { ShareLimit, ShareLimitValue } from '../share-limit/share-limit';
 import { TagSelect } from '../tag-select/tag-select';
 
 type AddTorrentFormValue = {
@@ -53,8 +54,7 @@ type AddTorrentFormValue = {
   firstLastPiecePrio: boolean;
   upLimitKbps: number | null;
   dlLimitKbps: number | null;
-  ratioLimit: number | null;
-  seedingTimeLimit: number | null;
+  shareLimits: ShareLimitValue | null;
   autoTMM: boolean;
 };
 
@@ -71,6 +71,7 @@ type AddTorrentFormValue = {
     FontAwesomeModule,
     NgSelectModule,
     TranslatePipe,
+    ShareLimit,
   ],
   templateUrl: './add-torrent.html',
   styleUrl: './add-torrent.scss',
@@ -122,8 +123,7 @@ export class AddTorrent implements OnInit {
     firstLastPiecePrio: new FormControl<boolean>(false, { nonNullable: true }),
     upLimitKbps: new FormControl<number | null>(null),
     dlLimitKbps: new FormControl<number | null>(null),
-    ratioLimit: new FormControl<number | null>(null),
-    seedingTimeLimit: new FormControl<number | null>(null),
+    shareLimits: new FormControl<ShareLimitValue | null>(null),
     autoTMM: new FormControl<boolean>(false, { nonNullable: true }),
   });
 
@@ -244,8 +244,12 @@ export class AddTorrent implements OnInit {
         root_folder: raw.root_folder === 'unset' ? undefined : raw.root_folder,
         upLimit: raw.upLimitKbps != null ? String(Math.round(raw.upLimitKbps * 1024)) : undefined,
         dlLimit: raw.dlLimitKbps != null ? String(Math.round(raw.dlLimitKbps * 1024)) : undefined,
-        ratioLimit: raw.ratioLimit != null ? String(raw.ratioLimit) : undefined,
-        seedingTimeLimit: raw.seedingTimeLimit != null ? String(raw.seedingTimeLimit) : undefined,
+        ratioLimit:
+          raw.shareLimits?.ratioLimit != null ? String(raw.shareLimits.ratioLimit) : undefined,
+        seedingTimeLimit:
+          raw.shareLimits?.seedingTimeLimit != null
+            ? String(raw.shareLimits.seedingTimeLimit)
+            : undefined,
       },
     };
 
@@ -271,8 +275,7 @@ export class AddTorrent implements OnInit {
         autoTMM: raw.autoTMM,
         upLimitKbps: raw.upLimitKbps,
         dlLimitKbps: raw.dlLimitKbps,
-        ratioLimit: raw.ratioLimit,
-        seedingTimeLimit: raw.seedingTimeLimit,
+        shareLimits: raw.shareLimits,
       });
       this.openFilesService.consumeCurrentDraft();
     } catch (e) {

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
@@ -36,8 +36,18 @@
 
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary" (click)="handleSubmit()" [disabled]="!canSave()">
-    {{ 'general.button.set' | translate }}
+    {{ 'general.button.save' | translate }}
   </button>
+  @if (hasClearableValues()) {
+    <button
+      type="button"
+      class="btn btn-link text-danger"
+      (click)="clearAll()"
+      [disabled]="!canSave()"
+    >
+      {{ 'general.button.reset' | translate }}
+    </button>
+  }
   <button type="button" class="btn btn-link" (click)="activeModal.dismiss()">
     {{ 'general.button.cancel' | translate }}
   </button>

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
@@ -1,0 +1,29 @@
+<div class="modal-header bb-modal-header">
+  <div class="bb-modal-header__text">
+    <h5 class="modal-title">
+      {{ 'components.modals.limit-torrent-share.title' | translate }}
+    </h5>
+
+    <div class="small text-body-secondary mt-1 bb-hash-clamp">subtitle</div>
+  </div>
+
+  <button
+    type="button"
+    class="btn-close"
+    aria-label="Close"
+    (click)="activeModal.dismiss()"
+  ></button>
+</div>
+
+<div class="modal-body">
+  <app-share-limit></app-share-limit>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-secondary" [disabled]="!canSave()">
+    {{ 'general.button.set' | translate }}
+  </button>
+  <button type="button" class="btn btn-link" (click)="activeModal.close()">
+    {{ 'general.button.cancel' | translate }}
+  </button>
+</div>

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
@@ -4,7 +4,19 @@
       {{ 'components.modals.limit-torrent-share.title' | translate }}
     </h5>
 
-    <div class="small text-body-secondary mt-1 bb-hash-clamp">subtitle</div>
+    <div
+      class="small text-body-secondary mt-1 bb-hash-clamp"
+      [ngbTooltip]="tooltipText()"
+      bbTooltipOverflow
+      tooltipClass="single-line-tooltip"
+      placement="bottom"
+    >
+      @if (selected() === 1) {
+        {{ selectionName() }}
+      } @else {
+        {{ 'general.label.torrent-selected' | translate: { count: selected() } }}
+      }
+    </div>
   </div>
 
   <button
@@ -16,14 +28,17 @@
 </div>
 
 <div class="modal-body">
-  <app-share-limit></app-share-limit>
+  <form [formGroup]="form" (submit)="handleSubmit()">
+    <app-share-limit formControlName="shareLimits"></app-share-limit>
+    <button type="submit" hidden [disabled]="!canSave()"></button>
+  </form>
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-secondary" [disabled]="!canSave()">
+  <button type="button" class="btn btn-secondary" (click)="handleSubmit()" [disabled]="!canSave()">
     {{ 'general.button.set' | translate }}
   </button>
-  <button type="button" class="btn btn-link" (click)="activeModal.close()">
+  <button type="button" class="btn btn-link" (click)="activeModal.dismiss()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.html
@@ -45,7 +45,7 @@
       (click)="clearAll()"
       [disabled]="!canSave()"
     >
-      {{ 'general.button.reset' | translate }}
+      {{ 'general.button.clear-all' | translate }}
     </button>
   }
   <button type="button" class="btn btn-link" (click)="activeModal.dismiss()">

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.spec.ts
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LimitTorrentShare } from './limit-torrent-share';
+
+describe('LimitTorrentShare', () => {
+  let component: LimitTorrentShare;
+  let fixture: ComponentFixture<LimitTorrentShare>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LimitTorrentShare],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LimitTorrentShare);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
@@ -1,0 +1,19 @@
+import { Component, inject } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { TranslatePipe } from '@ngx-translate/core';
+import { ShareLimit } from '../../share-limit/share-limit';
+
+@Component({
+  selector: 'app-limit-torrent-share',
+  imports: [ReactiveFormsModule, TranslatePipe, ShareLimit],
+  templateUrl: './limit-torrent-share.html',
+  styleUrl: './limit-torrent-share.scss',
+})
+export class LimitTorrentShare {
+  public readonly activeModal = inject(NgbActiveModal);
+
+  public canSave(): boolean {
+    return true;
+  }
+}

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
@@ -90,6 +90,22 @@ export class LimitTorrentShare implements OnInit {
     }
   }
 
+  public hasClearableValues(): boolean {
+    const v = this.form.controls.shareLimits.value;
+    return (
+      v !== null &&
+      (v.ratioLimit !== null || v.seedingTimeLimit !== null || v.inactiveSeedingTimeLimit !== null)
+    );
+  }
+
+  public clearAll(): void {
+    this.form.controls.shareLimits.setValue({
+      ratioLimit: null,
+      seedingTimeLimit: null,
+      inactiveSeedingTimeLimit: null,
+    });
+  }
+
   public canSave(): boolean {
     return !this.saving();
   }

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
@@ -1,19 +1,96 @@
-import { Component, inject } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
-import { ShareLimit } from '../../share-limit/share-limit';
+import { TooltipOverflow } from '../../../directives/tooltip-overflow';
+import { QbService } from '../../../services/qb.service';
+import { SelectionStoreService } from '../../../services/selection-store.service';
+import { ServerStoreService } from '../../../services/server-store.service';
+import { ShareLimit, ShareLimitValue } from '../../share-limit/share-limit';
 
 @Component({
   selector: 'app-limit-torrent-share',
-  imports: [ReactiveFormsModule, TranslatePipe, ShareLimit],
+  imports: [ReactiveFormsModule, TranslatePipe, ShareLimit, NgbTooltip, TooltipOverflow],
   templateUrl: './limit-torrent-share.html',
   styleUrl: './limit-torrent-share.scss',
 })
-export class LimitTorrentShare {
+export class LimitTorrentShare implements OnInit {
   public readonly activeModal = inject(NgbActiveModal);
+  private readonly qbService = inject(QbService);
+  private readonly selectionStoreService = inject(SelectionStoreService);
+  private readonly serverStoreService = inject(ServerStoreService);
+
+  public saving = signal(false);
+
+  public selected = signal(this.selectionStoreService.selected().length);
+
+  public selectionName = computed(() => {
+    const selected = this.selectionStoreService.selected();
+    return selected.length === 1 ? selected[0].name : selected.length;
+  });
+
+  public tooltipText = computed(() => String(this.selectionName()));
+
+  public form = new FormGroup({
+    shareLimits: new FormControl<ShareLimitValue | null>(null),
+  });
+
+  public async ngOnInit(): Promise<void> {
+    const serverId = this.serverStoreService.currentServerId() ?? '';
+    const selected = this.selectionStoreService.selected();
+    let value: ShareLimitValue;
+
+    if (selected.length === 1) {
+      const t = selected[0];
+      value = {
+        ratioLimit: t.ratio_limit >= 0 ? t.ratio_limit : null,
+        seedingTimeLimit: t.seeding_time_limit >= 0 ? t.seeding_time_limit : null,
+        inactiveSeedingTimeLimit:
+          t.inactive_seeding_time_limit >= 0 ? t.inactive_seeding_time_limit : null,
+      };
+    } else {
+      const prefs = await this.qbService.getAppPreferences(serverId);
+      value = {
+        ratioLimit: prefs.max_ratio_enabled ? prefs.max_ratio : null,
+        seedingTimeLimit: prefs.max_seeding_time_enabled ? prefs.max_seeding_time : null,
+        inactiveSeedingTimeLimit:
+          prefs.max_inactive_seeding_time_enabled && prefs.max_inactive_seeding_time != null
+            ? prefs.max_inactive_seeding_time
+            : null,
+      };
+    }
+
+    this.form.controls.shareLimits.setValue(value, { emitEvent: false });
+  }
+
+  public async handleSubmit(): Promise<void> {
+    this.saving.set(true);
+
+    const serverId = this.serverStoreService.currentServerId() ?? '';
+    const hashes = this.selectionStoreService.selectedHashes();
+    const value = this.form.getRawValue().shareLimits;
+
+    const ratioLimit = value?.ratioLimit ?? -1;
+    const seedingTimeLimit = value?.seedingTimeLimit ?? -1;
+    const inactiveSeedingTimeLimit = value?.inactiveSeedingTimeLimit ?? -1;
+
+    try {
+      await this.qbService.setShareLimits(
+        serverId,
+        hashes,
+        ratioLimit,
+        seedingTimeLimit,
+        inactiveSeedingTimeLimit,
+      );
+      this.activeModal.close();
+    } catch (error) {
+      console.error(LimitTorrentShare.name, 'handleSubmit', 'Failed to set share limits!', error);
+    } finally {
+      this.saving.set(false);
+    }
+  }
 
   public canSave(): boolean {
-    return true;
+    return !this.saving();
   }
 }

--- a/src/app/components/modals/torrent-details/general/general.html
+++ b/src/app/components/modals/torrent-details/general/general.html
@@ -59,7 +59,13 @@
           <span class="section-header">{{
             'components.modals.torrent-details.general.save-path' | translate
           }}</span>
-          <span class="section-value">{{ torrent()!.data.save_path }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.save_path"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.save_path }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -200,7 +206,13 @@
           <span class="section-header">{{
             'components.modals.torrent-details.general.category' | translate
           }}</span>
-          <span class="section-value">{{ torrent()!.data.category || '-' }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.category || '-'"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.category || '-' }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -226,7 +238,13 @@
           <span class="section-header">{{
             'components.modals.torrent-details.general.tags' | translate
           }}</span>
-          <span class="section-value">{{ torrent()!.data.tags || '-' }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.tags || '-'"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.tags || '-' }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -269,9 +287,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{
-            torrent()!.data.time_active | humanizeDuration: 'long' : 2
-          }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.time_active | humanizeDuration: 'long' : 2"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.time_active | humanizeDuration: 'long' : 2 }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -284,7 +306,14 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">
+          <span
+            class="section-value"
+            [ngbTooltip]="
+              isDownloading() ? (torrent()!.data.eta | humanizeDuration: 'long' : 2) : '-'
+            "
+            bbTooltipOverflow
+            placement="bottom"
+          >
             {{ isDownloading() ? (torrent()!.data.eta | humanizeDuration: 'long' : 2) : '-' }}
           </span>
         </div>
@@ -323,7 +352,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.downloaded | fileSize }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.downloaded | fileSize"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.downloaded | fileSize }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -338,7 +373,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.uploaded | fileSize }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.uploaded | fileSize"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.uploaded | fileSize }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -372,7 +413,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.dlspeed | fileSize }}/s</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.dlspeed | fileSize"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.dlspeed | fileSize }}/s</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -388,7 +435,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.upspeed | fileSize }}/s</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.upspeed | fileSize"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.upspeed | fileSize }}/s</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -422,7 +475,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.dl_limit | speedLimit }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.dl_limit | speedLimit"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.dl_limit | speedLimit }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -462,7 +521,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.up_limit | speedLimit }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.up_limit | speedLimit"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.up_limit | speedLimit }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -501,7 +566,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.properties.total_wasted | fileSize }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.properties.total_wasted | fileSize"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.properties.total_wasted | fileSize }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -517,7 +588,12 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.ratio | ratio"
+            bbTooltipOverflow
+            placement="bottom"
+          >
             {{ torrent()!.data.ratio | ratio }}
           </span>
         </div>
@@ -535,11 +611,21 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{
-            torrent()!.properties.reannounce
-              ? (torrent()!.properties.reannounce * 1000 | humanizeDuration: 'long' : 2)
-              : '-'
-          }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="
+              torrent()!.properties.reannounce
+                ? (torrent()!.properties.reannounce * 1000 | humanizeDuration: 'long' : 2)
+                : '-'
+            "
+            bbTooltipOverflow
+            placement="bottom"
+            >{{
+              torrent()!.properties.reannounce
+                ? (torrent()!.properties.reannounce * 1000 | humanizeDuration: 'long' : 2)
+                : '-'
+            }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -568,9 +654,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{
-            torrent()!.data.last_activity * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
-          }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.last_activity * 1000 | date: 'yyyy-MM-dd HH:mm:ss'"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.last_activity * 1000 | date: 'yyyy-MM-dd HH:mm:ss' }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -586,7 +676,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.ratio_limit | ratioLimit }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.ratio_limit | ratioLimit"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.ratio_limit | ratioLimit }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -626,7 +722,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.seeding_time_limit | timeLimit }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.seeding_time_limit | timeLimit"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.seeding_time_limit | timeLimit }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -668,9 +770,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{
-            torrent()!.data.inactive_seeding_time_limit | timeLimit
-          }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.inactive_seeding_time_limit | timeLimit"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.inactive_seeding_time_limit | timeLimit }}</span
+          >
           <div class="button-container">
             <button
               class="btn btn-sm btn-link"
@@ -718,7 +824,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.total_size | fileSize }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.total_size | fileSize"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.total_size | fileSize }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -755,7 +867,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.properties.created_by }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.properties.created_by"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.properties.created_by }}</span
+          >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -770,9 +888,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{
-            torrent()!.data.added_on * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
-          }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.added_on * 1000 | date: 'yyyy-MM-dd HH:mm:ss'"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.data.added_on * 1000 | date: 'yyyy-MM-dd HH:mm:ss' }}</span
+          >
           <span class="section-value"
             ><small>{{ torrent()!.data.added_on * 1000 | timeago }}</small></span
           >
@@ -814,9 +936,13 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{
-            torrent()!.properties.creation_date * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
-          }}</span>
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.properties.creation_date * 1000 | date: 'yyyy-MM-dd HH:mm:ss'"
+            bbTooltipOverflow
+            placement="bottom"
+            >{{ torrent()!.properties.creation_date * 1000 | date: 'yyyy-MM-dd HH:mm:ss' }}</span
+          >
           <span class="section-value"
             ><small>{{ torrent()!.properties.creation_date * 1000 | timeago }}</small></span
           >
@@ -835,7 +961,12 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.infohash_v1"
+            bbTooltipOverflow
+            placement="bottom"
+          >
             @if (torrent()!.data.infohash_v1) {
               <code>{{ torrent()!.data.infohash_v1 }}</code>
             } @else {
@@ -872,7 +1003,12 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.data.infohash_v2"
+            bbTooltipOverflow
+            placement="bottom"
+          >
             @if (torrent()!.data.infohash_v2) {
               <code>{{ torrent()!.data.infohash_v2 }}</code>
             } @else {
@@ -908,7 +1044,12 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">
+          <span
+            class="section-value"
+            [ngbTooltip]="torrent()!.properties.comment"
+            bbTooltipOverflow
+            placement="bottom"
+          >
             @if (torrent()!.properties.comment) {
               {{ torrent()!.properties.comment }}
             } @else {

--- a/src/app/components/modals/torrent-details/general/general.html
+++ b/src/app/components/modals/torrent-details/general/general.html
@@ -519,37 +519,7 @@
           </span>
           <span class="section-value">
             {{ torrent()!.data.ratio | ratio }}
-
-            @if (torrent()!.data.ratio_limit > 0) {
-              <small>
-                {{ 'components.modals.torrent-details.general.limit' | translate }}:
-                {{ torrent()!.data.ratio_limit | ratioLimit }}</small
-              >
-            }
           </span>
-          <div class="button-container">
-            <button
-              class="btn btn-sm btn-link"
-              placement="top"
-              [ngbTooltip]="
-                'components.modals.torrent-details.general.change-share-ratio-limit' | translate
-              "
-              (click)="changeShareRatioLimit()"
-            >
-              <fa-icon [icon]="icons['faPenToSquare']" />
-            </button>
-
-            <button
-              class="btn btn-sm btn-link"
-              placement="top"
-              [ngbTooltip]="
-                'components.modals.torrent-details.general.clear-share-ratio-limit' | translate
-              "
-              (click)="clearShareRatioLimit()"
-            >
-              <fa-icon [icon]="icons['faX']" />
-            </button>
-          </div>
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -601,6 +571,130 @@
           <span class="section-value">{{
             torrent()!.data.last_activity * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
           }}</span>
+        </div>
+        <div class="col-12 col-lg-6 col-xl-4 bb-section">
+          <span class="section-header">
+            {{ 'components.modals.torrent-details.general.ratio-limit' | translate }}
+            <bb-popover
+              placement="top"
+              [subject]="
+                'components.modals.torrent-details.general.popover.ratio-limit.title' | translate
+              "
+              [description]="
+                'components.modals.torrent-details.general.popover.ratio-limit.description'
+                  | translate
+              "
+            ></bb-popover>
+          </span>
+          <span class="section-value">{{ torrent()!.data.ratio_limit | ratioLimit }}</span>
+          <div class="button-container">
+            <button
+              class="btn btn-sm btn-link"
+              placement="top"
+              [ngbTooltip]="
+                'components.modals.torrent-details.general.edit-share-limits' | translate
+              "
+              (click)="openShareLimitsModal()"
+            >
+              <fa-icon [icon]="icons['faPenToSquare']" />
+            </button>
+            <button
+              class="btn btn-sm btn-link"
+              placement="top"
+              [ngbTooltip]="
+                'components.modals.torrent-details.general.clear-ratio-limit' | translate
+              "
+              [disabled]="torrent()!.data.ratio_limit === -1"
+              (click)="clearRatioLimit()"
+            >
+              <fa-icon [icon]="icons['faX']" />
+            </button>
+          </div>
+        </div>
+        <div class="col-12 col-lg-6 col-xl-4 bb-section">
+          <span class="section-header">
+            {{ 'components.modals.torrent-details.general.seeding-time-limit' | translate }}
+            <bb-popover
+              placement="top"
+              [subject]="
+                'components.modals.torrent-details.general.popover.seeding-time-limit.title'
+                  | translate
+              "
+              [description]="
+                'components.modals.torrent-details.general.popover.seeding-time-limit.description'
+                  | translate
+              "
+            ></bb-popover>
+          </span>
+          <span class="section-value">{{ torrent()!.data.seeding_time_limit | timeLimit }}</span>
+          <div class="button-container">
+            <button
+              class="btn btn-sm btn-link"
+              placement="top"
+              [ngbTooltip]="
+                'components.modals.torrent-details.general.edit-share-limits' | translate
+              "
+              (click)="openShareLimitsModal()"
+            >
+              <fa-icon [icon]="icons['faPenToSquare']" />
+            </button>
+            <button
+              class="btn btn-sm btn-link"
+              placement="top"
+              [ngbTooltip]="
+                'components.modals.torrent-details.general.clear-seeding-time-limit' | translate
+              "
+              [disabled]="torrent()!.data.seeding_time_limit === -1"
+              (click)="clearSeedingTimeLimit()"
+            >
+              <fa-icon [icon]="icons['faX']" />
+            </button>
+          </div>
+        </div>
+        <div class="col-12 col-lg-6 col-xl-4 bb-section">
+          <span class="section-header">
+            {{
+              'components.modals.torrent-details.general.inactive-seeding-time-limit' | translate
+            }}
+            <bb-popover
+              placement="top"
+              [subject]="
+                'components.modals.torrent-details.general.popover.inactive-seeding-time-limit.title'
+                  | translate
+              "
+              [description]="
+                'components.modals.torrent-details.general.popover.inactive-seeding-time-limit.description'
+                  | translate
+              "
+            ></bb-popover>
+          </span>
+          <span class="section-value">{{
+            torrent()!.data.inactive_seeding_time_limit | timeLimit
+          }}</span>
+          <div class="button-container">
+            <button
+              class="btn btn-sm btn-link"
+              placement="top"
+              [ngbTooltip]="
+                'components.modals.torrent-details.general.edit-share-limits' | translate
+              "
+              (click)="openShareLimitsModal()"
+            >
+              <fa-icon [icon]="icons['faPenToSquare']" />
+            </button>
+            <button
+              class="btn btn-sm btn-link"
+              placement="top"
+              [ngbTooltip]="
+                'components.modals.torrent-details.general.clear-inactive-seeding-time-limit'
+                  | translate
+              "
+              [disabled]="torrent()!.data.inactive_seeding_time_limit === -1"
+              (click)="clearInactiveSeedingTimeLimit()"
+            >
+              <fa-icon [icon]="icons['faX']" />
+            </button>
+          </div>
         </div>
       </div>
     </fieldset>

--- a/src/app/components/modals/torrent-details/general/general.html
+++ b/src/app/components/modals/torrent-details/general/general.html
@@ -269,7 +269,9 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ torrent()!.data.time_active | humanizeDuration }}</span>
+          <span class="section-value">{{
+            torrent()!.data.time_active | humanizeDuration: 'long' : 2
+          }}</span>
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
           <span class="section-header">
@@ -283,7 +285,7 @@
             ></bb-popover>
           </span>
           <span class="section-value">
-            {{ (torrent()!.data.eta | humanizeDuration) || '-' }}
+            {{ isDownloading() ? (torrent()!.data.eta | humanizeDuration: 'long' : 2) : '-' }}
           </span>
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
@@ -564,7 +566,9 @@
             ></bb-popover>
           </span>
           <span class="section-value">{{
-            humanizeDuration(torrent()!.properties.reannounce)
+            torrent()!.properties.reannounce
+              ? (torrent()!.properties.reannounce * 1000 | humanizeDuration: 'long' : 2)
+              : '-'
           }}</span>
           <div class="button-container">
             <button

--- a/src/app/components/modals/torrent-details/general/general.html
+++ b/src/app/components/modals/torrent-details/general/general.html
@@ -598,7 +598,9 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ formatDate(torrent()!.data.last_activity) }}</span>
+          <span class="section-value">{{
+            torrent()!.data.last_activity * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
+          }}</span>
         </div>
       </div>
     </fieldset>
@@ -674,9 +676,11 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ formatDate(torrent()!.data.added_on) }}</span>
+          <span class="section-value">{{
+            torrent()!.data.added_on * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
+          }}</span>
           <span class="section-value"
-            ><small>{{ formatAgo(torrent()!.data.added_on) }}</small></span
+            ><small>{{ torrent()!.data.added_on * 1000 | timeago }}</small></span
           >
         </div>
         <div class="col-12 col-lg-6 col-xl-4 bb-section">
@@ -695,8 +699,8 @@
           </span>
           <span class="section-value">
             @if (torrent()!.data.completion_on > 0) {
-              {{ formatDate(torrent()!.data.completion_on) }}
-              <small>{{ formatAgo(torrent()!.data.completion_on) }}</small>
+              {{ torrent()!.data.completion_on * 1000 | date: 'yyyy-MM-dd HH:mm:ss' }}
+              <small>{{ torrent()!.data.completion_on * 1000 | timeago }}</small>
             } @else {
               -
             }
@@ -716,9 +720,11 @@
               "
             ></bb-popover>
           </span>
-          <span class="section-value">{{ formatDate(torrent()!.properties.creation_date) }}</span>
+          <span class="section-value">{{
+            torrent()!.properties.creation_date * 1000 | date: 'yyyy-MM-dd HH:mm:ss'
+          }}</span>
           <span class="section-value"
-            ><small>{{ formatAgo(torrent()!.properties.creation_date) }}</small></span
+            ><small>{{ torrent()!.properties.creation_date * 1000 | timeago }}</small></span
           >
         </div>
         <div class="col-12 bb-section">

--- a/src/app/components/modals/torrent-details/general/general.ts
+++ b/src/app/components/modals/torrent-details/general/general.ts
@@ -192,10 +192,6 @@ export class General implements TorrentDetailTabComponent, OnInit {
     return this.timeagoPipe.transform(new Date(seconds * 1000)) ?? '—';
   }
 
-  public humanizeDuration(seconds: number | undefined): string {
-    return seconds ? this.humanizeDurationPipe.transform(seconds) : '-';
-  }
-
   public changeDownloadLimit(): void {
     this.commandBusService.emit({
       type: 'UI_LIMIT_TRANSFER',
@@ -318,5 +314,17 @@ export class General implements TorrentDetailTabComponent, OnInit {
   public toClipboard(field: string, value: string): void {
     this.toastService.info(`Copied ${field} to clipboard.`);
     this.clipboard.copy(value);
+  }
+
+  public isDownloading(): boolean {
+    return (
+      this.torrent()?.data.state === 'downloading' ||
+      this.torrent()?.data.state === 'pausedDL' ||
+      this.torrent()?.data.state === 'stoppedDL' ||
+      this.torrent()?.data.state === 'queuedDL' ||
+      this.torrent()?.data.state === 'stalledDL' ||
+      this.torrent()?.data.state === 'checkingDL' ||
+      this.torrent()?.data.state === 'forcedDL'
+    );
   }
 }

--- a/src/app/components/modals/torrent-details/general/general.ts
+++ b/src/app/components/modals/torrent-details/general/general.ts
@@ -39,6 +39,7 @@ import { HumanizeDurationPipe } from '../../../../pipes/humanize-duration-pipe';
 import { RatioLimitPipe } from '../../../../pipes/ratio-limit-pipe';
 import { RatioPipe } from '../../../../pipes/ratio-pipe';
 import { SpeedLimitPipe } from '../../../../pipes/speed-limit-pipe';
+import { TimeLimitPipe } from '../../../../pipes/time-limit-pipe';
 import { CommandBusService } from '../../../../services/command-bus.service';
 import { GeneralSettingsService } from '../../../../services/general-settings.service';
 import { PathService } from '../../../../services/path.service';
@@ -70,6 +71,7 @@ interface MergedData {
     NgbTooltip,
     RatioLimitPipe,
     RatioPipe,
+    TimeLimitPipe,
     BbPopover,
     TranslatePipe,
     TooltipOverflow,
@@ -233,12 +235,41 @@ export class General implements TorrentDetailTabComponent, OnInit {
     ]);
   }
 
-  public changeShareRatioLimit(): void {
-    this.toastService.info('Changing share ratio limit.');
+  public openShareLimitsModal(): void {
+    this.commandBusService.emit({ type: 'UI_LIMIT_SHARE' });
   }
 
-  public clearShareRatioLimit(): void {
-    this.toastService.info('Clearing share ratio limit.');
+  public clearRatioLimit(): void {
+    const t = this.torrent()!.data;
+    this.qbService.setShareLimits(
+      this.serverStoreService.currentServerId() as string,
+      [this.hash],
+      -1,
+      t.seeding_time_limit,
+      t.inactive_seeding_time_limit,
+    );
+  }
+
+  public clearSeedingTimeLimit(): void {
+    const t = this.torrent()!.data;
+    this.qbService.setShareLimits(
+      this.serverStoreService.currentServerId() as string,
+      [this.hash],
+      t.ratio_limit,
+      -1,
+      t.inactive_seeding_time_limit,
+    );
+  }
+
+  public clearInactiveSeedingTimeLimit(): void {
+    const t = this.torrent()!.data;
+    this.qbService.setShareLimits(
+      this.serverStoreService.currentServerId() as string,
+      [this.hash],
+      t.ratio_limit,
+      t.seeding_time_limit,
+      -1,
+    );
   }
 
   public forceReannounce(): void {

--- a/src/app/components/modals/torrent-details/general/general.ts
+++ b/src/app/components/modals/torrent-details/general/general.ts
@@ -30,7 +30,6 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { TimeagoPipe } from 'ngx-timeago';
 import { take, timer } from 'rxjs';
-import { DEFAULT_DATE_FORMATTER } from '../../../../app.const';
 import { TooltipOverflow } from '../../../../directives/tooltip-overflow';
 import { GeneralSettings } from '../../../../models/general-settings.model';
 import { QbTorrentProperties } from '../../../../models/qbittorrent.model';
@@ -61,6 +60,8 @@ interface MergedData {
   selector: 'app-general',
   imports: [
     BbSpinner,
+    DatePipe,
+    TimeagoPipe,
     FilesizePipe,
     HumanizeDurationPipe,
     SpeedLimitPipe,
@@ -71,10 +72,9 @@ interface MergedData {
     RatioPipe,
     BbPopover,
     TranslatePipe,
-    NgbTooltip,
     TooltipOverflow,
   ],
-  providers: [DatePipe, TimeagoPipe, HumanizeDurationPipe, RatioLimitPipe, RatioPipe],
+  providers: [],
   templateUrl: './general.html',
   styleUrl: './general.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -85,9 +85,6 @@ export class General implements TorrentDetailTabComponent, OnInit {
 
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly qbService = inject(QbService);
-  private readonly datePipe = inject(DatePipe);
-  private readonly timeagoPipe = inject(TimeagoPipe);
-  private readonly humanizeDurationPipe = inject(HumanizeDurationPipe);
   private readonly torrentStoreService = inject(TorrentStoreService);
   private readonly commandBusService = inject(CommandBusService);
   private readonly generalSettingsService = inject(GeneralSettingsService);
@@ -182,14 +179,6 @@ export class General implements TorrentDetailTabComponent, OnInit {
       console.error(General.name, 'load', 'Failed to fetch torrent properties!', error);
       throw new Error(error);
     }
-  }
-
-  public formatDate(seconds: number): string {
-    return this.datePipe.transform(new Date(seconds * 1000), DEFAULT_DATE_FORMATTER) ?? '—';
-  }
-
-  public formatAgo(seconds: number): string {
-    return this.timeagoPipe.transform(new Date(seconds * 1000)) ?? '—';
   }
 
   public changeDownloadLimit(): void {

--- a/src/app/components/share-limit/share-limit.html
+++ b/src/app/components/share-limit/share-limit.html
@@ -1,1 +1,58 @@
-share-limit works!
+<div [formGroup]="form" class="container-fluid px-0">
+  <div class="row">
+    <div class="col-6">
+      <div class="form-floating mb-3">
+        <input
+          type="number"
+          step="0.1"
+          class="form-control"
+          id="ratioLimit"
+          [placeholder]="'components.share-limit.ratio-limit' | translate"
+          formControlName="ratioLimit"
+          min="0"
+        />
+        <label for="ratioLimit">{{ 'components.share-limit.ratio-limit' | translate }}</label>
+      </div>
+    </div>
+
+    <div class="col-6">
+      <div class="input-group mb-3">
+        <div class="form-floating">
+          <input
+            type="number"
+            class="form-control"
+            id="seedingTimeLimit"
+            [placeholder]="'components.share-limit.seeding-time-limit' | translate"
+            formControlName="seedingTimeLimit"
+            min="0"
+          />
+          <label for="seedingTimeLimit">{{
+            'components.share-limit.seeding-time-limit' | translate
+          }}</label>
+        </div>
+        <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
+      </div>
+    </div>
+
+    @if (!hideInactive) {
+      <div class="col-12">
+        <div class="input-group">
+          <div class="form-floating">
+            <input
+              type="number"
+              class="form-control"
+              id="inactiveSeedingTimeLimit"
+              [placeholder]="'components.share-limit.inactive-seeding-time-limit' | translate"
+              formControlName="inactiveSeedingTimeLimit"
+              min="0"
+            />
+            <label for="inactiveSeedingTimeLimit">{{
+              'components.share-limit.inactive-seeding-time-limit' | translate
+            }}</label>
+          </div>
+          <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/components/share-limit/share-limit.html
+++ b/src/app/components/share-limit/share-limit.html
@@ -1,7 +1,7 @@
-<div [formGroup]="form" class="container-fluid px-0">
+<div [formGroup]="form" class="container-fluid">
   <div class="row">
-    <div class="col-6">
-      <div class="form-floating mb-3">
+    <div class="col-11 mb-3">
+      <div class="form-floating">
         <input
           type="number"
           step="0.1"
@@ -13,10 +13,22 @@
         />
         <label for="ratioLimit">{{ 'components.share-limit.ratio-limit' | translate }}</label>
       </div>
+
+      <div class="form-text mt-1 ms-2">
+        {{ form.controls.ratioLimit.value ?? -1 | ratioLimit }}
+      </div>
     </div>
 
-    <div class="col-6">
-      <div class="input-group mb-3">
+    <div class="col-1 d-flex align-items-center mb-3">
+      <bb-popover
+        [subject]="'components.share-limit.popover.ratio-limit.title' | translate"
+        [description]="'components.share-limit.popover.ratio-limit.description' | translate"
+        placement="left"
+      ></bb-popover>
+    </div>
+
+    <div class="col-11 mb-3">
+      <div class="input-group">
         <div class="form-floating">
           <input
             type="number"
@@ -32,10 +44,21 @@
         </div>
         <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
       </div>
+      <div class="form-text mt-1 ms-2">
+        {{ form.controls.seedingTimeLimit.value ?? -1 | timeLimit }}
+      </div>
+    </div>
+
+    <div class="col-1 d-flex align-items-center mb-3">
+      <bb-popover
+        [subject]="'components.share-limit.popover.seeding-time-limit.title' | translate"
+        [description]="'components.share-limit.popover.seeding-time-limit.description' | translate"
+        placement="left"
+      ></bb-popover>
     </div>
 
     @if (!hideInactive) {
-      <div class="col-12">
+      <div class="col-11 mb-3">
         <div class="input-group">
           <div class="form-floating">
             <input
@@ -52,7 +75,27 @@
           </div>
           <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
         </div>
+
+        <div class="form-text mt-1 ms-2">
+          {{ form.controls.inactiveSeedingTimeLimit.value ?? -1 | timeLimit }}
+        </div>
+      </div>
+
+      <div class="col-1 d-flex align-items-center">
+        <bb-popover
+          [subject]="'components.share-limit.popover.inactive-seeding-time-limit.title' | translate"
+          [description]="
+            'components.share-limit.popover.inactive-seeding-time-limit.description' | translate
+          "
+          placement="left"
+        ></bb-popover>
       </div>
     }
+
+    <div class="col-12">
+      <p class="small text-body-secondary mb-0">
+        {{ 'components.share-limit.hint' | translate }}
+      </p>
+    </div>
   </div>
 </div>

--- a/src/app/components/share-limit/share-limit.html
+++ b/src/app/components/share-limit/share-limit.html
@@ -1,6 +1,6 @@
-<div [formGroup]="form" class="container-fluid">
+<div [formGroup]="form" class="container-fluid px-0">
   <div class="row">
-    <div class="col-11 mb-3">
+    <div class="col-11">
       <div class="form-floating">
         <input
           type="number"
@@ -13,21 +13,24 @@
         />
         <label for="ratioLimit">{{ 'components.share-limit.ratio-limit' | translate }}</label>
       </div>
-
-      <div class="form-text mt-1 ms-2">
-        {{ form.controls.ratioLimit.value ?? -1 | ratioLimit }}
-      </div>
     </div>
 
-    <div class="col-1 d-flex align-items-center mb-3">
+    <div class="col-1 d-flex align-items-center">
       <bb-popover
+        class="mt-2"
         [subject]="'components.share-limit.popover.ratio-limit.title' | translate"
         [description]="'components.share-limit.popover.ratio-limit.description' | translate"
         placement="left"
       ></bb-popover>
     </div>
 
-    <div class="col-11 mb-3">
+    <div class="col-12 mb-3">
+      <div class="form-text mt-1 ms-2">
+        {{ form.controls.ratioLimit.value ?? -1 | ratioLimit }}
+      </div>
+    </div>
+
+    <div class="col-11">
       <div class="input-group">
         <div class="form-floating">
           <input
@@ -44,21 +47,25 @@
         </div>
         <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
       </div>
-      <div class="form-text mt-1 ms-2">
-        {{ form.controls.seedingTimeLimit.value ?? -1 | timeLimit }}
-      </div>
     </div>
 
-    <div class="col-1 d-flex align-items-center mb-3">
+    <div class="col-1 d-flex align-items-center">
       <bb-popover
+        class="mt-2"
         [subject]="'components.share-limit.popover.seeding-time-limit.title' | translate"
         [description]="'components.share-limit.popover.seeding-time-limit.description' | translate"
         placement="left"
       ></bb-popover>
     </div>
 
+    <div class="col-12 mb-3">
+      <div class="form-text mt-1 ms-2">
+        {{ form.controls.seedingTimeLimit.value ?? -1 | timeLimit }}
+      </div>
+    </div>
+
     @if (!hideInactive) {
-      <div class="col-11 mb-3">
+      <div class="col-11">
         <div class="input-group">
           <div class="form-floating">
             <input
@@ -75,14 +82,11 @@
           </div>
           <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
         </div>
-
-        <div class="form-text mt-1 ms-2">
-          {{ form.controls.inactiveSeedingTimeLimit.value ?? -1 | timeLimit }}
-        </div>
       </div>
 
       <div class="col-1 d-flex align-items-center">
         <bb-popover
+          class="mt-2"
           [subject]="'components.share-limit.popover.inactive-seeding-time-limit.title' | translate"
           [description]="
             'components.share-limit.popover.inactive-seeding-time-limit.description' | translate
@@ -90,12 +94,12 @@
           placement="left"
         ></bb-popover>
       </div>
-    }
 
-    <div class="col-12">
-      <p class="small text-body-secondary mb-0">
-        {{ 'components.share-limit.hint' | translate }}
-      </p>
-    </div>
+      <div class="col-12">
+        <div class="form-text mt-1 ms-2">
+          {{ form.controls.inactiveSeedingTimeLimit.value ?? -1 | timeLimit }}
+        </div>
+      </div>
+    }
   </div>
 </div>

--- a/src/app/components/share-limit/share-limit.html
+++ b/src/app/components/share-limit/share-limit.html
@@ -1,0 +1,1 @@
+share-limit works!

--- a/src/app/components/share-limit/share-limit.scss
+++ b/src/app/components/share-limit/share-limit.scss
@@ -1,0 +1,3 @@
+bb-popover {
+  margin-left: -10px;
+}

--- a/src/app/components/share-limit/share-limit.scss
+++ b/src/app/components/share-limit/share-limit.scss
@@ -1,3 +1,0 @@
-bb-popover {
-  margin-left: -10px;
-}

--- a/src/app/components/share-limit/share-limit.spec.ts
+++ b/src/app/components/share-limit/share-limit.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShareLimit } from './share-limit';
+
+describe('ShareLimit', () => {
+  let component: ShareLimit;
+  let fixture: ComponentFixture<ShareLimit>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ShareLimit],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShareLimit);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/share-limit/share-limit.ts
+++ b/src/app/components/share-limit/share-limit.ts
@@ -1,4 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormControl,
+  FormGroup,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { TranslatePipe } from '@ngx-translate/core';
 
 export type ShareLimitValue = {
   ratioLimit: number | null;
@@ -8,8 +16,60 @@ export type ShareLimitValue = {
 
 @Component({
   selector: 'app-share-limit',
-  imports: [],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './share-limit.html',
   styleUrl: './share-limit.scss',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ShareLimit),
+      multi: true,
+    },
+  ],
 })
-export class ShareLimit {}
+export class ShareLimit implements ControlValueAccessor, OnInit {
+  @Input() public hideInactive = false;
+
+  public form = new FormGroup({
+    ratioLimit: new FormControl<number | null>(null),
+    seedingTimeLimit: new FormControl<number | null>(null),
+    inactiveSeedingTimeLimit: new FormControl<number | null>(null),
+  });
+
+  private onChange: (value: ShareLimitValue) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  public ngOnInit(): void {
+    this.form.valueChanges.subscribe((value) => {
+      this.onChange({
+        ratioLimit: value.ratioLimit ?? null,
+        seedingTimeLimit: value.seedingTimeLimit ?? null,
+        inactiveSeedingTimeLimit: value.inactiveSeedingTimeLimit ?? null,
+      });
+      this.onTouched();
+    });
+  }
+
+  public writeValue(value: ShareLimitValue | null): void {
+    this.form.patchValue(
+      value ?? { ratioLimit: null, seedingTimeLimit: null, inactiveSeedingTimeLimit: null },
+      { emitEvent: false },
+    );
+  }
+
+  public registerOnChange(fn: (value: ShareLimitValue) => void): void {
+    this.onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    if (isDisabled) {
+      this.form.disable();
+    } else {
+      this.form.enable();
+    }
+  }
+}

--- a/src/app/components/share-limit/share-limit.ts
+++ b/src/app/components/share-limit/share-limit.ts
@@ -7,6 +7,9 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
+import { RatioLimitPipe } from '../../pipes/ratio-limit-pipe';
+import { TimeLimitPipe } from '../../pipes/time-limit-pipe';
+import { BbPopover } from '../bb-popover/bb-popover';
 
 export type ShareLimitValue = {
   ratioLimit: number | null;
@@ -16,7 +19,7 @@ export type ShareLimitValue = {
 
 @Component({
   selector: 'app-share-limit',
-  imports: [ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe, BbPopover, TimeLimitPipe, RatioLimitPipe],
   templateUrl: './share-limit.html',
   styleUrl: './share-limit.scss',
   providers: [

--- a/src/app/components/share-limit/share-limit.ts
+++ b/src/app/components/share-limit/share-limit.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+export type ShareLimitValue = {
+  ratioLimit: number | null;
+  seedingTimeLimit: number | null;
+  inactiveSeedingTimeLimit: number | null;
+};
+
+@Component({
+  selector: 'app-share-limit',
+  imports: [],
+  templateUrl: './share-limit.html',
+  styleUrl: './share-limit.scss',
+})
+export class ShareLimit {}

--- a/src/app/models/add-torrent.model.ts
+++ b/src/app/models/add-torrent.model.ts
@@ -1,3 +1,5 @@
+import { ShareLimitValue } from '../components/share-limit/share-limit';
+
 export type RootFolderMode = 'unset' | 'true' | 'false';
 
 export type AddTorrentSettings = {
@@ -12,8 +14,7 @@ export type AddTorrentSettings = {
   autoTMM: boolean;
   upLimitKbps: number | null;
   dlLimitKbps: number | null;
-  ratioLimit: number | null;
-  seedingTimeLimit: number | null;
+  shareLimits: ShareLimitValue | null;
 };
 
 export const DEFAULT_ADD_TORRENT_SETTINGS: AddTorrentSettings = {
@@ -28,6 +29,5 @@ export const DEFAULT_ADD_TORRENT_SETTINGS: AddTorrentSettings = {
   autoTMM: false,
   upLimitKbps: null,
   dlLimitKbps: null,
-  ratioLimit: null,
-  seedingTimeLimit: null,
+  shareLimits: null,
 };

--- a/src/app/models/command.model.ts
+++ b/src/app/models/command.model.ts
@@ -21,6 +21,7 @@ export type UiCommand =
   | { type: 'UI_SET_TORRENT_LOCATION'; torrent: Torrent }
   | { type: 'UI_RENAME_TORRENT'; torrent: Torrent }
   | { type: 'UI_LIMIT_TRANSFER'; direction: LimitDirectionType; target: LimitTargetType }
+  | { type: 'UI_LIMIT_SHARE' }
   | { type: 'UI_SET_TORRENT_TAGS'; torrent: Torrent }
   | { type: 'UI_SET_TORRENT_CATEGORY'; torrent: Torrent }
   | { type: 'UI_OPEN_DESTINATION'; remotePath: string | null; hash: string }

--- a/src/app/models/qbittorrent.model.ts
+++ b/src/app/models/qbittorrent.model.ts
@@ -164,6 +164,8 @@ export interface QbAppPreferences {
   max_ratio_enabled: boolean;
   max_seeding_time: number;
   max_seeding_time_enabled: boolean;
+  max_inactive_seeding_time?: number;
+  max_inactive_seeding_time_enabled?: boolean;
   outgoing_ports_max: number;
   outgoing_ports_min: number;
   peer_proportional: boolean;

--- a/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -24,6 +24,7 @@ import {
   faPen,
   faPlay,
   faRotate,
+  faShare,
   faTags,
   faTrashCan,
   faUpload,
@@ -227,6 +228,17 @@ export class GridContextMenuService {
             direction: 'dl',
             target: 'torrent',
           }),
+      },
+      {
+        kind: 'item',
+        id: 'speed.limitTorrentShare',
+        label: 'pages.main.grid.context-menu.item.limit-torrent-share',
+        icon: faShare,
+        action: () => {
+          this.commandBusService.emit({
+            type: 'UI_LIMIT_SHARE',
+          });
+        },
       },
       {
         kind: 'item',

--- a/src/app/pages/main/grid/grid.lib.ts
+++ b/src/app/pages/main/grid/grid.lib.ts
@@ -12,6 +12,7 @@ import {
   RowClassParams,
   RowDoubleClickedEvent,
   SelectionChangedEvent,
+  ValueFormatterParams,
 } from 'ag-grid-community';
 import { GRID_SHARED_OPTIONS } from '../../../app.const';
 import { DatepickerRangeFilter } from '../../../components/datepicker-range-filter/datepicker-range-filter';
@@ -149,7 +150,16 @@ export function getGridColDefs(
       headerTooltip: translateService.instant('pages.main.grid.grid-lib.col-def.eta'),
       minWidth: 50,
       width: 200,
-      valueFormatter: uiFormatService.duration,
+      valueFormatter: (params: ValueFormatterParams<Torrent, any>): string =>
+        params.data?.state === 'uploading' ||
+        params.data?.state === 'pausedUP' ||
+        params.data?.state === 'stoppedUP' ||
+        params.data?.state === 'queuedUP' ||
+        params.data?.state === 'stalledUP' ||
+        params.data?.state === 'checkingUP' ||
+        params.data?.state === 'forcedUP'
+          ? ''
+          : uiFormatService.duration(params),
     },
     {
       colId: 'size',
@@ -317,6 +327,7 @@ export function getGridColDefs(
       minWidth: 50,
       width: 155,
       cellClass: 'tabular-nums',
+      valueFormatter: uiFormatService.timeLimit,
     },
     {
       colId: 'time_active',
@@ -480,6 +491,7 @@ export function getGridColDefs(
       minWidth: 50,
       width: 165,
       cellClass: 'tabular-nums',
+      valueFormatter: uiFormatService.timeLimit,
     },
     {
       colId: 'max_inactive_seeding_time',
@@ -494,6 +506,7 @@ export function getGridColDefs(
       minWidth: 50,
       width: 165,
       cellClass: 'tabular-nums',
+      valueFormatter: uiFormatService.timeLimit,
     },
     {
       colId: 'inactive_seeding_time_limit',
@@ -508,6 +521,7 @@ export function getGridColDefs(
       minWidth: 50,
       width: 170,
       cellClass: 'tabular-nums',
+      valueFormatter: uiFormatService.timeLimit,
     },
     {
       colId: 'content_path',

--- a/src/app/pages/settings/status-bar/status-bar.html
+++ b/src/app/pages/settings/status-bar/status-bar.html
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div cdkDropListGroup class="status-bar-config">
-      <fieldset class="bb-fieldset">
+      <fieldset class="bb-fieldset mt-2 mb-1">
         <legend>{{ 'pages.settings.tab.status-bar.label.widget-pool' | translate }}</legend>
         <div
           cdkDropList
@@ -24,7 +24,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="bb-fieldset">
+      <fieldset class="bb-fieldset mt-0">
         <legend>{{ 'pages.settings.tab.status-bar.label.widgets' | translate }}</legend>
         <div class="container-fluid">
           <div class="row">

--- a/src/app/pages/settings/torrent-list-grid/torrent-list-grid.html
+++ b/src/app/pages/settings/torrent-list-grid/torrent-list-grid.html
@@ -9,7 +9,7 @@
     </div>
   </div>
   <form [formGroup]="torrentListGridForm">
-    <fieldset class="bb-fieldset">
+    <fieldset class="bb-fieldset mt-2">
       <legend>{{ 'pages.settings.tab.torrent-list-grid.label.grid-options' | translate }}</legend>
       <div class="container-fluid">
         <div class="row mb-3">

--- a/src/app/pipes/humanize-duration-pipe.ts
+++ b/src/app/pipes/humanize-duration-pipe.ts
@@ -17,14 +17,19 @@ export class HumanizeDurationPipe implements PipeTransform {
       return '';
     }
 
+    const MS_PER_YEAR = 365.25 * 24 * 3600 * 1000;
+    const MS_PER_MONTH = MS_PER_YEAR / 12;
+
     const duration = {
-      days: Math.floor(ms / 86400000),
+      years: Math.floor(ms / MS_PER_YEAR),
+      months: Math.floor((ms % MS_PER_YEAR) / MS_PER_MONTH),
+      days: Math.floor((ms % MS_PER_MONTH) / 86400000),
       hours: Math.floor((ms % 86400000) / 3600000),
       minutes: Math.floor((ms % 3600000) / 60000),
       seconds: Math.floor((ms % 60000) / 1000),
     };
 
-    const fields = ['days', 'hours', 'minutes', 'seconds'] as const;
+    const fields = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'] as const;
     const firstNonZero = fields.findIndex((f) => duration[f] > 0);
     if (firstNonZero !== -1) {
       fields.slice(firstNonZero + precision).forEach((f) => (duration[f] = 0));

--- a/src/app/pipes/humanize-duration-pipe.ts
+++ b/src/app/pipes/humanize-duration-pipe.ts
@@ -10,18 +10,25 @@ import { TranslateService } from '@ngx-translate/core';
 export class HumanizeDurationPipe implements PipeTransform {
   private translate = inject(TranslateService);
 
-  transform(ms: number, style: 'long' | 'short' | 'narrow' = 'long'): string {
+  transform(ms: number, style: 'long' | 'short' | 'narrow' = 'long', precision = Infinity): string {
     const locale = this.translate.getCurrentLang() || this.translate.getFallbackLang() || 'en-US';
 
-    if (ms === null || ms === undefined || isNaN(ms) || ms >= 8640000) {
+    if (ms === null || ms === undefined || isNaN(ms)) {
       return '';
     }
 
     const duration = {
-      hours: Math.floor(ms / 3600000),
+      days: Math.floor(ms / 86400000),
+      hours: Math.floor((ms % 86400000) / 3600000),
       minutes: Math.floor((ms % 3600000) / 60000),
       seconds: Math.floor((ms % 60000) / 1000),
     };
+
+    const fields = ['days', 'hours', 'minutes', 'seconds'] as const;
+    const firstNonZero = fields.findIndex((f) => duration[f] > 0);
+    if (firstNonZero !== -1) {
+      fields.slice(firstNonZero + precision).forEach((f) => (duration[f] = 0));
+    }
 
     try {
       return new DurationFormat(locale, { style }).format(duration);

--- a/src/app/pipes/speed-limit-pipe.ts
+++ b/src/app/pipes/speed-limit-pipe.ts
@@ -6,7 +6,7 @@ import { formatBytes } from '../utils/format-bytes';
   standalone: true,
 })
 export class SpeedLimitPipe implements PipeTransform {
-  transform(limit: number): unknown {
+  transform(limit: number): string {
     return limit <= 0 ? '-' : formatBytes(limit) + '/s';
   }
 }

--- a/src/app/pipes/time-limit-pipe.spec.ts
+++ b/src/app/pipes/time-limit-pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TimeLimitPipe } from './time-limit-pipe';
+
+describe('TimeLimitPipe', () => {
+  it('create an instance', () => {
+    const pipe = new TimeLimitPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/time-limit-pipe.ts
+++ b/src/app/pipes/time-limit-pipe.ts
@@ -1,11 +1,12 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { HumanizeDurationPipe } from './humanize-duration-pipe';
 
 @Pipe({
-  name: 'ratioLimit',
-  standalone: true,
+  name: 'timeLimit',
 })
-export class RatioLimitPipe implements PipeTransform {
+export class TimeLimitPipe implements PipeTransform {
+  private readonly humanizeDurationPipe = inject(HumanizeDurationPipe);
   private readonly translateService = inject(TranslateService);
 
   transform(value: number): string {
@@ -14,7 +15,7 @@ export class RatioLimitPipe implements PipeTransform {
     } else if (value === -1) {
       return this.translateService.instant('general.limit.no-limit');
     } else {
-      return value.toFixed(2);
+      return this.humanizeDurationPipe.transform(value * 60 * 1000, 'long', 2);
     }
   }
 }

--- a/src/app/services/qb.service.ts
+++ b/src/app/services/qb.service.ts
@@ -210,7 +210,7 @@ export class QbService {
   }
 
   async setTorrentLocation(serverId: string, hashes: string[], location: string): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     const loc = (location ?? '').trim();
 
     if (clean.length === 0) return Promise.reject(new Error('No hashes provided'));
@@ -353,7 +353,7 @@ export class QbService {
   }
 
   async deleteTorrents(serverId: string, hashes: string[], deleteFiles: boolean): Promise<string> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return Promise.reject(new Error('No hashes to delete'));
 
     const res = await this.request<string>(serverId, {
@@ -367,7 +367,7 @@ export class QbService {
   }
 
   async recheckTorrents(serverId: string, hashes: string[]): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -380,7 +380,7 @@ export class QbService {
   }
 
   async reannounceTorrents(serverId: string, hashes: string[]): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -470,7 +470,7 @@ export class QbService {
   }
 
   async increasePrio(serverId: string, hashes: string[]): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -484,7 +484,7 @@ export class QbService {
   }
 
   async decreasePrio(serverId: string, hashes: string[]): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -498,7 +498,7 @@ export class QbService {
   }
 
   async topPrio(serverId: string, hashes: string[]): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -512,7 +512,7 @@ export class QbService {
   }
 
   async bottomPrio(serverId: string, hashes: string[]): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -526,7 +526,7 @@ export class QbService {
   }
 
   async setForceStart(serverId: string, hashes: string[], value: boolean): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -539,7 +539,7 @@ export class QbService {
   }
 
   async setSuperSeeding(serverId: string, hashes: string[], value: boolean): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -552,7 +552,7 @@ export class QbService {
   }
 
   async setAutoManagement(serverId: string, hashes: string[], enable: boolean): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     if (cleanHashes.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -569,7 +569,7 @@ export class QbService {
     serverId: string,
     hashes?: string[],
   ): Promise<number | Record<string, number>> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     const isPerTorrent = cleanHashes.length > 0;
 
     const path = isPerTorrent ? '/api/v2/torrents/downloadLimit' : '/api/v2/transfer/downloadLimit';
@@ -587,7 +587,7 @@ export class QbService {
   }
 
   async setDownloadLimit(serverId: string, limit: number, hashes?: string[]): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     const isPerTorrent = cleanHashes.length > 0;
 
     const path = isPerTorrent
@@ -609,7 +609,7 @@ export class QbService {
     serverId: string,
     hashes?: string[],
   ): Promise<number | Record<string, number>> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     const isPerTorrent = cleanHashes.length > 0;
 
     const path = isPerTorrent ? '/api/v2/torrents/uploadLimit' : '/api/v2/transfer/uploadLimit';
@@ -627,7 +627,7 @@ export class QbService {
   }
 
   async setUploadLimit(serverId: string, limit: number, hashes?: string[]): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     const isPerTorrent = cleanHashes.length > 0;
 
     const path = isPerTorrent
@@ -646,7 +646,7 @@ export class QbService {
   }
 
   async addTorrentTags(serverId: string, hashes: string[], tags: string[]): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     if (cleanHashes.length === 0) return;
 
     const cleanTags = (tags ?? []).map((t) => (t ?? '').trim()).filter(Boolean);
@@ -662,7 +662,7 @@ export class QbService {
   }
 
   async removeTorrentTags(serverId: string, hashes: string[], tags: string[]): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     if (cleanHashes.length === 0) return;
 
     const cleanTags = (tags ?? []).map((t) => (t ?? '').trim()).filter(Boolean);
@@ -714,7 +714,7 @@ export class QbService {
   }
 
   async setTorrentCategory(serverId: string, hashes: string[], category: string): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     if (cleanHashes.length === 0) return;
 
     const res = await this.request<void>(serverId, {
@@ -727,7 +727,7 @@ export class QbService {
   }
 
   async clearTorrentsCategory(serverId: string, hashes: string[]): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     if (cleanHashes.length === 0) return;
 
     await this.request<void>(serverId, {
@@ -787,7 +787,7 @@ export class QbService {
     seedingTimeLimit: number,
     inactiveSeedingTimeLimit: number,
   ): Promise<void> {
-    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const cleanHashes = this.cleanHashList(hashes);
     if (cleanHashes.length === 0) return Promise.reject(new Error('No hashes provided'));
 
     const res = await this.request<void>(serverId, {
@@ -829,7 +829,7 @@ export class QbService {
     action: 'pause' | 'resume',
     hashes: string[],
   ): Promise<void> {
-    const clean = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    const clean = this.cleanHashList(hashes);
     if (clean.length === 0) return;
 
     const form = { hashes: clean.join('|') };
@@ -883,6 +883,10 @@ export class QbService {
     const res = await this.request<string>(serverId, { path, method: 'POST', form }, options);
 
     if (!res.ok) throw new HttpError(res.status, res.statusText, `Failed to ${action} torrents`);
+  }
+
+  private cleanHashList(hashes: string[] | undefined): string[] {
+    return (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
   }
 
   private extractIpcStatus(err: any): number | null {

--- a/src/app/services/qb.service.ts
+++ b/src/app/services/qb.service.ts
@@ -780,6 +780,30 @@ export class QbService {
     if (!res.ok) throw new HttpError(res.status, res.statusText, `Failed to remove categories`);
   }
 
+  async setShareLimits(
+    serverId: string,
+    hashes: string[],
+    ratioLimit: number,
+    seedingTimeLimit: number,
+    inactiveSeedingTimeLimit: number,
+  ): Promise<void> {
+    const cleanHashes = (hashes ?? []).map((h) => (h ?? '').trim()).filter(Boolean);
+    if (cleanHashes.length === 0) return Promise.reject(new Error('No hashes provided'));
+
+    const res = await this.request<void>(serverId, {
+      path: '/api/v2/torrents/setShareLimits',
+      method: 'POST',
+      form: {
+        hashes: cleanHashes.join('|'),
+        ratioLimit,
+        seedingTimeLimit,
+        inactiveSeedingTimeLimit,
+      },
+    });
+
+    if (!res.ok) throw new HttpError(res.status, res.statusText, `Failed to set share limits`);
+  }
+
   public async getAlternativeSpeedLimitState(serverId: string): Promise<boolean> {
     const res = await this.request<number>(serverId, {
       path: '/api/v2/transfer/speedLimitsMode',

--- a/src/app/services/ui-command-handler.service.ts
+++ b/src/app/services/ui-command-handler.service.ts
@@ -152,7 +152,7 @@ export class UiCommandHandlerService {
           case 'UI_LIMIT_SHARE':
             if (this.isModalOpen(LimitTorrentShare)) break;
 
-            const limitTorrentShare = this.modalService.open(LimitTorrentShare, {});
+            const limitTorrentShare = this.modalService.open(LimitTorrentShare, { size: 'lg' });
 
             limitTorrentShare.result.then((res: any) => {}).catch((error: any) => {});
             break;

--- a/src/app/services/ui-command-handler.service.ts
+++ b/src/app/services/ui-command-handler.service.ts
@@ -5,6 +5,7 @@ import { filter } from 'rxjs';
 import { About } from '../components/about/about';
 import { AddTorrent } from '../components/add-torrent/add-torrent';
 import { DeleteTorrent } from '../components/modals/delete-torrent/delete-torrent';
+import { LimitTorrentShare } from '../components/modals/limit-torrent-share/limit-torrent-share';
 import { LimitTransferRate } from '../components/modals/limit-transfer-rate/limit-transfer-rate';
 import { RenameTorrent } from '../components/modals/rename-torrent/rename-torrent';
 import { ServerEditor } from '../components/modals/server-editor/server-editor';
@@ -146,6 +147,14 @@ export class UiCommandHandlerService {
             limitTransferModalRef.componentInstance.target = command.target;
 
             limitTransferModalRef.result.then((res: any) => {}).catch((error: any) => {});
+            break;
+
+          case 'UI_LIMIT_SHARE':
+            if (this.isModalOpen(LimitTorrentShare)) break;
+
+            const limitTorrentShare = this.modalService.open(LimitTorrentShare, {});
+
+            limitTorrentShare.result.then((res: any) => {}).catch((error: any) => {});
             break;
 
           case 'UI_SET_TORRENT_TAGS':

--- a/src/app/services/ui-format.service.ts
+++ b/src/app/services/ui-format.service.ts
@@ -5,6 +5,7 @@ import { HumanizeDurationPipe } from '../pipes/humanize-duration-pipe';
 import { LocalTimestampPipe } from '../pipes/local-timestamp-pipe';
 import { RatioLimitPipe } from '../pipes/ratio-limit-pipe';
 import { RatioPipe } from '../pipes/ratio-pipe';
+import { TimeLimitPipe } from '../pipes/time-limit-pipe';
 
 @Injectable({ providedIn: 'root' })
 export class UiFormatService {
@@ -13,6 +14,7 @@ export class UiFormatService {
   private readonly ratioPipe = inject(RatioPipe);
   private readonly localTimestampPipe = inject(LocalTimestampPipe);
   private readonly ratioLimitPipe = inject(RatioLimitPipe);
+  private readonly timeLimitPipe = inject(TimeLimitPipe);
 
   public readonly utcDateComparator = (
     filterLocalDateAtMidnight: Date,
@@ -54,4 +56,7 @@ export class UiFormatService {
 
   public readonly ratioLimit = (params: ValueFormatterParams): string =>
     this.ratioLimitPipe.transform(params.value);
+
+  public readonly timeLimit = (params: ValueFormatterParams): string =>
+    this.timeLimitPipe.transform(params.value);
 }


### PR DESCRIPTION
## Issue ID

Fixes #27 

## Description

Now BitButler is able to handle share limits
 - ratio limit
 - seeding time limit
 - inactive seeding time limit

### Changes in AddTorrent

<img width="907" height="456" alt="image" src="https://github.com/user-attachments/assets/bb1946a2-6d64-421c-96bd-5f4ddf9702d8" />

 - UI layout of form controls has changed, new description popovers are added
 - each section got moved into a fieldset

### Changes in Torrent List Grid

<img width="1205" height="226" alt="image" src="https://github.com/user-attachments/assets/0162229b-4b9d-4a6c-93ca-2587d4f0c133" />

<img width="474" height="674" alt="image" src="https://github.com/user-attachments/assets/1930eaf9-ddbd-42a4-9e85-7dee24f6bc56" />

 - share related fileds now properly showing either the value or the global limit / no limit text
 - set share limits action added to the right-click context menu

### New modal component for inputs

<img width="839" height="525" alt="image" src="https://github.com/user-attachments/assets/e949f5e4-aa28-4ed5-9aa4-0038a193da51" />

Clicking the context menu item, the user will get a modal where the values can be changed or reset.

 ### Torrent Details general view changes

<img width="1198" height="528" alt="image" src="https://github.com/user-attachments/assets/01d957e2-4f53-4fa3-a349-8fb63405d5dd" />

The transfer section is updated with the new values