### PR TITLE
Fixed Windows CRLF line ending issues

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(git add *)"]
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Force LF line endings for all text files regardless of OS or git core.autocrlf setting
+* text=auto eol=lf
+
+# Explicitly binary files (no line ending conversion)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.bmp binary
+*.node binary
+*.exe binary
+*.dll binary

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "printWidth": 100,
     "singleQuote": true,
     "semi": true,
+    "endOfLine": "lf",
     "trailingComma": "all",
     "arrowParens": "always",
     "plugins": [


### PR DESCRIPTION
## Issue ID

Fixes #71 

## Description

Fixed Windows CRLF line ending issues by adding .gitattributes, endOfLine lf to Prettier, and end_of_line lf to .editorconfig.