### PR TITLE
Adding torrents via url and magnetlink

### DIFF
--- a/electron/ipc/qbittorrent.js
+++ b/electron/ipc/qbittorrent.js
@@ -29,7 +29,7 @@ const stmtGetByIdFull = db.prepare(`
 `);
 
 async function qbTorrentsAdd(payload) {
-  const { id, torrents, options } = payload;
+  const { id, torrents, urls, options } = payload;
 
   const fd = new FormData();
   let appended = 0;
@@ -47,7 +47,12 @@ async function qbTorrentsAdd(payload) {
     }
   }
 
-  if (!appended) throw new Error('No torrent attached to form-data.');
+  if (Array.isArray(urls) && urls.length > 0) {
+    fd.append('urls', urls.join('\n'));
+    appended++;
+  }
+
+  if (!appended) throw new Error('No torrent or URL attached to form-data.');
 
   for (const [k, v] of Object.entries(options ?? {})) {
     if (v === undefined || v === null) continue;

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -40,7 +40,7 @@
       "title": "Torrent hozzáadása",
       "add-form": {
         "file-browser": "Torrent fájl",
-        "magnet-links": "Mágnes linkek (soronként egy)",
+        "magnet-links": "URL-ek (soronként egy)",
         "save-path": "Mentési útvonal",
         "rename": "Átnevezés",
         "skip-hash-checking": "Hash-ellenőrzés kihagyása",
@@ -545,7 +545,7 @@
       "button-bar": {
         "button": {
           "add-file": "Fájl hozzáadása",
-          "add-link": "Link hozzáadása",
+          "add-link": "URL hozzáadása",
           "delete": "Törlés",
           "start": "Indítás",
           "stop": "Leállítás",

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -40,6 +40,7 @@
       "title": "Torrent hozzáadása",
       "add-form": {
         "file-browser": "Torrent fájl",
+        "magnet-links": "Mágnes linkek (soronként egy)",
         "save-path": "Mentési útvonal",
         "rename": "Átnevezés",
         "skip-hash-checking": "Hash-ellenőrzés kihagyása",
@@ -60,6 +61,7 @@
         "seeding-time-limit-unit": "perc"
       },
       "label": {
+        "input": "Bemenet",
         "general": "Általános",
         "settings": "Beállítások",
         "limits": "Korlátok",
@@ -970,7 +972,9 @@
       "update": "Frissítés",
       "show": "Megjelenítés",
       "open-details": "Részletek megnyitása",
-      "edit": "Szerkesztés"
+      "edit": "Szerkesztés",
+      "add-link": "Link hozzáadása",
+      "add-file": "Fájl hozzáadása"
     },
     "form": {
       "feedback": {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -40,7 +40,7 @@
       "title": "Torrent hozzáadása",
       "add-form": {
         "file-browser": "Torrent fájl",
-        "magnet-links": "URL-ek (soronként egy)",
+        "magnet-links": "Linkek (soronként egy)",
         "save-path": "Mentési útvonal",
         "rename": "Átnevezés",
         "skip-hash-checking": "Hash-ellenőrzés kihagyása",
@@ -545,7 +545,7 @@
       "button-bar": {
         "button": {
           "add-file": "Fájl hozzáadása",
-          "add-link": "URL hozzáadása",
+          "add-link": "Hozzáadás linkből",
           "delete": "Törlés",
           "start": "Indítás",
           "stop": "Leállítás",

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -545,6 +545,7 @@
       "button-bar": {
         "button": {
           "add-file": "Fájl hozzáadása",
+          "add-link": "Link hozzáadása",
           "delete": "Törlés",
           "start": "Indítás",
           "stop": "Leállítás",
@@ -972,9 +973,7 @@
       "update": "Frissítés",
       "show": "Megjelenítés",
       "open-details": "Részletek megnyitása",
-      "edit": "Szerkesztés",
-      "add-link": "Link hozzáadása",
-      "add-file": "Fájl hozzáadása"
+      "edit": "Szerkesztés"
     },
     "form": {
       "feedback": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -545,6 +545,7 @@
       "button-bar": {
         "button": {
           "add-file": "Add File",
+          "add-link": "Add Link",
           "delete": "Delete",
           "start": "Start",
           "stop": "Stop",
@@ -972,9 +973,7 @@
       "update": "Update",
       "show": "Show",
       "open-details": "Open Details",
-      "edit": "Edit",
-      "add-link": "Add Link",
-      "add-file": "Add File"
+      "edit": "Edit"
     },
     "form": {
       "feedback": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -40,7 +40,7 @@
       "title": "Adding a Torrent",
       "add-form": {
         "file-browser": "Torrent File",
-        "magnet-links": "Magnet Links (one per line)",
+        "magnet-links": "URLs (one per line)",
         "save-path": "Save Path",
         "rename": "Rename",
         "skip-hash-checking": "Skip hash checking",
@@ -545,7 +545,7 @@
       "button-bar": {
         "button": {
           "add-file": "Add File",
-          "add-link": "Add Link",
+          "add-link": "Add URL",
           "delete": "Delete",
           "start": "Start",
           "stop": "Stop",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -40,7 +40,7 @@
       "title": "Adding a Torrent",
       "add-form": {
         "file-browser": "Torrent File",
-        "magnet-links": "URLs (one per line)",
+        "magnet-links": "Links (one per line)",
         "save-path": "Save Path",
         "rename": "Rename",
         "skip-hash-checking": "Skip hash checking",
@@ -545,7 +545,7 @@
       "button-bar": {
         "button": {
           "add-file": "Add File",
-          "add-link": "Add URL",
+          "add-link": "Add from Link",
           "delete": "Delete",
           "start": "Start",
           "stop": "Stop",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -40,6 +40,7 @@
       "title": "Adding a Torrent",
       "add-form": {
         "file-browser": "Torrent File",
+        "magnet-links": "Magnet Links (one per line)",
         "save-path": "Save Path",
         "rename": "Rename",
         "skip-hash-checking": "Skip hash checking",
@@ -60,6 +61,7 @@
         "seeding-time-limit-unit": "minute"
       },
       "label": {
+        "input": "Input",
         "general": "General",
         "settings": "Settings",
         "limits": "Limits",
@@ -970,7 +972,9 @@
       "update": "Update",
       "show": "Show",
       "open-details": "Open Details",
-      "edit": "Edit"
+      "edit": "Edit",
+      "add-link": "Add Link",
+      "add-file": "Add File"
     },
     "form": {
       "feedback": {

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -15,41 +15,60 @@
 <div class="modal-body">
   <form [formGroup]="addForm" (submit)="handleSubmit($event)">
     <fieldset class="bb-fieldset mt-0">
-      <legend>{{ 'components.add-torrent.label.general' | translate }}</legend>
+      <legend>{{ 'components.add-torrent.label.input' | translate }}</legend>
 
-      <div class="form-floating mb-3">
-        <div class="input-group mb-1">
-          <div class="form-floating">
+      @if (inputMode() === 'file') {
+        <div class="form-floating mb-3">
+          <div class="input-group mb-1">
+            <div class="form-floating">
+              <input
+                type="text"
+                class="form-control"
+                id="file_browser"
+                [placeholder]="'components.add-torrent.add-form.file-browser' | translate"
+                formControlName="file"
+                [class.is-invalid]="
+                  addForm.controls.file.invalid &&
+                  (addForm.controls.file.touched || addForm.controls.file.dirty)
+                "
+                readonly
+                (click)="fileInput.click()"
+              />
+              <label for="file_browser">{{
+                'components.add-torrent.add-form.file-browser' | translate
+              }}</label>
+            </div>
+
+            <button type="button" class="btn btn-outline-primary" (click)="fileInput.click()">
+              {{ 'general.button.browse' | translate }}
+            </button>
             <input
-              type="text"
-              class="form-control"
-              id="file_browser"
-              [placeholder]="'components.add-torrent.add-form.file-browser' | translate"
-              formControlName="file"
-              [class.is-invalid]="
-                addForm.controls.file.invalid &&
-                (addForm.controls.file.touched || addForm.controls.file.dirty)
-              "
-              readonly
-              (click)="fileInput.click()"
+              type="file"
+              #fileInput
+              hidden
+              accept=".torrent"
+              (change)="handleFileSelected($event)"
             />
-            <label for="file_browser">{{
-              'components.add-torrent.add-form.file-browser' | translate
-            }}</label>
           </div>
-
-          <button type="button" class="btn btn-outline-primary" (click)="fileInput.click()">
-            {{ 'general.button.browse' | translate }}
-          </button>
-          <input
-            type="file"
-            #fileInput
-            hidden
-            accept=".torrent"
-            (change)="handleFileSelected($event)"
-          />
         </div>
-      </div>
+      } @else {
+        <div class="form-floating mb-1">
+          <textarea
+            class="form-control"
+            id="magnet_links"
+            style="height: 120px"
+            [placeholder]="'components.add-torrent.add-form.magnet-links' | translate"
+            formControlName="magnetLinks"
+          ></textarea>
+          <label for="magnet_links">{{
+            'components.add-torrent.add-form.magnet-links' | translate
+          }}</label>
+        </div>
+      }
+    </fieldset>
+
+    <fieldset class="bb-fieldset">
+      <legend>{{ 'components.add-torrent.label.general' | translate }}</legend>
 
       <div class="form-floating mb-3">
         <input
@@ -74,29 +93,31 @@
         }
       </div>
 
-      <div class="form-floating mb-3">
-        <input
-          type="text"
-          class="form-control"
-          id="rename"
-          [placeholder]="'components.add-torrent.add-form.rename' | translate"
-          formControlName="rename"
-          [class.is-invalid]="addForm.controls.rename.invalid && addForm.controls.rename.dirty"
-        />
-        <label for="rename">{{ 'components.add-torrent.add-form.rename' | translate }}</label>
-        @if (addForm.controls.rename.invalid && addForm.controls.rename.dirty) {
-          @if (addForm.controls.rename.hasError('noSlash')) {
-            <div class="invalid-feedback px-2">
-              {{ 'general.form.feedback.no-slash' | translate }}
-            </div>
+      @if (inputMode() === 'file') {
+        <div class="form-floating mb-3">
+          <input
+            type="text"
+            class="form-control"
+            id="rename"
+            [placeholder]="'components.add-torrent.add-form.rename' | translate"
+            formControlName="rename"
+            [class.is-invalid]="addForm.controls.rename.invalid && addForm.controls.rename.dirty"
+          />
+          <label for="rename">{{ 'components.add-torrent.add-form.rename' | translate }}</label>
+          @if (addForm.controls.rename.invalid && addForm.controls.rename.dirty) {
+            @if (addForm.controls.rename.hasError('noSlash')) {
+              <div class="invalid-feedback px-2">
+                {{ 'general.form.feedback.no-slash' | translate }}
+              </div>
+            }
+            @if (addForm.controls.rename.hasError('required')) {
+              <div class="invalid-feedback px-2">
+                {{ 'general.form.feedback.required' | translate }}
+              </div>
+            }
           }
-          @if (addForm.controls.rename.hasError('required')) {
-            <div class="invalid-feedback px-2">
-              {{ 'general.form.feedback.required' | translate }}
-            </div>
-          }
-        }
-      </div>
+        </div>
+      }
 
       <div class="mb-3">
         <app-category-select formControlName="category"></app-category-select>
@@ -288,6 +309,15 @@
   >
     {{ 'general.button.add' | translate }}
   </button>
+  @if (inputMode() === 'file') {
+    <button type="button" class="btn btn-outline-secondary" (click)="switchInputMode('link')">
+      {{ 'general.button.add-link' | translate }}
+    </button>
+  } @else {
+    <button type="button" class="btn btn-outline-secondary" (click)="switchInputMode('file')">
+      {{ 'general.button.add-file' | translate }}
+    </button>
+  }
   <button type="button" class="btn btn-link" (click)="handleCancel()">
     {{ 'general.button.cancel' | translate }}
   </button>

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -276,7 +276,12 @@
       </div>
     </fieldset>
 
-    @if (showTree() && effectiveDraft() && effectiveDraft().torrent?.files?.length) {
+    @if (
+      inputMode() === 'file' &&
+      showTree() &&
+      effectiveDraft() &&
+      effectiveDraft().torrent?.files?.length
+    ) {
       <fieldset class="bb-fieldset">
         <legend>{{ 'components.add-torrent.label.files' | translate }}</legend>
 

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -54,7 +54,7 @@
       } @else {
         <div class="form-floating mb-1">
           <textarea
-            class="form-control"
+            class="form-control mb-3"
             id="magnet_links"
             style="height: 120px"
             [placeholder]="'components.add-torrent.add-form.magnet-links' | translate"

--- a/src/app/components/add-torrent/add-torrent.html
+++ b/src/app/components/add-torrent/add-torrent.html
@@ -93,31 +93,29 @@
         }
       </div>
 
-      @if (inputMode() === 'file') {
-        <div class="form-floating mb-3">
-          <input
-            type="text"
-            class="form-control"
-            id="rename"
-            [placeholder]="'components.add-torrent.add-form.rename' | translate"
-            formControlName="rename"
-            [class.is-invalid]="addForm.controls.rename.invalid && addForm.controls.rename.dirty"
-          />
-          <label for="rename">{{ 'components.add-torrent.add-form.rename' | translate }}</label>
-          @if (addForm.controls.rename.invalid && addForm.controls.rename.dirty) {
-            @if (addForm.controls.rename.hasError('noSlash')) {
-              <div class="invalid-feedback px-2">
-                {{ 'general.form.feedback.no-slash' | translate }}
-              </div>
-            }
-            @if (addForm.controls.rename.hasError('required')) {
-              <div class="invalid-feedback px-2">
-                {{ 'general.form.feedback.required' | translate }}
-              </div>
-            }
+      <div class="form-floating mb-3">
+        <input
+          type="text"
+          class="form-control"
+          id="rename"
+          [placeholder]="'components.add-torrent.add-form.rename' | translate"
+          formControlName="rename"
+          [class.is-invalid]="addForm.controls.rename.invalid && addForm.controls.rename.dirty"
+        />
+        <label for="rename">{{ 'components.add-torrent.add-form.rename' | translate }}</label>
+        @if (addForm.controls.rename.invalid && addForm.controls.rename.dirty) {
+          @if (addForm.controls.rename.hasError('noSlash')) {
+            <div class="invalid-feedback px-2">
+              {{ 'general.form.feedback.no-slash' | translate }}
+            </div>
           }
-        </div>
-      }
+          @if (addForm.controls.rename.hasError('required')) {
+            <div class="invalid-feedback px-2">
+              {{ 'general.form.feedback.required' | translate }}
+            </div>
+          }
+        }
+      </div>
 
       <div class="mb-3">
         <app-category-select formControlName="category"></app-category-select>
@@ -309,15 +307,6 @@
   >
     {{ 'general.button.add' | translate }}
   </button>
-  @if (inputMode() === 'file') {
-    <button type="button" class="btn btn-outline-secondary" (click)="switchInputMode('link')">
-      {{ 'general.button.add-link' | translate }}
-    </button>
-  } @else {
-    <button type="button" class="btn btn-outline-secondary" (click)="switchInputMode('file')">
-      {{ 'general.button.add-file' | translate }}
-    </button>
-  }
   <button type="button" class="btn btn-link" (click)="handleCancel()">
     {{ 'general.button.cancel' | translate }}
   </button>

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -236,6 +236,7 @@ export class AddTorrent implements OnInit {
 
     const sharedOptions = {
       savepath: raw.savepath?.trim() || undefined,
+      rename: raw.rename?.trim() || undefined,
       category: raw.category?.trim() || undefined,
       tags: raw.tags?.join(',') || undefined,
       paused: raw.paused ? 'true' : 'false',
@@ -274,7 +275,7 @@ export class AddTorrent implements OnInit {
         await window.bitbutler.qb.torrentsAdd({
           id: serverId,
           torrents: [selectedFile],
-          options: { ...sharedOptions, rename: raw.rename?.trim() || undefined },
+          options: sharedOptions,
         });
 
         const state = this.savedFileState;

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -45,6 +45,7 @@ import { TransferLimit, TransferLimitValue } from '../transfer-limit/transfer-li
 
 type AddTorrentFormValue = {
   file: string;
+  magnetLinks: string;
   savepath: string | null;
   rename: string | null;
   paused: boolean;
@@ -102,6 +103,7 @@ export class AddTorrent implements OnInit {
 
   public manualDraft = signal<TorrentDraft | null>(null);
   public readonly searchSavePaths = this.typeaheadService.searchSavePaths;
+  public inputMode = signal<'file' | 'link'>('file');
   public showTree = signal(false);
   public treeInEditMode = signal(false);
   private savedFileState: FileTreeSaveEvent | null = null;
@@ -115,6 +117,7 @@ export class AddTorrent implements OnInit {
 
   public addForm = new FormGroup({
     file: new FormControl<string>('', { nonNullable: true }),
+    magnetLinks: new FormControl<string>('', { nonNullable: true }),
     savepath: new FormControl<string | null>(null, [Validators.required]),
     rename: new FormControl<string | null>(null, [Validators.required, this.noSlashValidator()]),
     paused: new FormControl<boolean>(false, { nonNullable: true }),
@@ -161,6 +164,8 @@ export class AddTorrent implements OnInit {
 
   constructor() {
     effect(() => {
+      if (this.inputMode() === 'link') return;
+
       const pending = this.pending();
       if (pending.length > this.initialQueueCount()) {
         this.initialQueueCount.set(pending.length);
@@ -220,9 +225,6 @@ export class AddTorrent implements OnInit {
 
     if (!this.canSubmit()) return;
 
-    const selectedFile = this.selectedTorrentFile();
-    if (!selectedFile) return;
-
     const serverId = this.serverStoreService.currentServerId();
 
     if (!serverId) {
@@ -232,47 +234,58 @@ export class AddTorrent implements OnInit {
 
     const raw = this.addForm.getRawValue() as AddTorrentFormValue;
 
-    const payload = {
-      id: serverId,
-      torrents: [selectedFile],
-      options: {
-        savepath: raw.savepath?.trim() || undefined,
-        rename: raw.rename?.trim() || undefined,
-        category: raw.category?.trim() || undefined,
-        tags: raw.tags?.join(',') || undefined,
-        paused: raw.paused ? 'true' : 'false',
-        skip_checking: raw.skip_checking ? 'true' : 'false',
-        sequentialDownload: raw.sequentialDownload ? 'true' : 'false',
-        firstLastPiecePrio: raw.firstLastPiecePrio ? 'true' : 'false',
-        autoTMM: raw.autoTMM ? 'true' : 'false',
-        root_folder: raw.root_folder === 'unset' ? undefined : raw.root_folder,
-        upLimit:
-          raw.transferRateLimits?.uploadLimit != null
-            ? String(Math.round(raw.transferRateLimits.uploadLimit * 1024))
-            : undefined,
-        dlLimit:
-          raw.transferRateLimits?.downloadLimit != null
-            ? String(Math.round(raw.transferRateLimits.downloadLimit * 1024))
-            : undefined,
-        ratioLimit:
-          raw.shareLimits?.ratioLimit != null ? String(raw.shareLimits.ratioLimit) : undefined,
-        seedingTimeLimit:
-          raw.shareLimits?.seedingTimeLimit != null
-            ? String(raw.shareLimits.seedingTimeLimit)
-            : undefined,
-      },
+    const sharedOptions = {
+      savepath: raw.savepath?.trim() || undefined,
+      category: raw.category?.trim() || undefined,
+      tags: raw.tags?.join(',') || undefined,
+      paused: raw.paused ? 'true' : 'false',
+      skip_checking: raw.skip_checking ? 'true' : 'false',
+      sequentialDownload: raw.sequentialDownload ? 'true' : 'false',
+      firstLastPiecePrio: raw.firstLastPiecePrio ? 'true' : 'false',
+      autoTMM: raw.autoTMM ? 'true' : 'false',
+      root_folder: raw.root_folder === 'unset' ? undefined : raw.root_folder,
+      upLimit:
+        raw.transferRateLimits?.uploadLimit != null
+          ? String(Math.round(raw.transferRateLimits.uploadLimit * 1024))
+          : undefined,
+      dlLimit:
+        raw.transferRateLimits?.downloadLimit != null
+          ? String(Math.round(raw.transferRateLimits.downloadLimit * 1024))
+          : undefined,
+      ratioLimit:
+        raw.shareLimits?.ratioLimit != null ? String(raw.shareLimits.ratioLimit) : undefined,
+      seedingTimeLimit:
+        raw.shareLimits?.seedingTimeLimit != null
+          ? String(raw.shareLimits.seedingTimeLimit)
+          : undefined,
     };
 
     this.isSubmitting.set(true);
     try {
-      await window.bitbutler.qb.torrentsAdd(payload);
-      const state = this.savedFileState;
-      const hasTreeCustomizations =
-        state != null &&
-        (state.renames.length > 0 || state.files.some((f) => (f.priority ?? 1) !== 1));
-      if (hasTreeCustomizations) {
-        await this.tryRenameContentAfterAdd(serverId);
+      if (this.inputMode() === 'link') {
+        await window.bitbutler.qb.torrentsAdd({
+          id: serverId,
+          urls: this.getMagnetLinks(),
+          torrents: [],
+          options: sharedOptions,
+        });
+      } else {
+        const selectedFile = this.selectedTorrentFile()!;
+        await window.bitbutler.qb.torrentsAdd({
+          id: serverId,
+          torrents: [selectedFile],
+          options: { ...sharedOptions, rename: raw.rename?.trim() || undefined },
+        });
+
+        const state = this.savedFileState;
+        const hasTreeCustomizations =
+          state != null &&
+          (state.renames.length > 0 || state.files.some((f) => (f.priority ?? 1) !== 1));
+        if (hasTreeCustomizations) {
+          await this.tryRenameContentAfterAdd(serverId);
+        }
       }
+
       await this.addTorrentSettings.save({
         savepath: raw.savepath,
         paused: raw.paused,
@@ -287,15 +300,18 @@ export class AddTorrent implements OnInit {
         shareLimits: raw.shareLimits,
       });
 
-      const originalPath = this.effectiveDraft()?.originalPath;
-      if (originalPath) {
-        const generalSettings = await this.generalSettingsService.load();
-        if (generalSettings.behavior.deleteTorrentFile) {
-          await window.bitbutler.torrent.deleteFile({ path: originalPath });
+      if (this.inputMode() === 'link') {
+        this.activeModal.close(true);
+      } else {
+        const originalPath = this.effectiveDraft()?.originalPath;
+        if (originalPath) {
+          const generalSettings = await this.generalSettingsService.load();
+          if (generalSettings.behavior.deleteTorrentFile) {
+            await window.bitbutler.torrent.deleteFile({ path: originalPath });
+          }
         }
+        this.openFilesService.consumeCurrentDraft();
       }
-
-      this.openFilesService.consumeCurrentDraft();
     } catch (e) {
       console.error(AddTorrent.name, 'handleSubmit', '[AddTorrent] qb add failed', e);
       this.addForm.setErrors({ addFailed: true });
@@ -305,12 +321,41 @@ export class AddTorrent implements OnInit {
   }
 
   public canSubmit(): boolean {
+    if (this.inputMode() === 'link') {
+      return (
+        !this.isSubmitting() &&
+        !this.treeInEditMode() &&
+        this.getMagnetLinks().length > 0 &&
+        this.addForm.valid
+      );
+    }
     return (
       this.addForm.valid &&
       !this.isSubmitting() &&
       this.selectedTorrentFile() !== null &&
       !this.treeInEditMode()
     );
+  }
+
+  public switchInputMode(mode: 'file' | 'link'): void {
+    this.inputMode.set(mode);
+    if (mode === 'link') {
+      this.selectedTorrentFile.set(null);
+      this.addForm.controls.file.disable();
+      this.addForm.controls.rename.disable();
+      this.showTree.set(false);
+    } else {
+      this.addForm.controls.magnetLinks.setValue('', { emitEvent: false });
+      this.addForm.controls.file.enable();
+      this.addForm.controls.rename.enable();
+    }
+  }
+
+  private getMagnetLinks(): string[] {
+    return (this.addForm.controls.magnetLinks.value ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
   }
 
   public async handleFileSelected(event: Event): Promise<void> {

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -342,12 +342,10 @@ export class AddTorrent implements OnInit {
     if (mode === 'link') {
       this.selectedTorrentFile.set(null);
       this.addForm.controls.file.disable();
-      this.addForm.controls.rename.disable();
       this.showTree.set(false);
     } else {
       this.addForm.controls.magnetLinks.setValue('', { emitEvent: false });
       this.addForm.controls.file.enable();
-      this.addForm.controls.rename.enable();
     }
   }
 

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -342,10 +342,14 @@ export class AddTorrent implements OnInit {
     if (mode === 'link') {
       this.selectedTorrentFile.set(null);
       this.addForm.controls.file.disable();
+      this.addForm.controls.rename.removeValidators(Validators.required);
+      this.addForm.controls.rename.updateValueAndValidity();
       this.showTree.set(false);
     } else {
       this.addForm.controls.magnetLinks.setValue('', { emitEvent: false });
       this.addForm.controls.file.enable();
+      this.addForm.controls.rename.addValidators(Validators.required);
+      this.addForm.controls.rename.updateValueAndValidity();
     }
   }
 

--- a/src/app/models/command.model.ts
+++ b/src/app/models/command.model.ts
@@ -14,7 +14,12 @@ export type UiCommand =
   | { type: 'UI_TORRENT_DELETE_REQUEST'; defaultRemoveFiles?: boolean }
   | { type: 'UI_OPEN_SETTINGS'; tabToOpen?: SettingsTabId }
   | { type: 'UI_OPEN_TORRENT_DETAILS'; hash: string }
-  | { type: 'UI_ADD_TORRENT'; draft?: TorrentDraft; selected?: SelectedTorrentInput }
+  | {
+      type: 'UI_ADD_TORRENT';
+      draft?: TorrentDraft;
+      selected?: SelectedTorrentInput;
+      mode?: 'file' | 'link';
+    }
   | { type: 'UI_OPEN_ABOUT' }
   | { type: 'UI_SET_TORRENT_LOCATION'; torrent: Torrent }
   | { type: 'UI_RENAME_TORRENT'; torrent: Torrent }

--- a/src/app/pages/main/button-bar/button-bar.ts
+++ b/src/app/pages/main/button-bar/button-bar.ts
@@ -19,6 +19,7 @@ import {
   faArrowsUpToLine,
   faFileArrowUp,
   faGear,
+  faLink,
   faPause,
   faPlay,
   faPlayCircle,
@@ -70,6 +71,13 @@ export class ButtonBar implements OnInit {
         id: 'new.addTorrentFile',
         label: 'pages.main.button-bar.button.add-file',
         icon: faFileArrowUp,
+        variant: 'primary',
+      },
+      {
+        kind: 'action',
+        id: 'new.addTorrentLink',
+        label: 'pages.main.button-bar.button.add-link',
+        icon: faLink,
         variant: 'primary',
       },
       { kind: 'divider' },
@@ -228,6 +236,9 @@ export class ButtonBar implements OnInit {
         break;
       case 'new.addTorrentFile':
         this.commandBusService.emit({ type: 'UI_ADD_TORRENT' });
+        break;
+      case 'new.addTorrentLink':
+        this.commandBusService.emit({ type: 'UI_ADD_TORRENT', mode: 'link' });
         break;
       case 'queue.moveTop':
         this.commandBusService.emit({ type: 'QUEUE_MOVE_TOP' });

--- a/src/app/pages/settings/general/general.ts
+++ b/src/app/pages/settings/general/general.ts
@@ -14,7 +14,7 @@ import {
   NgSelectComponent,
 } from '@ng-select/ng-select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { filter, firstValueFrom, from, tap } from 'rxjs';
+import { firstValueFrom, from, tap } from 'rxjs';
 import { BbPopover } from '../../../components/bb-popover/bb-popover';
 import { BbSpinner } from '../../../components/bb-spinner/bb-spinner';
 import { GeneralSettings, ToastPosition } from '../../../models/general-settings.model';
@@ -170,9 +170,7 @@ export class General implements SettingsTabComponent, OnInit {
     await this.generalSettingsService.save(settings);
 
     if (newLang !== currentLang) {
-      await firstValueFrom(
-        this.translateService.onLangChange.pipe(filter((event) => event.lang === newLang)),
-      );
+      await firstValueFrom(this.translateService.use(newLang));
     }
 
     this.themeService.applyFromSettings(settings.appearance.family, settings.appearance.mode);

--- a/src/app/services/ui-command-handler.service.ts
+++ b/src/app/services/ui-command-handler.service.ts
@@ -106,6 +106,10 @@ export class UiCommandHandlerService {
               keyboard: false,
             });
 
+            if (command.mode === 'link') {
+              addTorrentModalRef.componentInstance.switchInputMode('link');
+            }
+
             addTorrentModalRef.result.then(() => {}).catch(() => {});
             break;
 

--- a/src/bitbutler.d.ts
+++ b/src/bitbutler.d.ts
@@ -13,6 +13,7 @@ declare global {
   type BitButlerQbTorrentsAddPayload = {
     id: string;
     torrents: SelectedTorrentInput[];
+    urls?: string[];
     options?: Record<string, unknown>;
   };
 


### PR DESCRIPTION
## Issue ID

Fixes #56 

## Description

<img width="357" height="97" alt="image" src="https://github.com/user-attachments/assets/7c6b883d-826f-4684-91c3-3af3b4d1b7ef" />

A new button is added to the top button bar, now torrents can be added from url, or as magnet links.

<img width="846" height="443" alt="image" src="https://github.com/user-attachments/assets/7d00affd-1a87-4064-bf39-69082b887260" />

The first INPUT section is changing depending on the button the user pressed. For links, a new textarea is shown for links.

<img width="846" height="443" alt="image" src="https://github.com/user-attachments/assets/446c50fb-745a-430e-8c98-606ec79963ff" />

The old browse button for files.
