### PR TITLE
Upgrading the ng-select component

### DIFF
--- a/packages/app/src/app/components/save-path-select/save-path-select.html
+++ b/packages/app/src/app/components/save-path-select/save-path-select.html
@@ -11,9 +11,12 @@
           [editableSearchTerm]="true"
           [formControl]="selectControl"
           [keyDownFn]="keyDownFn"
+          [markFirst]="true"
           [openOnEnter]="false"
           [placeholder]="defaultPath()"
           [fixedPlaceholder]="false"
+          (search)="resetHighlight()"
+          (open)="resetHighlight()"
           #ngselect
         >
         </ng-select>

--- a/packages/app/src/app/components/save-path-select/save-path-select.ts
+++ b/packages/app/src/app/components/save-path-select/save-path-select.ts
@@ -110,6 +110,10 @@ export class SavePathSelect implements OnInit, ControlValueAccessor, AfterViewIn
 
   addTag = (term: string): string => term;
 
+  public resetHighlight(): void {
+    this.ngselect.itemsList.unmarkItem();
+  }
+
   keyDownFn(event: KeyboardEvent): boolean {
     if (event.key === 'Escape') {
       return false;

--- a/packages/app/src/styles/_ng-select.scss
+++ b/packages/app/src/styles/_ng-select.scss
@@ -1,7 +1,27 @@
 .ng-select .ng-clear-wrapper {
   color: var(--bb-control-placeholder) !important;
-  &:hover .ng-clear {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 20px !important;
+  height: 20px !important;
+  border-radius: 50% !important;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease !important;
+
+  &:hover {
     color: var(--bs-danger) !important;
+    background-color: color-mix(in srgb, var(--bs-danger) 15%, transparent) !important;
+
+    .ng-clear {
+      color: inherit !important;
+    }
+  }
+
+  .ng-clear {
+    font-size: 18px !important;
+    line-height: 1 !important;
   }
 }
 


### PR DESCRIPTION
## Issue ID

Fixes #78 

## Description

Upgrades the `ng-select` component with two improvements:

**Typeahead-like navigation behavior (`SavePathSelect`)**
 - Marks the first item when the dropdown opens so keyboard navigation works immediately
 - Resets the highlighted item when the user types or reopens the dropdown, preventing stale highlights from a previous interaction
 - Binds (`search`) and (`open`) events to `resetHighlight()` which calls `itemsList.unmarkItem()` internally

**Clear button styling (`_ng-select.scss`)**
 - Restyled the clear (×) button to match the caret in color (`var(--bb-control-placeholder)`) and visual weight (18px, 20×20px wrapper)
 - Added a circular hover state with a subtle danger-tinted background for clear affordance
 - Smooth 120ms transitions for color and background consistent with the rest of the control