### PR TITLE
Pin rows and columns in the torrent list

### DIFF
--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -491,6 +491,7 @@
         "context-menu": {
           "header": {
             "cell": "Cella",
+            "row": "Sor",
             "torrent": "Torrent",
             "control": "Vezérlés",
             "files": "Fájlok",
@@ -532,7 +533,13 @@
             "hide-column": "Oszlop elrejtése",
             "clear-filter": "Szűrő törlése",
             "show-all": "Összes megjelenítése",
-            "hide-all": "Összes elrejtése"
+            "hide-all": "Összes elrejtése",
+            "pin-to-top": "Rögzítés felülre",
+            "pin-to-bottom": "Rögzítés alulra",
+            "unpin": "Rögzítés feloldása",
+            "pin-left": "Rögzítés balra",
+            "pin-right": "Rögzítés jobbra",
+            "unpin-column": "Oszlop rögzítésének feloldása"
           }
         },
         "overlays": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -493,6 +493,7 @@
         "context-menu": {
           "header": {
             "cell": "Cell",
+            "row": "Row",
             "torrent": "Torrent",
             "control": "Control",
             "files": "Files",
@@ -504,6 +505,8 @@
           },
           "item": {
             "copy-cell-value": "Copy cell value",
+            "pin-to-top": "Pin to top",
+            "pin-to-bottom": "Pin to bottom",
             "copy-info-hash": "Copy info hash",
             "copy-magnet-link": "Copy magnet link",
             "copy-as-json": "Copy as JSON",
@@ -534,7 +537,11 @@
             "hide-column": "Hide Column",
             "clear-filter": "Clear Filter",
             "show-all": "Show All",
-            "hide-all": "Hide All"
+            "hide-all": "Hide All",
+            "unpin": "Unpin",
+            "pin-left": "Pin left",
+            "pin-right": "Pin right",
+            "unpin-column": "Unpin column"
           }
         },
         "overlays": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -505,8 +505,6 @@
           },
           "item": {
             "copy-cell-value": "Copy cell value",
-            "pin-to-top": "Pin to top",
-            "pin-to-bottom": "Pin to bottom",
             "copy-info-hash": "Copy info hash",
             "copy-magnet-link": "Copy magnet link",
             "copy-as-json": "Copy as JSON",
@@ -538,6 +536,8 @@
             "clear-filter": "Clear Filter",
             "show-all": "Show All",
             "hide-all": "Hide All",
+            "pin-to-top": "Pin to top",
+            "pin-to-bottom": "Pin to bottom",
             "unpin": "Unpin",
             "pin-left": "Pin left",
             "pin-right": "Pin right",

--- a/src/app/app.const.ts
+++ b/src/app/app.const.ts
@@ -24,6 +24,7 @@ const GRID_PARAMS_SHARED = {
   spacing: 6,
   borderRadius: 6,
   wrapperBorderRadius: 10,
+  pinnedRowBorder: '2px solid var(--bb-accent)',
 } as const;
 
 export const GRID_LIGHT_THEME = themeQuartz.withPart(iconSetQuartzLight).withParams({
@@ -43,5 +44,4 @@ export const GRID_SHARED_OPTIONS: GridOptions = {
   suppressCellFocus: true,
   columnHoverHighlight: false,
   tooltipMouseTrack: true,
-  enableRowPinning: true,
 };

--- a/src/app/app.const.ts
+++ b/src/app/app.const.ts
@@ -25,6 +25,7 @@ const GRID_PARAMS_SHARED = {
   borderRadius: 6,
   wrapperBorderRadius: 10,
   pinnedRowBorder: '2px solid var(--bb-accent)',
+  pinnedColumnBorder: '2px solid var(--bb-accent)',
 } as const;
 
 export const GRID_LIGHT_THEME = themeQuartz.withPart(iconSetQuartzLight).withParams({

--- a/src/app/app.const.ts
+++ b/src/app/app.const.ts
@@ -43,4 +43,5 @@ export const GRID_SHARED_OPTIONS: GridOptions = {
   suppressCellFocus: true,
   columnHoverHighlight: false,
   tooltipMouseTrack: true,
+  enableRowPinning: true,
 };

--- a/src/app/models/command.model.ts
+++ b/src/app/models/command.model.ts
@@ -25,7 +25,10 @@ export type UiCommand =
   | { type: 'UI_SET_TORRENT_CATEGORY'; torrent: Torrent }
   | { type: 'UI_OPEN_DESTINATION'; remotePath: string | null; hash: string }
   | { type: 'UI_UPDATE_AVAILABLE'; update: UpdateCheckResponse }
-  | { type: 'UI_RENAME_FILES'; hash: string };
+  | { type: 'UI_RENAME_FILES'; hash: string }
+  | { type: 'UI_TORRENT_PIN_TOP' }
+  | { type: 'UI_TORRENT_PIN_BOTTOM' }
+  | { type: 'UI_TORRENT_UNPIN' };
 
 export type TorrentCommand =
   | { type: 'TORRENT_DELETE_CONFIRM'; removeFiles: boolean }

--- a/src/app/models/torrent-list-grid.model.ts
+++ b/src/app/models/torrent-list-grid.model.ts
@@ -8,6 +8,8 @@ export interface TorrentListGridSettings {
   pagination: boolean;
   animateRows: boolean;
   rowDoubleClickAction: RowDoubleClickAction;
+  pinnedTopHashes: string[];
+  pinnedBottomHashes: string[];
 }
 
 export const DEFAULT_TORRENT_LIST_GRID_SETTINGS: TorrentListGridSettings = {
@@ -28,4 +30,6 @@ export const DEFAULT_TORRENT_LIST_GRID_SETTINGS: TorrentListGridSettings = {
   pagination: false,
   animateRows: true,
   rowDoubleClickAction: 'DETAILS',
+  pinnedTopHashes: [],
+  pinnedBottomHashes: [],
 };

--- a/src/app/pages/main/grid/context-menu/context-menu.types.ts
+++ b/src/app/pages/main/grid/context-menu/context-menu.types.ts
@@ -12,6 +12,7 @@ export interface GridContextMenuData {
 
   row: Torrent;
   selected: Torrent[];
+  rowPinned: 'top' | 'bottom' | null | undefined;
 }
 
 export type ContextMenuVariant = 'default' | 'info' | 'success' | 'warning' | 'danger';

--- a/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -27,7 +27,6 @@ import {
   faPlay,
   faRotate,
   faTags,
-  faThumbTack,
   faTrashCan,
   faUpload,
   faXmark,
@@ -69,7 +68,7 @@ export class GridContextMenuService {
       {
         kind: 'item',
         id: 'row.pinToTop',
-        icon: faThumbTack,
+        icon: faArrowUp,
         label: 'pages.main.grid.context-menu.item.pin-to-top',
         disabled: data.rowPinned === 'top',
         action: () => this.commandBusService.emit({ type: 'UI_TORRENT_PIN_TOP' }),
@@ -77,7 +76,7 @@ export class GridContextMenuService {
       {
         kind: 'item',
         id: 'row.pinToBottom',
-        icon: faThumbTack,
+        icon: faArrowDown,
         label: 'pages.main.grid.context-menu.item.pin-to-bottom',
         disabled: data.rowPinned === 'bottom',
         action: () => this.commandBusService.emit({ type: 'UI_TORRENT_PIN_BOTTOM' }),

--- a/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -2,6 +2,8 @@ import { inject, Injectable } from '@angular/core';
 import { faSquare, faSquareCheck } from '@fortawesome/free-regular-svg-icons';
 import {
   faArrowDown,
+  faArrowLeft,
+  faArrowRight,
   faArrowsDownToLine,
   faArrowsUpToLine,
   faArrowUp,
@@ -69,6 +71,7 @@ export class GridContextMenuService {
         id: 'row.pinToTop',
         icon: faThumbTack,
         label: 'pages.main.grid.context-menu.item.pin-to-top',
+        disabled: data.rowPinned === 'top',
         action: () => this.commandBusService.emit({ type: 'UI_TORRENT_PIN_TOP' }),
       },
       {
@@ -76,6 +79,7 @@ export class GridContextMenuService {
         id: 'row.pinToBottom',
         icon: faThumbTack,
         label: 'pages.main.grid.context-menu.item.pin-to-bottom',
+        disabled: data.rowPinned === 'bottom',
         action: () => this.commandBusService.emit({ type: 'UI_TORRENT_PIN_BOTTOM' }),
       },
       {
@@ -388,6 +392,30 @@ export class GridContextMenuService {
         action: () => {
           this.filterService.clearColumnFilter(payload.colId);
         },
+      },
+      {
+        kind: 'item',
+        id: `pinLeft.${payload.colId}`,
+        label: 'pages.main.grid.context-menu.item.pin-left',
+        icon: faArrowLeft,
+        disabled: column.isPinnedLeft(),
+        action: () => api.setColumnsPinned([payload.colId], 'left'),
+      },
+      {
+        kind: 'item',
+        id: `pinRight.${payload.colId}`,
+        label: 'pages.main.grid.context-menu.item.pin-right',
+        icon: faArrowRight,
+        disabled: column.isPinnedRight(),
+        action: () => api.setColumnsPinned([payload.colId], 'right'),
+      },
+      {
+        kind: 'item',
+        id: `unpinColumn.${payload.colId}`,
+        label: 'pages.main.grid.context-menu.item.unpin-column',
+        icon: faXmark,
+        disabled: !column.getPinned(),
+        action: () => api.setColumnsPinned([payload.colId], null),
       },
       { kind: 'divider' },
       {

--- a/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -25,8 +25,10 @@ import {
   faPlay,
   faRotate,
   faTags,
+  faThumbTack,
   faTrashCan,
   faUpload,
+  faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import type { Column, ColumnHeaderContextMenuEvent } from 'ag-grid-community';
 
@@ -59,6 +61,30 @@ export class GridContextMenuService {
         label: 'pages.main.grid.context-menu.item.copy-cell-value',
         icon: faCopy,
         action: () => this.clipboard.copy(String(data.cell.value)),
+      },
+      { kind: 'divider' },
+      { kind: 'header', label: 'pages.main.grid.context-menu.header.row' },
+      {
+        kind: 'item',
+        id: 'row.pinToTop',
+        icon: faThumbTack,
+        label: 'pages.main.grid.context-menu.item.pin-to-top',
+        action: () => this.commandBusService.emit({ type: 'UI_TORRENT_PIN_TOP' }),
+      },
+      {
+        kind: 'item',
+        id: 'row.pinToBottom',
+        icon: faThumbTack,
+        label: 'pages.main.grid.context-menu.item.pin-to-bottom',
+        action: () => this.commandBusService.emit({ type: 'UI_TORRENT_PIN_BOTTOM' }),
+      },
+      {
+        kind: 'item',
+        id: 'row.unpin',
+        icon: faXmark,
+        label: 'pages.main.grid.context-menu.item.unpin',
+        disabled: !data.rowPinned,
+        action: () => this.commandBusService.emit({ type: 'UI_TORRENT_UNPIN' }),
       },
       { kind: 'divider' },
       {

--- a/src/app/pages/main/grid/grid.ts
+++ b/src/app/pages/main/grid/grid.ts
@@ -193,14 +193,27 @@ export class Grid implements AfterViewInit {
       }
 
       const selectedHashes = new Set(selectedTorrents.map((t) => t.hash));
-      this.api.forEachNode((node) => {
+      const syncNode = (node: {
+        data?: Torrent;
+        isSelected: () => boolean;
+        setSelected: (v: boolean) => void;
+      }) => {
         if (node.data) {
           const shouldBeSelected = selectedHashes.has(node.data.hash);
           if (node.isSelected() !== shouldBeSelected) {
             node.setSelected(shouldBeSelected);
           }
         }
-      });
+      };
+      this.api.forEachNode(syncNode);
+      for (let i = 0; i < this.api.getPinnedTopRowCount(); i++) {
+        const node = this.api.getPinnedTopRow(i);
+        if (node) syncNode(node);
+      }
+      for (let i = 0; i < this.api.getPinnedBottomRowCount(); i++) {
+        const node = this.api.getPinnedBottomRow(i);
+        if (node) syncNode(node);
+      }
     });
 
     this.commandBusService.commands$
@@ -215,24 +228,25 @@ export class Grid implements AfterViewInit {
       )
       .subscribe((cmd) => {
         const hashes = this.selectionStore.selected().map((t) => t.hash);
+        const hashSet = new Set(hashes);
 
         if (cmd.type === 'UI_TORRENT_UNPIN') {
           this.pinnedTopHashes.set(
-            new Set([...this.pinnedTopHashes()].filter((h) => !hashes.includes(h))),
+            new Set([...this.pinnedTopHashes()].filter((h) => !hashSet.has(h))),
           );
           this.pinnedBottomHashes.set(
-            new Set([...this.pinnedBottomHashes()].filter((h) => !hashes.includes(h))),
+            new Set([...this.pinnedBottomHashes()].filter((h) => !hashSet.has(h))),
           );
         } else if (cmd.type === 'UI_TORRENT_PIN_TOP') {
           // Move from bottom to top if already bottom-pinned
           this.pinnedBottomHashes.set(
-            new Set([...this.pinnedBottomHashes()].filter((h) => !hashes.includes(h))),
+            new Set([...this.pinnedBottomHashes()].filter((h) => !hashSet.has(h))),
           );
           this.pinnedTopHashes.set(new Set([...this.pinnedTopHashes(), ...hashes]));
         } else {
           // UI_TORRENT_PIN_BOTTOM — move from top to bottom if already top-pinned
           this.pinnedTopHashes.set(
-            new Set([...this.pinnedTopHashes()].filter((h) => !hashes.includes(h))),
+            new Set([...this.pinnedTopHashes()].filter((h) => !hashSet.has(h))),
           );
           this.pinnedBottomHashes.set(new Set([...this.pinnedBottomHashes(), ...hashes]));
         }

--- a/src/app/pages/main/grid/grid.ts
+++ b/src/app/pages/main/grid/grid.ts
@@ -195,7 +195,7 @@ export class Grid implements AfterViewInit {
       const selectedHashes = new Set(selectedTorrents.map((t) => t.hash));
       const syncNode = (node: {
         data?: Torrent;
-        isSelected: () => boolean;
+        isSelected: () => boolean | undefined;
         setSelected: (v: boolean) => void;
       }) => {
         if (node.data) {

--- a/src/app/pages/main/grid/grid.ts
+++ b/src/app/pages/main/grid/grid.ts
@@ -6,6 +6,7 @@ import {
   HostListener,
   inject,
   Input,
+  signal,
   ViewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -19,8 +20,9 @@ import {
   type GridOptions,
   type RowDoubleClickedEvent,
 } from 'ag-grid-community';
-import { firstValueFrom, skip, Subject, throttleTime } from 'rxjs';
+import { filter, firstValueFrom, skip, Subject, throttleTime } from 'rxjs';
 import { GRID_DARK_THEME, GRID_LIGHT_THEME } from '../../../app.const';
+import { UiCommand } from '../../../models/command.model';
 import { TorrentListGridSettings } from '../../../models/torrent-list-grid.model';
 import { Torrent } from '../../../models/torrent.model';
 import { CommandBusService } from '../../../services/command-bus.service';
@@ -68,6 +70,8 @@ export class Grid implements AfterViewInit {
   private readonly saveGridState$ = new Subject<void>();
 
   private api: GridApi<Torrent> | null = null;
+  private readonly pinnedTopHashes = signal<Set<string>>(new Set());
+  private readonly pinnedBottomHashes = signal<Set<string>>(new Set());
   private selectionAnchorIndex: number | null = null;
   private selectionLeadIndex: number | null = null;
 
@@ -165,8 +169,17 @@ export class Grid implements AfterViewInit {
 
     effect(() => {
       const torrents = this.torrentStore.torrentsArray();
+      const topHashes = this.pinnedTopHashes();
+      const bottomHashes = this.pinnedBottomHashes();
       if (!this.api) return;
-      this.api.setGridOption('rowData', torrents);
+
+      const pinnedTop = torrents.filter((t) => topHashes.has(t.hash));
+      const pinnedBottom = torrents.filter((t) => bottomHashes.has(t.hash));
+      const mainRows = torrents.filter((t) => !topHashes.has(t.hash) && !bottomHashes.has(t.hash));
+
+      this.api.setGridOption('rowData', mainRows);
+      this.api.setGridOption('pinnedTopRowData', pinnedTop);
+      this.api.setGridOption('pinnedBottomRowData', pinnedBottom);
     });
 
     effect(() => {
@@ -189,6 +202,49 @@ export class Grid implements AfterViewInit {
         }
       });
     });
+
+    this.commandBusService.commands$
+      .pipe(
+        filter(
+          (cmd): cmd is UiCommand =>
+            cmd.type === 'UI_TORRENT_PIN_TOP' ||
+            cmd.type === 'UI_TORRENT_PIN_BOTTOM' ||
+            cmd.type === 'UI_TORRENT_UNPIN',
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((cmd) => {
+        const hashes = this.selectionStore.selected().map((t) => t.hash);
+
+        if (cmd.type === 'UI_TORRENT_UNPIN') {
+          this.pinnedTopHashes.set(
+            new Set([...this.pinnedTopHashes()].filter((h) => !hashes.includes(h))),
+          );
+          this.pinnedBottomHashes.set(
+            new Set([...this.pinnedBottomHashes()].filter((h) => !hashes.includes(h))),
+          );
+        } else if (cmd.type === 'UI_TORRENT_PIN_TOP') {
+          // Move from bottom to top if already bottom-pinned
+          this.pinnedBottomHashes.set(
+            new Set([...this.pinnedBottomHashes()].filter((h) => !hashes.includes(h))),
+          );
+          this.pinnedTopHashes.set(new Set([...this.pinnedTopHashes(), ...hashes]));
+        } else {
+          // UI_TORRENT_PIN_BOTTOM — move from top to bottom if already top-pinned
+          this.pinnedTopHashes.set(
+            new Set([...this.pinnedTopHashes()].filter((h) => !hashes.includes(h))),
+          );
+          this.pinnedBottomHashes.set(new Set([...this.pinnedBottomHashes(), ...hashes]));
+        }
+
+        if (this.api) {
+          void this.gridStateService.save(
+            this.api,
+            [...this.pinnedTopHashes()],
+            [...this.pinnedBottomHashes()],
+          );
+        }
+      });
   }
 
   private areSelectionsEqual(a: Torrent[], b: Torrent[]): boolean {
@@ -206,12 +262,19 @@ export class Grid implements AfterViewInit {
 
     this.api.setGridOption('pagination', settings.pagination);
     this.api.setGridOption('animateRows', settings.animateRows);
+
+    this.pinnedTopHashes.set(new Set(settings.pinnedTopHashes ?? []));
+    this.pinnedBottomHashes.set(new Set(settings.pinnedBottomHashes ?? []));
   }
 
   ngAfterViewInit(): void {
     this.saveGridState$.pipe(throttleTime(500, undefined, { trailing: true })).subscribe(() => {
       if (!this.api) return;
-      this.gridStateService.save(this.api);
+      void this.gridStateService.save(
+        this.api,
+        [...this.pinnedTopHashes()],
+        [...this.pinnedBottomHashes()],
+      );
     });
 
     this.filterService.external$
@@ -373,6 +436,7 @@ export class Grid implements AfterViewInit {
         row: event.data,
         cell: { value: event.value, colId: event.column.getColId(), rowId: event.data.hash },
         selected: this.selectionStore.selected(),
+        rowPinned: event.node.rowPinned,
       }),
     });
   };

--- a/src/app/services/grid-state.service.ts
+++ b/src/app/services/grid-state.service.ts
@@ -48,8 +48,12 @@ export class GridStateService {
       ...settings,
       columnState: null,
       filterModel: null,
+      pinnedTopHashes: [],
+      pinnedBottomHashes: [],
     });
     api.setFilterModel(null);
     api.resetColumnState();
+    api.setGridOption('pinnedTopRowData', []);
+    api.setGridOption('pinnedBottomRowData', []);
   }
 }

--- a/src/app/services/grid-state.service.ts
+++ b/src/app/services/grid-state.service.ts
@@ -23,7 +23,7 @@ export class GridStateService {
     return hasColumnState || hasFilterModel;
   }
 
-  async save(api: GridApi): Promise<void> {
+  async save(api: GridApi, pinnedTopHashes: string[], pinnedBottomHashes: string[]): Promise<void> {
     const settings = await firstValueFrom(
       this.torrentListGridSettingsService
         .asObservable()
@@ -33,6 +33,8 @@ export class GridStateService {
       ...settings,
       columnState: api.getColumnState(),
       filterModel: api.getFilterModel(),
+      pinnedTopHashes,
+      pinnedBottomHashes,
     });
   }
 


### PR DESCRIPTION
## Issue ID

Fixes #29 

## Description

Now rows and columns can be pinned to top, bottom, left and right.

Rows can be pinned from the right click context menu

<img width="492" height="679" alt="image" src="https://github.com/user-attachments/assets/7ba78ac2-196d-4384-bd62-60da28bb8394" />

Columns can be pinned either from the right click context menu, or dragging the column to the border of the grid.

<img width="492" height="679" alt="image" src="https://github.com/user-attachments/assets/25dad857-1ebd-4d95-a096-7f446da658c1" />
