### PR TITLE
Tree View component tweaks

### DIFF
--- a/electron/torrents/parse-torrent.js
+++ b/electron/torrents/parse-torrent.js
@@ -10,9 +10,10 @@ export async function parseTorrentBufferToDraft(buffer, meta) {
     const parsed = await Promise.resolve(parseTorrent(buffer));
 
     const files = Array.isArray(parsed?.files)
-      ? parsed.files.map((f) => ({
+      ? parsed.files.map((f, i) => ({
           path: norm(f.path),
           length: Number(f.length ?? 0),
+          index: i,
         }))
       : [];
 

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -486,7 +486,7 @@ export class AddTorrent implements OnInit {
       const savedFiles = this.savedFileState?.files ?? null;
       if (savedFiles) {
         const nonDefault = savedFiles
-          .map((f, i) => ({ index: i, priority: f.priority ?? 1 }))
+          .map((f, i) => ({ index: f.index ?? i, priority: f.priority ?? 1 }))
           .filter((f) => f.priority !== 1);
         for (const f of nonDefault) {
           await this.qbService.setFilePriority(serverId, hash, [f.index], f.priority);

--- a/src/app/components/add-torrent/add-torrent.ts
+++ b/src/app/components/add-torrent/add-torrent.ts
@@ -485,11 +485,16 @@ export class AddTorrent implements OnInit {
 
       const savedFiles = this.savedFileState?.files ?? null;
       if (savedFiles) {
-        const nonDefault = savedFiles
-          .map((f, i) => ({ index: f.index ?? i, priority: f.priority ?? 1 }))
-          .filter((f) => f.priority !== 1);
-        for (const f of nonDefault) {
-          await this.qbService.setFilePriority(serverId, hash, [f.index], f.priority);
+        const nonDefault = savedFiles.filter((f) => (f.priority ?? 1) !== 1);
+        if (nonDefault.length > 0) {
+          const contents = await this.qbService.torrentContents(serverId, hash);
+          const pathToIndex = new Map(contents.map((c) => [c.name, c.index]));
+          for (const f of nonDefault) {
+            const index = pathToIndex.get(f.path);
+            if (index !== undefined) {
+              await this.qbService.setFilePriority(serverId, hash, [index], f.priority ?? 0);
+            }
+          }
         }
       }
     } catch (error) {

--- a/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/src/app/components/bb-file-tree/bb-file-tree.html
@@ -102,6 +102,7 @@
           [(ngModel)]="node.name"
           (click)="$event.stopPropagation()"
           (change)="onFolderNameChange(node)"
+          (keydown.enter)="onRenameEnter($event, node, 'folder')"
         />
 
         <div class="bb-meta">
@@ -159,7 +160,12 @@
           >{{ node.name }}</span
         >
       } @else {
-        <input class="bb-input" [(ngModel)]="node.name" (change)="onFileNameChange(node)" />
+        <input
+          class="bb-input"
+          [(ngModel)]="node.name"
+          (change)="onFileNameChange(node)"
+          (keydown.enter)="onRenameEnter($event, node, 'file')"
+        />
       }
 
       @if (showMeta && node.file; as f) {

--- a/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/src/app/components/bb-file-tree/bb-file-tree.html
@@ -103,6 +103,7 @@
           (click)="$event.stopPropagation()"
           (change)="onFolderNameChange(node)"
           (keydown.enter)="onRenameEnter($event, node, 'folder')"
+          (keydown.escape)="onEscapeInInput($event)"
         />
 
         <div class="bb-meta">
@@ -165,6 +166,7 @@
           [(ngModel)]="node.name"
           (change)="onFileNameChange(node)"
           (keydown.enter)="onRenameEnter($event, node, 'file')"
+          (keydown.escape)="onEscapeInInput($event)"
         />
       }
 

--- a/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -58,6 +58,7 @@ export class BbFileTree implements OnChanges {
   @Input({ required: true }) files: TorrentFileEntry[] = [];
   @Input() allowEdit = false;
   @Input() startInEditMode = false;
+  @Input() saveOnEnter = false;
   @Input() expandAll = false;
   @Input() showMeta = true;
   @Input() hideProgress = false;
@@ -257,6 +258,13 @@ export class BbFileTree implements OnChanges {
     const checked = (event.target as HTMLInputElement).checked;
     f.priority = checked ? 1 : 0;
     this.calculateStats();
+  }
+
+  onRenameEnter(event: KeyboardEvent, node: BbFileTreeNode, type: 'file' | 'folder'): void {
+    event.preventDefault();
+    if (type === 'file') this.onFileNameChange(node);
+    else this.onFolderNameChange(node);
+    if (this.saveOnEnter) this.saveEdit();
   }
 
   onFileNameChange(node: BbFileTreeNode): void {

--- a/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -142,6 +142,14 @@ export class BbFileTree implements OnChanges {
     }
   }
 
+  private resetNodeNamesFromPaths(nodes: BbFileTreeNode[]): void {
+    for (const node of nodes) {
+      const slashIdx = node.fullPath.lastIndexOf('/');
+      node.name = slashIdx >= 0 ? node.fullPath.slice(slashIdx + 1) : node.fullPath;
+      if (node.children) this.resetNodeNamesFromPaths(node.children);
+    }
+  }
+
   private updateNodeFiles(nodes: BbFileTreeNode[], fileMap: Map<string, TorrentFileEntry>): number {
     let count = 0;
     for (const node of nodes) {
@@ -168,6 +176,7 @@ export class BbFileTree implements OnChanges {
   }
 
   public cancelEdit(): void {
+    this.resetNodeNamesFromPaths(this.data);
     for (let i = 0; i < this.originalFiles.length && i < this.files.length; i++) {
       this.files[i].priority = this.originalFiles[i].priority;
     }

--- a/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -266,7 +266,7 @@ export class BbFileTree implements OnChanges {
     this.saveEdit();
   }
 
-  onEscapeInInput(event: KeyboardEvent): void {
+  onEscapeInInput(event: Event): void {
     event.stopPropagation();
     event.preventDefault();
     this.cancelEdit();

--- a/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -101,7 +101,8 @@ export class BbFileTree implements OnChanges {
 
   public icon = { faEdit, faCheck, faX };
 
-  trackByPath = (_index: number, node: BbFileTreeNode): string => node.fullPath;
+  trackByPath = (_index: number, node: BbFileTreeNode): string =>
+    `${this.editMode()}:${node.fullPath}`;
 
   ngOnChanges(): void {
     if (this.editMode()) return;
@@ -142,14 +143,6 @@ export class BbFileTree implements OnChanges {
     }
   }
 
-  private resetNodeNamesFromPaths(nodes: BbFileTreeNode[]): void {
-    for (const node of nodes) {
-      const slashIdx = node.fullPath.lastIndexOf('/');
-      node.name = slashIdx >= 0 ? node.fullPath.slice(slashIdx + 1) : node.fullPath;
-      if (node.children) this.resetNodeNamesFromPaths(node.children);
-    }
-  }
-
   private updateNodeFiles(nodes: BbFileTreeNode[], fileMap: Map<string, TorrentFileEntry>): number {
     let count = 0;
     for (const node of nodes) {
@@ -176,7 +169,6 @@ export class BbFileTree implements OnChanges {
   }
 
   public cancelEdit(): void {
-    this.resetNodeNamesFromPaths(this.data);
     for (let i = 0; i < this.originalFiles.length && i < this.files.length; i++) {
       this.files[i].priority = this.originalFiles[i].priority;
     }

--- a/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -58,7 +58,6 @@ export class BbFileTree implements OnChanges {
   @Input({ required: true }) files: TorrentFileEntry[] = [];
   @Input() allowEdit = false;
   @Input() startInEditMode = false;
-  @Input() saveOnEnter = false;
   @Input() expandAll = false;
   @Input() showMeta = true;
   @Input() hideProgress = false;
@@ -264,7 +263,13 @@ export class BbFileTree implements OnChanges {
     event.preventDefault();
     if (type === 'file') this.onFileNameChange(node);
     else this.onFolderNameChange(node);
-    if (this.saveOnEnter) this.saveEdit();
+    this.saveEdit();
+  }
+
+  onEscapeInInput(event: KeyboardEvent): void {
+    event.stopPropagation();
+    event.preventDefault();
+    this.cancelEdit();
   }
 
   onFileNameChange(node: BbFileTreeNode): void {

--- a/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -260,7 +260,7 @@ export class BbFileTree implements OnChanges {
     this.calculateStats();
   }
 
-  onRenameEnter(event: KeyboardEvent, node: BbFileTreeNode, type: 'file' | 'folder'): void {
+  onRenameEnter(event: Event, node: BbFileTreeNode, type: 'file' | 'folder'): void {
     event.preventDefault();
     if (type === 'file') this.onFileNameChange(node);
     else this.onFolderNameChange(node);

--- a/src/app/components/modals/torrent-details/content/content.html
+++ b/src/app/components/modals/torrent-details/content/content.html
@@ -12,7 +12,6 @@
     [showMeta]="true"
     [allowEdit]="true"
     [startInEditMode]="startInEditMode"
-    [saveOnEnter]="true"
     (saved)="onSaved($event)"
     (editModeChange)="onEditModeChange($event)"
   >

--- a/src/app/components/modals/torrent-details/content/content.html
+++ b/src/app/components/modals/torrent-details/content/content.html
@@ -12,6 +12,7 @@
     [showMeta]="true"
     [allowEdit]="true"
     [startInEditMode]="startInEditMode"
+    [saveOnEnter]="true"
     (saved)="onSaved($event)"
     (editModeChange)="onEditModeChange($event)"
   >


### PR DESCRIPTION
## Issue ID

Fixes #58 

## Description

Originally a bug ticket, but since the PR is already open, added a few tweaks as well:
 - skipping files and renaming them was having issues: wrong files got skipped, wrong files got renamed
 - now keypress event handlers are added to the tree view component itself. if the user is pressing:
    - enter: changes will be saved
    - escape: changes will be reverted

Then edit mode will turn off. When the tree view component is rendered in the add-torrent component, the file will not be added automatically, just the file changes will be saved. On escape the changes are reverted, edit mode is turned off.