### PR TITLE
Transfer limit component refactored

### DIFF
--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -55,8 +55,6 @@
         "auto-tmm": "Automatikus Torrentkezelés (TMM) használata",
         "sequential-download": "Sorrendi letöltés engedélyezése",
         "first-last-piece-prio": "Első és utolsó szelet priorizálása",
-        "up-limit": "Feltöltési korlát",
-        "down-limit": "Letöltési korlát",
         "ratio-limit": "Arány korlát",
         "seeding-time-limit": "Seedelési időkorlát",
         "seeding-time-limit-unit": "perc"
@@ -157,12 +155,8 @@
         }
       },
       "limit-transfer-rate": {
-        "title-upload": "Feltöltési sebesség korlátozása",
-        "title-download": "Letöltési sebesség korlátozása",
-        "global": "Globális átviteli korlát",
-        "limit-upload": "Feltöltési korlát",
-        "limit-download": "Letöltési korlát",
-        "clear-limit": "Korlát törlése"
+        "title": "Átviteli sebesség korlátozása",
+        "global": "Globális átviteli korlát"
       },
       "rename-torrent": {
         "title": "Torrent átnevezése",
@@ -472,11 +466,24 @@
         "unsaved-indicator": "Mentetlen változtatások"
       }
     },
+    "transfer-rate-limit": {
+      "upload-limit": "Feltöltési korlát (KiB/s)",
+      "download-limit": "Letöltési korlát (KiB/s)",
+      "popover": {
+        "upload-limit": {
+          "title": "Feltöltési korlát",
+          "description": "Maximális feltöltési sebesség KiB/s-ban. A 0 korlátlan sebességet jelent."
+        },
+        "download-limit": {
+          "title": "Letöltési korlát",
+          "description": "Maximális letöltési sebesség KiB/s-ban. A 0 korlátlan sebességet jelent."
+        }
+      }
+    },
     "share-limit": {
       "ratio-limit": "Arány korlát",
-      "seeding-time-limit": "Seedelési időkorlát",
-      "inactive-seeding-time-limit": "Inaktív seedelési időkorlát",
-      "time-unit": "perc",
+      "seeding-time-limit": "Seedelési időkorlát (perc)",
+      "inactive-seeding-time-limit": "Inaktív seedelési időkorlát (perc)",
       "popover": {
         "ratio-limit": {
           "title": "Arány korlát",
@@ -580,8 +587,7 @@
             "set-category": "Kategória beállítása",
             "set-tags": "Címkék beállítása",
             "remove": "Eltávolítás",
-            "limit-upload-rate": "Feltöltési sebesség korlátozása",
-            "limit-download-rate": "Letöltési sebesség korlátozása",
+            "limit-transfer-rate": "Átviteli sebesség korlátozása",
             "limit-torrent-share": "Megosztási korlátok beállítása",
             "enable-super-seeding": "Super seeding engedélyezése",
             "disable-super-seeding": "Super seeding tiltása",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -55,8 +55,6 @@
         "auto-tmm": "Use Auto TMM",
         "sequential-download": "Enable sequential download",
         "first-last-piece-prio": "Prioritize download first last piece",
-        "up-limit": "Upload Limit",
-        "down-limit": "Download Limit",
         "ratio-limit": "Ratio Limit",
         "seeding-time-limit": "Seeding Time Limit",
         "seeding-time-limit-unit": "minute"
@@ -157,12 +155,8 @@
         }
       },
       "limit-transfer-rate": {
-        "title-upload": "Limit upload Speed",
-        "title-download": "Limit download Speed",
-        "global": "Global Transfer Limit",
-        "limit-upload": "Upload Limit",
-        "limit-download": "Download Limit",
-        "clear-limit": "Clear Limit"
+        "title": "Limit Transfer Rate",
+        "global": "Global Transfer Limit"
       },
       "rename-torrent": {
         "title": "Rename Torrent",
@@ -472,11 +466,24 @@
         "unsaved-indicator": "Unsaved changes"
       }
     },
+    "transfer-rate-limit": {
+      "upload-limit": "Upload Limit (KiB/s)",
+      "download-limit": "Download Limit (KiB/s)",
+      "popover": {
+        "upload-limit": {
+          "title": "Upload Limit",
+          "description": "Maximum upload speed in KiB/s. Enter 0 for unlimited."
+        },
+        "download-limit": {
+          "title": "Download Limit",
+          "description": "Maximum download speed in KiB/s. Enter 0 for unlimited."
+        }
+      }
+    },
     "share-limit": {
       "ratio-limit": "Ratio Limit",
-      "seeding-time-limit": "Seeding Time Limit",
-      "inactive-seeding-time-limit": "Inactive Seeding Time Limit",
-      "time-unit": "min",
+      "seeding-time-limit": "Seeding Time Limit (min)",
+      "inactive-seeding-time-limit": "Inactive Seeding Time Limit (min)",
       "popover": {
         "ratio-limit": {
           "title": "Ratio Limit",
@@ -580,8 +587,7 @@
             "set-category": "Set Category",
             "set-tags": "Set Tags",
             "remove": "Remove",
-            "limit-upload-rate": "Limit upload rate",
-            "limit-download-rate": "Limit download rate",
+            "limit-transfer-rate": "Limit Transfer Rate",
             "limit-torrent-share": "Set Share Limits",
             "enable-super-seeding": "Enable Super Seeding",
             "disable-super-seeding": "Disable Super Seeding",

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -246,42 +246,8 @@
 
       <div class="container px-0">
         <div class="row">
-          <div class="col-6">
-            <div class="input-group mb-3">
-              <div class="form-floating">
-                <input
-                  type="number"
-                  class="form-control"
-                  id="upLimitKbps"
-                  [placeholder]="'components.add-torrent.add-form.up-limit' | translate"
-                  formControlName="upLimitKbps"
-                  min="0"
-                />
-                <label for="upLimitKbps">{{
-                  'components.add-torrent.add-form.up-limit' | translate
-                }}</label>
-              </div>
-              <span class="input-group-text">KiB/s</span>
-            </div>
-          </div>
-
-          <div class="col-6">
-            <div class="input-group mb-3">
-              <div class="form-floating">
-                <input
-                  type="number"
-                  class="form-control"
-                  id="dlLimitKbps"
-                  [placeholder]="'components.add-torrent.add-form.down-limit' | translate"
-                  formControlName="dlLimitKbps"
-                  min="0"
-                />
-                <label for="dlLimitKbps">{{
-                  'components.add-torrent.add-form.down-limit' | translate
-                }}</label>
-              </div>
-              <span class="input-group-text">KiB/s</span>
-            </div>
+          <div class="col-12 mb-3">
+            <app-transfer-rate-limit formControlName="transferRateLimits"></app-transfer-rate-limit>
           </div>
 
           <div class="col-12">

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -40,6 +40,10 @@ import { CategorySelect } from '../category-select/category-select';
 import { TorrentExists } from '../modals/torrent-exists/torrent-exists';
 import { ShareLimit, ShareLimitValue } from '../share-limit/share-limit';
 import { TagSelect } from '../tag-select/tag-select';
+import {
+  TransferRateLimit,
+  TransferRateLimitValue,
+} from '../transfer-rate-limit/transfer-rate-limit';
 
 type AddTorrentFormValue = {
   file: string;
@@ -52,8 +56,7 @@ type AddTorrentFormValue = {
   skip_checking: boolean;
   sequentialDownload: boolean;
   firstLastPiecePrio: boolean;
-  upLimitKbps: number | null;
-  dlLimitKbps: number | null;
+  transferRateLimits: TransferRateLimitValue | null;
   shareLimits: ShareLimitValue | null;
   autoTMM: boolean;
 };
@@ -72,6 +75,7 @@ type AddTorrentFormValue = {
     NgSelectModule,
     TranslatePipe,
     ShareLimit,
+    TransferRateLimit,
   ],
   templateUrl: './add-torrent.html',
   styleUrl: './add-torrent.scss',
@@ -121,8 +125,7 @@ export class AddTorrent implements OnInit {
     skip_checking: new FormControl<boolean>(false, { nonNullable: true }),
     sequentialDownload: new FormControl<boolean>(false, { nonNullable: true }),
     firstLastPiecePrio: new FormControl<boolean>(false, { nonNullable: true }),
-    upLimitKbps: new FormControl<number | null>(null),
-    dlLimitKbps: new FormControl<number | null>(null),
+    transferRateLimits: new FormControl<TransferRateLimitValue | null>(null),
     shareLimits: new FormControl<ShareLimitValue | null>(null),
     autoTMM: new FormControl<boolean>(false, { nonNullable: true }),
   });
@@ -242,8 +245,14 @@ export class AddTorrent implements OnInit {
         firstLastPiecePrio: raw.firstLastPiecePrio ? 'true' : 'false',
         autoTMM: raw.autoTMM ? 'true' : 'false',
         root_folder: raw.root_folder === 'unset' ? undefined : raw.root_folder,
-        upLimit: raw.upLimitKbps != null ? String(Math.round(raw.upLimitKbps * 1024)) : undefined,
-        dlLimit: raw.dlLimitKbps != null ? String(Math.round(raw.dlLimitKbps * 1024)) : undefined,
+        upLimit:
+          raw.transferRateLimits?.uploadLimit != null
+            ? String(Math.round(raw.transferRateLimits.uploadLimit * 1024))
+            : undefined,
+        dlLimit:
+          raw.transferRateLimits?.downloadLimit != null
+            ? String(Math.round(raw.transferRateLimits.downloadLimit * 1024))
+            : undefined,
         ratioLimit:
           raw.shareLimits?.ratioLimit != null ? String(raw.shareLimits.ratioLimit) : undefined,
         seedingTimeLimit:
@@ -273,8 +282,7 @@ export class AddTorrent implements OnInit {
         sequentialDownload: raw.sequentialDownload,
         firstLastPiecePrio: raw.firstLastPiecePrio,
         autoTMM: raw.autoTMM,
-        upLimitKbps: raw.upLimitKbps,
-        dlLimitKbps: raw.dlLimitKbps,
+        transferRateLimits: raw.transferRateLimits,
         shareLimits: raw.shareLimits,
       });
       this.openFilesService.consumeCurrentDraft();

--- a/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
+++ b/src/app/components/modals/limit-torrent-share/limit-torrent-share.ts
@@ -104,6 +104,7 @@ export class LimitTorrentShare implements OnInit {
       seedingTimeLimit: null,
       inactiveSeedingTimeLimit: null,
     });
+    this.handleSubmit();
   }
 
   public canSave(): boolean {

--- a/src/app/components/modals/limit-transfer-rate/limit-transfer-rate.html
+++ b/src/app/components/modals/limit-transfer-rate/limit-transfer-rate.html
@@ -1,12 +1,7 @@
 <div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">
-      {{
-        (direction === 'ul'
-          ? 'components.modals.limit-transfer-rate.title-upload'
-          : 'components.modals.limit-transfer-rate.title-download'
-        ) | translate
-      }}
+      {{ 'components.modals.limit-transfer-rate.title' | translate }}
     </h5>
 
     <div
@@ -33,49 +28,29 @@
     (click)="activeModal.dismiss()"
   ></button>
 </div>
+
 <div class="modal-body">
-  <form [formGroup]="limitTransferForm" (submit)="handleSubmit()">
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-12">
-          <div class="input-group">
-            <div class="form-floating">
-              <input
-                type="number"
-                class="form-control"
-                id="limit"
-                placeholder="0"
-                autofocus
-                formControlName="limit"
-                min="0"
-              />
-              <label for="limit">
-                {{
-                  (direction === 'ul'
-                    ? 'components.modals.limit-transfer-rate.limit-upload'
-                    : 'components.modals.limit-transfer-rate.limit-download'
-                  ) | translate
-                }}</label
-              >
-            </div>
-            <span class="input-group-text">KiB/s</span>
-          </div>
-        </div>
-      </div>
-    </div>
+  <form [formGroup]="form" (submit)="handleSubmit()">
+    <app-transfer-rate-limit formControlName="transferRateLimits"></app-transfer-rate-limit>
     <button type="submit" hidden [disabled]="!canSave()"></button>
   </form>
 </div>
+
 <div class="modal-footer">
   <button type="button" class="btn btn-secondary" (click)="handleSubmit()" [disabled]="!canSave()">
-    {{ 'general.button.set' | translate }}
+    {{ 'general.button.save' | translate }}
   </button>
-  @if (hasClearableLimit()) {
-    <button type="button" class="btn btn-link" (click)="clearFilters()" [disabled]="!canSave()">
-      {{ 'components.modals.limit-transfer-rate.clear-limit' | translate }}
+  @if (hasClearableValues()) {
+    <button
+      type="button"
+      class="btn btn-link text-danger"
+      (click)="clearAll()"
+      [disabled]="!canSave()"
+    >
+      {{ 'general.button.clear-all' | translate }}
     </button>
   }
-  <button type="button" class="btn btn-link" (click)="activeModal.close()">
+  <button type="button" class="btn btn-link" (click)="activeModal.dismiss()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/src/app/components/modals/limit-transfer-rate/limit-transfer-rate.ts
+++ b/src/app/components/modals/limit-transfer-rate/limit-transfer-rate.ts
@@ -1,36 +1,36 @@
 import { Component, computed, inject, Input, OnInit, signal } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
-import { AutofocusDirective } from '../../../directives/autofocus';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
-import { LimitDirectionType, LimitTargetType } from '../../../models/command.model';
+import { LimitTargetType } from '../../../models/command.model';
 import { QbService } from '../../../services/qb.service';
 import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
+import {
+  TransferRateLimit,
+  TransferRateLimitValue,
+} from '../../transfer-rate-limit/transfer-rate-limit';
 
 @Component({
   selector: 'app-limit-transfer-rate',
-  imports: [ReactiveFormsModule, AutofocusDirective, NgbTooltip, TranslatePipe, TooltipOverflow],
+  imports: [ReactiveFormsModule, TranslatePipe, TransferRateLimit, NgbTooltip, TooltipOverflow],
   templateUrl: './limit-transfer-rate.html',
   styleUrl: './limit-transfer-rate.scss',
 })
 export class LimitTransferRate implements OnInit {
   @Input() public target!: LimitTargetType;
-  @Input() public direction!: LimitDirectionType;
 
   private readonly qbService = inject(QbService);
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly selectionStoreService = inject(SelectionStoreService);
   public activeModal = inject(NgbActiveModal);
 
-  public limitTransferForm = new FormGroup({
-    limit: new FormControl(0, [Validators.required]),
+  public form = new FormGroup({
+    transferRateLimits: new FormControl<TransferRateLimitValue | null>(null),
   });
 
-  public hasClearableLimit = signal<boolean>(false);
   public saving = signal<boolean>(false);
-
   public selected = signal<number>(this.selectionStoreService.selected().length);
 
   public selectionName = computed(() => {
@@ -45,56 +45,70 @@ export class LimitTransferRate implements OnInit {
 
   public async ngOnInit(): Promise<void> {
     const serverId = this.serverStoreService.currentServerId() as string;
-    let limit = 0;
+    let uploadBytes = 0;
+    let downloadBytes = 0;
 
     if (this.target === 'global') {
-      if (this.direction === 'ul') {
-        limit = (await this.qbService.getUploadLimit(serverId)) as number;
-      } else {
-        limit = (await this.qbService.getDownloadLimit(serverId)) as number;
-      }
-    } else if (this.target === 'torrent') {
+      [uploadBytes, downloadBytes] = await Promise.all([
+        this.qbService.getUploadLimit(serverId) as Promise<number>,
+        this.qbService.getDownloadLimit(serverId) as Promise<number>,
+      ]);
+    } else {
       const selectedTorrents = this.selectionStoreService.selected();
       if (selectedTorrents.length > 0) {
         const torrent = selectedTorrents[0];
-        limit = this.direction === 'ul' ? torrent.up_limit : torrent.dl_limit;
+        uploadBytes = torrent.up_limit;
+        downloadBytes = torrent.dl_limit;
       }
     }
 
-    this.limitTransferForm.get('limit')?.patchValue(limit > 0 ? Math.floor(limit / 1024) : 0);
-    this.hasClearableLimit.set(limit > 0);
+    this.form.controls.transferRateLimits.setValue(
+      {
+        uploadLimit: uploadBytes > 0 ? Math.floor(uploadBytes / 1024) : null,
+        downloadLimit: downloadBytes > 0 ? Math.floor(downloadBytes / 1024) : null,
+      },
+      { emitEvent: false },
+    );
   }
 
   public async handleSubmit(): Promise<void> {
     this.saving.set(true);
     const serverId = this.serverStoreService.currentServerId() as string;
-    const limitInKiB = this.limitTransferForm.get('limit')?.value ?? 0;
-    const limit = limitInKiB * 1024;
+    const value = this.form.controls.transferRateLimits.value;
+    const uploadBytes = (value?.uploadLimit ?? 0) * 1024;
+    const downloadBytes = (value?.downloadLimit ?? 0) * 1024;
     const hashes =
       this.target === 'torrent'
         ? this.selectionStoreService.selected().map((t) => t.hash.trim())
         : undefined;
 
     try {
-      if (this.direction === 'ul') {
-        await this.qbService.setUploadLimit(serverId, limit, hashes);
-      } else {
-        await this.qbService.setDownloadLimit(serverId, limit, hashes);
-      }
+      await Promise.all([
+        this.qbService.setUploadLimit(serverId, uploadBytes, hashes),
+        this.qbService.setDownloadLimit(serverId, downloadBytes, hashes),
+      ]);
     } catch (error: any) {
-      console.error(LimitTransferRate.name, 'handleSubmit', 'Failed to update limit!');
+      console.error(LimitTransferRate.name, 'handleSubmit', 'Failed to update limits!');
     } finally {
       this.saving.set(false);
       this.activeModal.close();
     }
   }
 
-  public clearFilters(): void {
-    this.limitTransferForm.get('limit')?.patchValue(0);
+  public clearAll(): void {
+    this.form.controls.transferRateLimits.setValue({
+      uploadLimit: null,
+      downloadLimit: null,
+    });
     this.handleSubmit();
   }
 
+  public hasClearableValues(): boolean {
+    const v = this.form.controls.transferRateLimits.value;
+    return v !== null && (v.uploadLimit !== null || v.downloadLimit !== null);
+  }
+
   public canSave(): boolean {
-    return this.limitTransferForm.valid && !this.saving();
+    return this.form.valid && !this.saving();
   }
 }

--- a/src/app/components/modals/limit-transfer-rate/limit-transfer-rate.ts
+++ b/src/app/components/modals/limit-transfer-rate/limit-transfer-rate.ts
@@ -1,4 +1,12 @@
-import { Component, computed, inject, Input, OnInit, signal } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  computed,
+  inject,
+  Input,
+  OnInit,
+  signal,
+} from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -24,6 +32,7 @@ export class LimitTransferRate implements OnInit {
   private readonly qbService = inject(QbService);
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly selectionStoreService = inject(SelectionStoreService);
+  private readonly cdr = inject(ChangeDetectorRef);
   public activeModal = inject(NgbActiveModal);
 
   public form = new FormGroup({
@@ -69,6 +78,7 @@ export class LimitTransferRate implements OnInit {
       },
       { emitEvent: false },
     );
+    this.cdr.markForCheck();
   }
 
   public async handleSubmit(): Promise<void> {

--- a/src/app/components/modals/torrent-details/general/general.ts
+++ b/src/app/components/modals/torrent-details/general/general.ts
@@ -186,7 +186,6 @@ export class General implements TorrentDetailTabComponent, OnInit {
   public changeDownloadLimit(): void {
     this.commandBusService.emit({
       type: 'UI_LIMIT_TRANSFER',
-      direction: 'dl',
       target: 'torrent',
     });
   }
@@ -194,7 +193,6 @@ export class General implements TorrentDetailTabComponent, OnInit {
   public changeUploadLimit(): void {
     this.commandBusService.emit({
       type: 'UI_LIMIT_TRANSFER',
-      direction: 'ul',
       target: 'torrent',
     });
   }

--- a/src/app/components/share-limit/share-limit.html
+++ b/src/app/components/share-limit/share-limit.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" class="container-fluid px-0">
   <div class="row">
-    <div class="col-11">
+    <div class="col-5">
       <div class="form-floating">
         <input
           type="number"
@@ -30,22 +30,19 @@
       </div>
     </div>
 
-    <div class="col-11">
-      <div class="input-group">
-        <div class="form-floating">
-          <input
-            type="number"
-            class="form-control"
-            id="seedingTimeLimit"
-            [placeholder]="'components.share-limit.seeding-time-limit' | translate"
-            formControlName="seedingTimeLimit"
-            min="0"
-          />
-          <label for="seedingTimeLimit">{{
-            'components.share-limit.seeding-time-limit' | translate
-          }}</label>
-        </div>
-        <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
+    <div class="col-5">
+      <div class="form-floating">
+        <input
+          type="number"
+          class="form-control"
+          id="seedingTimeLimit"
+          [placeholder]="'components.share-limit.seeding-time-limit' | translate"
+          formControlName="seedingTimeLimit"
+          min="0"
+        />
+        <label for="seedingTimeLimit">{{
+          'components.share-limit.seeding-time-limit' | translate
+        }}</label>
       </div>
     </div>
 
@@ -65,22 +62,19 @@
     </div>
 
     @if (!hideInactive) {
-      <div class="col-11">
-        <div class="input-group">
-          <div class="form-floating">
-            <input
-              type="number"
-              class="form-control"
-              id="inactiveSeedingTimeLimit"
-              [placeholder]="'components.share-limit.inactive-seeding-time-limit' | translate"
-              formControlName="inactiveSeedingTimeLimit"
-              min="0"
-            />
-            <label for="inactiveSeedingTimeLimit">{{
-              'components.share-limit.inactive-seeding-time-limit' | translate
-            }}</label>
-          </div>
-          <span class="input-group-text">{{ 'components.share-limit.time-unit' | translate }}</span>
+      <div class="col-5">
+        <div class="form-floating">
+          <input
+            type="number"
+            class="form-control"
+            id="inactiveSeedingTimeLimit"
+            [placeholder]="'components.share-limit.inactive-seeding-time-limit' | translate"
+            formControlName="inactiveSeedingTimeLimit"
+            min="0"
+          />
+          <label for="inactiveSeedingTimeLimit">{{
+            'components.share-limit.inactive-seeding-time-limit' | translate
+          }}</label>
         </div>
       </div>
 

--- a/src/app/components/share-limit/share-limit.html
+++ b/src/app/components/share-limit/share-limit.html
@@ -20,14 +20,8 @@
         class="mt-2"
         [subject]="'components.share-limit.popover.ratio-limit.title' | translate"
         [description]="'components.share-limit.popover.ratio-limit.description' | translate"
-        placement="left"
+        placement="top"
       ></bb-popover>
-    </div>
-
-    <div class="col-12 mb-3">
-      <div class="form-text mt-1 ms-2">
-        {{ form.controls.ratioLimit.value ?? -1 | ratioLimit }}
-      </div>
     </div>
 
     <div class="col-5">
@@ -51,11 +45,17 @@
         class="mt-2"
         [subject]="'components.share-limit.popover.seeding-time-limit.title' | translate"
         [description]="'components.share-limit.popover.seeding-time-limit.description' | translate"
-        placement="left"
+        placement="top"
       ></bb-popover>
     </div>
 
-    <div class="col-12 mb-3">
+    <div class="col-6">
+      <div class="form-text mt-1 ms-2">
+        {{ form.controls.ratioLimit.value ?? -1 | ratioLimit }}
+      </div>
+    </div>
+
+    <div class="col-6 mb-3">
       <div class="form-text mt-1 ms-2">
         {{ form.controls.seedingTimeLimit.value ?? -1 | timeLimit }}
       </div>
@@ -85,7 +85,7 @@
           [description]="
             'components.share-limit.popover.inactive-seeding-time-limit.description' | translate
           "
-          placement="left"
+          placement="top"
         ></bb-popover>
       </div>
 

--- a/src/app/components/transfer-rate-limit/transfer-rate-limit.html
+++ b/src/app/components/transfer-rate-limit/transfer-rate-limit.html
@@ -23,7 +23,7 @@
         [description]="
           'components.transfer-rate-limit.popover.upload-limit.description' | translate
         "
-        placement="left"
+        placement="top"
       ></bb-popover>
     </div>
 
@@ -50,7 +50,7 @@
         [description]="
           'components.transfer-rate-limit.popover.download-limit.description' | translate
         "
-        placement="left"
+        placement="top"
       ></bb-popover>
     </div>
 

--- a/src/app/components/transfer-rate-limit/transfer-rate-limit.html
+++ b/src/app/components/transfer-rate-limit/transfer-rate-limit.html
@@ -1,0 +1,69 @@
+<div [formGroup]="form" class="container-fluid px-0">
+  <div class="row">
+    <div class="col-5">
+      <div class="form-floating">
+        <input
+          type="number"
+          class="form-control"
+          id="uploadLimit"
+          [placeholder]="'components.transfer-rate-limit.upload-limit' | translate"
+          formControlName="uploadLimit"
+          min="0"
+        />
+        <label for="uploadLimit">{{
+          'components.transfer-rate-limit.upload-limit' | translate
+        }}</label>
+      </div>
+    </div>
+
+    <div class="col-1 d-flex align-items-center">
+      <bb-popover
+        class="mt-2"
+        [subject]="'components.transfer-rate-limit.popover.upload-limit.title' | translate"
+        [description]="
+          'components.transfer-rate-limit.popover.upload-limit.description' | translate
+        "
+        placement="left"
+      ></bb-popover>
+    </div>
+
+    <div class="col-12 mb-3">
+      <div class="form-text mt-1 ms-2">
+        {{ (form.controls.uploadLimit.value ?? 0) * 1024 | speedLimit }}
+      </div>
+    </div>
+
+    <div class="col-5">
+      <div class="form-floating">
+        <input
+          type="number"
+          class="form-control"
+          id="downloadLimit"
+          [placeholder]="'components.transfer-rate-limit.download-limit' | translate"
+          formControlName="downloadLimit"
+          min="0"
+        />
+        <label for="downloadLimit">{{
+          'components.transfer-rate-limit.download-limit' | translate
+        }}</label>
+      </div>
+    </div>
+
+    <div class="col-1 d-flex align-items-center">
+      <bb-popover
+        class="mt-2"
+        [subject]="'components.transfer-rate-limit.popover.download-limit.title' | translate"
+        [description]="
+          'components.transfer-rate-limit.popover.download-limit.description' | translate
+        "
+        placement="left"
+      ></bb-popover>
+    </div>
+
+    <div class="col-12">
+      <div class="form-text mt-1 ms-2">
+        {{ (form.controls.downloadLimit.value ?? 0) * 1024 | speedLimit }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/transfer-rate-limit/transfer-rate-limit.html
+++ b/src/app/components/transfer-rate-limit/transfer-rate-limit.html
@@ -27,12 +27,6 @@
       ></bb-popover>
     </div>
 
-    <div class="col-12 mb-3">
-      <div class="form-text mt-1 ms-2">
-        {{ (form.controls.uploadLimit.value ?? 0) * 1024 | speedLimit }}
-      </div>
-    </div>
-
     <div class="col-5">
       <div class="form-floating">
         <input
@@ -60,7 +54,13 @@
       ></bb-popover>
     </div>
 
-    <div class="col-12">
+    <div class="col-6">
+      <div class="form-text mt-1 ms-2">
+        {{ (form.controls.uploadLimit.value ?? 0) * 1024 | speedLimit }}
+      </div>
+    </div>
+
+    <div class="col-6">
       <div class="form-text mt-1 ms-2">
         {{ (form.controls.downloadLimit.value ?? 0) * 1024 | speedLimit }}
       </div>

--- a/src/app/components/transfer-rate-limit/transfer-rate-limit.spec.ts
+++ b/src/app/components/transfer-rate-limit/transfer-rate-limit.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TransferRateLimit } from './transfer-rate-limit';
+
+describe('TransferRateLimit', () => {
+  let component: TransferRateLimit;
+  let fixture: ComponentFixture<TransferRateLimit>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TransferRateLimit],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TransferRateLimit);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/transfer-rate-limit/transfer-rate-limit.ts
+++ b/src/app/components/transfer-rate-limit/transfer-rate-limit.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, forwardRef, inject, OnInit } from '@angular/core';
 import {
   ControlValueAccessor,
   FormControl,
@@ -29,6 +29,8 @@ export type TransferRateLimitValue = {
   ],
 })
 export class TransferRateLimit implements ControlValueAccessor, OnInit {
+  private readonly cdr = inject(ChangeDetectorRef);
+
   public form = new FormGroup({
     uploadLimit: new FormControl<number | null>(null),
     downloadLimit: new FormControl<number | null>(null),
@@ -51,6 +53,7 @@ export class TransferRateLimit implements ControlValueAccessor, OnInit {
     this.form.patchValue(value ?? { uploadLimit: null, downloadLimit: null }, {
       emitEvent: false,
     });
+    this.cdr.markForCheck();
   }
 
   public registerOnChange(fn: (value: TransferRateLimitValue) => void): void {

--- a/src/app/components/transfer-rate-limit/transfer-rate-limit.ts
+++ b/src/app/components/transfer-rate-limit/transfer-rate-limit.ts
@@ -1,0 +1,71 @@
+import { Component, forwardRef, OnInit } from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormControl,
+  FormGroup,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { TranslatePipe } from '@ngx-translate/core';
+import { SpeedLimitPipe } from '../../pipes/speed-limit-pipe';
+import { BbPopover } from '../bb-popover/bb-popover';
+
+export type TransferRateLimitValue = {
+  uploadLimit: number | null; // KiB/s; null = no limit (unlimited)
+  downloadLimit: number | null; // KiB/s; null = no limit (unlimited)
+};
+
+@Component({
+  selector: 'app-transfer-rate-limit',
+  imports: [ReactiveFormsModule, TranslatePipe, BbPopover, SpeedLimitPipe],
+  templateUrl: './transfer-rate-limit.html',
+  styleUrl: './transfer-rate-limit.scss',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TransferRateLimit),
+      multi: true,
+    },
+  ],
+})
+export class TransferRateLimit implements ControlValueAccessor, OnInit {
+  public form = new FormGroup({
+    uploadLimit: new FormControl<number | null>(null),
+    downloadLimit: new FormControl<number | null>(null),
+  });
+
+  private onChange: (value: TransferRateLimitValue) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  public ngOnInit(): void {
+    this.form.valueChanges.subscribe((value) => {
+      this.onChange({
+        uploadLimit: value.uploadLimit ?? null,
+        downloadLimit: value.downloadLimit ?? null,
+      });
+      this.onTouched();
+    });
+  }
+
+  public writeValue(value: TransferRateLimitValue | null): void {
+    this.form.patchValue(value ?? { uploadLimit: null, downloadLimit: null }, {
+      emitEvent: false,
+    });
+  }
+
+  public registerOnChange(fn: (value: TransferRateLimitValue) => void): void {
+    this.onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    if (isDisabled) {
+      this.form.disable();
+    } else {
+      this.form.enable();
+    }
+  }
+}

--- a/src/app/models/add-torrent.model.ts
+++ b/src/app/models/add-torrent.model.ts
@@ -1,4 +1,5 @@
 import { ShareLimitValue } from '../components/share-limit/share-limit';
+import { TransferRateLimitValue } from '../components/transfer-rate-limit/transfer-rate-limit';
 
 export type RootFolderMode = 'unset' | 'true' | 'false';
 
@@ -12,8 +13,7 @@ export type AddTorrentSettings = {
   sequentialDownload: boolean;
   firstLastPiecePrio: boolean;
   autoTMM: boolean;
-  upLimitKbps: number | null;
-  dlLimitKbps: number | null;
+  transferRateLimits: TransferRateLimitValue | null;
   shareLimits: ShareLimitValue | null;
 };
 
@@ -27,7 +27,6 @@ export const DEFAULT_ADD_TORRENT_SETTINGS: AddTorrentSettings = {
   sequentialDownload: false,
   firstLastPiecePrio: false,
   autoTMM: false,
-  upLimitKbps: null,
-  dlLimitKbps: null,
+  transferRateLimits: null,
   shareLimits: null,
 };

--- a/src/app/models/command.model.ts
+++ b/src/app/models/command.model.ts
@@ -7,8 +7,6 @@ export type SelectedTorrentInput =
   | { name: string; path: string }
   | { name: string; bytes: number[] };
 
-export type LimitDirectionType = 'ul' | 'dl';
-
 export type LimitTargetType = 'global' | 'torrent';
 
 export type UiCommand =
@@ -20,7 +18,7 @@ export type UiCommand =
   | { type: 'UI_OPEN_ABOUT' }
   | { type: 'UI_SET_TORRENT_LOCATION'; torrent: Torrent }
   | { type: 'UI_RENAME_TORRENT'; torrent: Torrent }
-  | { type: 'UI_LIMIT_TRANSFER'; direction: LimitDirectionType; target: LimitTargetType }
+  | { type: 'UI_LIMIT_TRANSFER'; target: LimitTargetType }
   | { type: 'UI_LIMIT_SHARE' }
   | { type: 'UI_SET_TORRENT_TAGS'; torrent: Torrent }
   | { type: 'UI_SET_TORRENT_CATEGORY'; torrent: Torrent }

--- a/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { faSquare, faSquareCheck } from '@fortawesome/free-regular-svg-icons';
 import {
   faArrowDown,
+  faArrowDownUpAcrossLine,
   faArrowLeft,
   faArrowRight,
   faArrowsDownToLine,
@@ -260,7 +261,7 @@ export class GridContextMenuService {
             kind: 'item',
             id: 'speed.limitTransferRate',
             label: 'pages.main.grid.context-menu.item.limit-transfer-rate',
-            icon: faArrowsLeftRight,
+            icon: faArrowDownUpAcrossLine,
             action: () =>
               this.commandBusService.emit({
                 type: 'UI_LIMIT_TRANSFER',

--- a/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -12,7 +12,6 @@ import {
   faCheck,
   faCode,
   faCopy,
-  faDownload,
   faEye,
   faEyeSlash,
   faFilePen,
@@ -38,7 +37,6 @@ import {
   faThumbTack,
   faThumbTackSlash,
   faTrashCan,
-  faUpload,
   faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import type { ColDef, Column, ColumnHeaderContextMenuEvent } from 'ag-grid-community';
@@ -260,25 +258,12 @@ export class GridContextMenuService {
         children: [
           {
             kind: 'item',
-            id: 'speed.limitUpload',
-            label: 'pages.main.grid.context-menu.item.limit-upload-rate',
-            icon: faUpload,
+            id: 'speed.limitTransferRate',
+            label: 'pages.main.grid.context-menu.item.limit-transfer-rate',
+            icon: faArrowsLeftRight,
             action: () =>
               this.commandBusService.emit({
                 type: 'UI_LIMIT_TRANSFER',
-                direction: 'ul',
-                target: 'torrent',
-              }),
-          },
-          {
-            kind: 'item',
-            id: 'speed.limitDownload',
-            label: 'pages.main.grid.context-menu.item.limit-download-rate',
-            icon: faDownload,
-            action: () =>
-              this.commandBusService.emit({
-                type: 'UI_LIMIT_TRANSFER',
-                direction: 'dl',
                 target: 'torrent',
               }),
           },

--- a/src/app/pages/main/server-state/server-state.html
+++ b/src/app/pages/main/server-state/server-state.html
@@ -86,7 +86,7 @@
         [ngbTooltip]="tipLiveDl"
         placement="top"
         container="body"
-        (click)="setGlobalTransferLimit('dl')"
+        (click)="setGlobalTransferLimit()"
       >
         <fa-icon [icon]="icons.faDownload" class="icon-dl"></fa-icon>
         <div class="d-flex flex-column speed-limit-stack">
@@ -103,7 +103,7 @@
         [ngbTooltip]="tipLiveUl"
         placement="top"
         container="body"
-        (click)="setGlobalTransferLimit('ul')"
+        (click)="setGlobalTransferLimit()"
       >
         <fa-icon [icon]="icons.faUpload" class="icon-ul"></fa-icon>
         <div class="d-flex flex-column speed-limit-stack">

--- a/src/app/pages/main/server-state/server-state.ts
+++ b/src/app/pages/main/server-state/server-state.ts
@@ -27,7 +27,6 @@ import {
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { animationFrameScheduler, interval, map, switchMap } from 'rxjs';
-import { LimitDirectionType } from '../../../models/command.model';
 import { QbServerState } from '../../../models/torrent.model';
 import { FilesizePipe } from '../../../pipes/filesize-pipe';
 import { CommandBusService } from '../../../services/command-bus.service';
@@ -143,8 +142,8 @@ export class ServerState implements OnChanges {
     this.commandBusService.emit({ type: 'TRANSFER_LIMIT_ALTERNATIVE_TOGGLE' });
   }
 
-  public setGlobalTransferLimit(direction: LimitDirectionType): void {
-    this.commandBusService.emit({ type: 'UI_LIMIT_TRANSFER', target: 'global', direction });
+  public setGlobalTransferLimit(): void {
+    this.commandBusService.emit({ type: 'UI_LIMIT_TRANSFER', target: 'global' });
   }
 
   private reset(): void {

--- a/src/app/services/ui-command-handler.service.ts
+++ b/src/app/services/ui-command-handler.service.ts
@@ -147,6 +147,7 @@ export class UiCommandHandlerService {
             if (this.isModalOpen(LimitTransferRate)) break;
             const limitTransferModalRef = this.modalService.open(LimitTransferRate, {
               centered: true,
+              size: 'lg',
             });
 
             limitTransferModalRef.componentInstance.target = command.target;

--- a/src/app/services/ui-command-handler.service.ts
+++ b/src/app/services/ui-command-handler.service.ts
@@ -149,7 +149,6 @@ export class UiCommandHandlerService {
               centered: true,
             });
 
-            limitTransferModalRef.componentInstance.direction = command.direction;
             limitTransferModalRef.componentInstance.target = command.target;
 
             limitTransferModalRef.result.then((res: any) => {}).catch((error: any) => {});


### PR DESCRIPTION
## Issue ID

Fixes #45 

## Description

<img width="500" height="421" alt="image" src="https://github.com/user-attachments/assets/381267c2-4776-4b40-8af3-40e18f0b8689" />

<img width="867" height="383" alt="image" src="https://github.com/user-attachments/assets/e52a027b-72e8-4a4e-a1da-b51a798e9667" />

<img width="846" height="573" alt="image" src="https://github.com/user-attachments/assets/54491406-ad4c-4ea9-8783-68f71c05fa90" />

<img width="852" height="430" alt="image" src="https://github.com/user-attachments/assets/12db9ff7-6510-4f01-9909-2440ad515bd9" />

Transfer limit inputs got reorganized in a single reusable component. This component is rendered in a modal when context menu item clicked, and in add-torrent component.