### PR TITLE
Updating electron-hot script for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "serve": "npm run serve --workspace=packages/app",
     "electron-dev": "wait-on http://localhost:4200 && npm run build:electron && electron . --no-sandbox --disable-gpu-sandbox",
     "electron-ts:watch": "rimraf packages/electron/dist && wait-on http://localhost:4200 && npm run --silent watch --workspace=packages/electron",
-    "electron-hot": "wait-on http://localhost:4200 packages/electron/dist/main.js && nodemon --watch packages/electron/dist --ext js --delay 2 --exec 'electron . --no-sandbox --disable-gpu-sandbox'",
+    "electron-hot": "wait-on http://localhost:4200 packages/electron/dist/main.js && nodemon --watch packages/electron/dist --ext js --delay 2 --exec \"electron . --no-sandbox --disable-gpu-sandbox\"", 
     "start": "concurrently -n \"angular,tsc,electron\" -c \"cyan,yellow,green\" \"npm:serve\" \"npm:electron-ts:watch\" \"npm:electron-hot\"",
     "start:once": "concurrently -n \"angular,electron\" -c \"red,blue\" \"npm:serve\" \"npm:electron-dev\"",
     "workspace:clean": "rimraf dist-electron dist",


### PR DESCRIPTION
## Issue ID

Fixes #69 

## Description

Single quotes in the nodemon --exec argument work on bash but not on Windows cmd.exe, where they're treated as literal characters - making the command 'electron instead of electron. Replacing them with escaped double quotes (\") fixes this on Windows while remaining valid on Linux/Mac.