### PR TITLE
File-tree component refactor and bugfix

### DIFF
--- a/docs/superpowers/plans/2026-05-13-file-tree-rename-fix.md
+++ b/docs/superpowers/plans/2026-05-13-file-tree-rename-fix.md
@@ -1,0 +1,763 @@
+# File Tree Rename Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix multi-session rename corruption in the `bb-file-tree` component so that renames emitted in `FileTreeSaveEvent` are always relative to the genesis file paths, making the component work correctly in both `add-torrent` and `content.ts` contexts.
+
+**Architecture:** Remove the incremental `renameQueue` and instead compute the complete effective rename set in `saveEdit()` by comparing each leaf node's `node.file.path` (genesis, never mutated) against the path reconstructed by `flatten()` (current, from `node.name`). Add a `sessionDirty` flag to guard `cancelEdit()` with a confirm dialog.
+
+**Tech Stack:** Angular 20 (zoneless, signal-based), `@ng-bootstrap/ng-bootstrap` modal/confirm, `@ngx-translate/core`, Vitest via `ng test`.
+
+---
+
+## File Map
+
+| File                                                                             | Change                                                                                                                              |
+| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/app/src/app/components/bb-file-tree/bb-file-tree.ts`                   | Remove `renameQueue`; add `collectRenames`; update `saveEdit`; add `sessionDirty`; inject `ConfirmService`; make `cancelEdit` async |
+| `packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts`              | Add tests for multi-session rename, `sessionDirty`, and cancel confirm guard; update existing `cancelEdit` tests to `await`         |
+| `packages/app/src/app/components/add-torrent/add-torrent.ts`                     | Remove folder rename branch in `tryRenameContentAfterAdd`                                                                           |
+| `packages/app/src/app/components/modals/torrent-details/content/content.ts`      | Remove folder rename branch in `onSaved`                                                                                            |
+| `packages/app/src/app/components/modals/torrent-details/content/content.spec.ts` | Remove mock for `renameTorrentFolder`                                                                                               |
+| `public/i18n/us.json`                                                            | Add `components.bb-file-tree.confirm.cancel.{title,message}`                                                                        |
+| `public/i18n/hu.json`                                                            | Add `components.bb-file-tree.confirm.cancel.{title,message}`                                                                        |
+
+---
+
+## Task 1: Update `FileTreeSaveEvent` — remove `type` from renames
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.ts:33-36`
+- Modify: `packages/app/src/app/components/add-torrent/add-torrent.ts:463-470`
+- Modify: `packages/app/src/app/components/modals/torrent-details/content/content.ts:88-96`
+
+- [ ] **Step 1: Update the `FileTreeSaveEvent` type**
+
+In `bb-file-tree.ts`, replace lines 33–36:
+
+```typescript
+export type FileTreeSaveEvent = {
+  files: TorrentFileEntry[];
+  renames: { oldPath: string; newPath: string }[];
+};
+```
+
+- [ ] **Step 2: Fix `add-torrent.ts` — remove folder rename branch**
+
+In `tryRenameContentAfterAdd`, replace the entire `for` loop over renames (currently lines 465–470):
+
+```typescript
+for (const item of this.savedFileState?.renames ?? []) {
+  await this.qbService.renameTorrentFile(serverId, hash, item.oldPath, item.newPath);
+}
+```
+
+- [ ] **Step 3: Fix `content.ts` — remove folder rename branch**
+
+In `onSaved`, replace the entire `for` loop over renames (currently lines 88–96):
+
+```typescript
+for (const item of event.renames) {
+  await this.qbService.renameTorrentFile(serverId, this.hash, item.oldPath, item.newPath);
+}
+```
+
+- [ ] **Step 4: Fix `content.spec.ts` — remove `renameTorrentFolder` from mock**
+
+In `content.spec.ts`, remove `renameTorrentFolder: vi.fn()` from the `QbService` mock. The mock becomes:
+
+```typescript
+{
+  provide: QbService,
+  useValue: {
+    torrentContents: vi.fn().mockResolvedValue([]),
+    renameTorrentFile: vi.fn(),
+    setFilePriority: vi.fn(),
+  },
+},
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: `Test Files  105 passed`, `Tests  1005 passed` (or close — existing tests don't assert on `type` in rename events).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/app/components/bb-file-tree/bb-file-tree.ts \
+        packages/app/src/app/components/add-torrent/add-torrent.ts \
+        packages/app/src/app/components/modals/torrent-details/content/content.ts \
+        packages/app/src/app/components/modals/torrent-details/content/content.spec.ts
+git commit -m "$(cat <<'EOF'
+#80: remove type distinction from FileTreeSaveEvent renames
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Write failing tests for multi-session rename fix
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts`
+
+- [ ] **Step 1: Add a new `describe` block for `saveEdit renames` with four failing tests**
+
+Add the following block after the existing `enterEditMode / cancelEdit / saveEdit` describe block in `bb-file-tree.spec.ts`:
+
+```typescript
+describe('saveEdit renames', () => {
+  beforeEach(() => {
+    component.files = [makeFile('dir/a.txt'), makeFile('dir/b.txt')];
+    component.ngOnChanges();
+  });
+
+  it('should emit empty renames when no files were renamed', () => {
+    component.enterEditMode();
+    const spy = vi.fn();
+    component.saved.subscribe(spy);
+    component.saveEdit();
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ renames: [] }));
+  });
+
+  it('should emit genesis-to-current rename when a file is renamed', () => {
+    component.enterEditMode();
+    const fileNode = component.data[0].children![0]; // dir/a.txt
+    fileNode.name = 'z.txt';
+    component.onFileNameChange(fileNode);
+
+    const spy = vi.fn();
+    component.saved.subscribe(spy);
+    component.saveEdit();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renames: [{ oldPath: 'dir/a.txt', newPath: 'dir/z.txt' }],
+      }),
+    );
+  });
+
+  it('should emit correct rename after two edit sessions (multi-session bug)', () => {
+    component.files = [makeFile('a.txt')];
+    component.ngOnChanges();
+
+    // Session 1: a.txt → xxx.txt
+    component.enterEditMode();
+    const node = component.data[0];
+    node.name = 'xxx.txt';
+    component.onFileNameChange(node);
+    component.saveEdit();
+
+    // Session 2: xxx.txt → yyy.txt
+    component.enterEditMode();
+    node.name = 'yyy.txt';
+    component.onFileNameChange(node);
+
+    const spy = vi.fn();
+    component.saved.subscribe(spy);
+    component.saveEdit();
+
+    // Must emit genesis (a.txt) → current (yyy.txt), not stale (xxx.txt) → current
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renames: [{ oldPath: 'a.txt', newPath: 'yyy.txt' }],
+      }),
+    );
+  });
+
+  it('should emit one rename per file when a folder is renamed', () => {
+    component.enterEditMode();
+    const folderNode = component.data[0]; // dir
+    folderNode.name = 'newdir';
+    component.onFolderNameChange(folderNode);
+
+    const spy = vi.fn();
+    component.saved.subscribe(spy);
+    component.saveEdit();
+
+    const event = spy.mock.calls[0][0] as FileTreeSaveEvent;
+    expect(event.renames).toHaveLength(2);
+    expect(event.renames).toEqual(
+      expect.arrayContaining([
+        { oldPath: 'dir/a.txt', newPath: 'newdir/a.txt' },
+        { oldPath: 'dir/b.txt', newPath: 'newdir/b.txt' },
+      ]),
+    );
+  });
+});
+```
+
+Also add `FileTreeSaveEvent` to the import at the top of the spec file:
+
+```typescript
+import { BbFileTree, BbFileTreeNode, FileTreeSaveEvent } from './bb-file-tree';
+```
+
+- [ ] **Step 2: Run tests — expect the four new tests to fail**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: the four new `saveEdit renames` tests fail. The multi-session test fails because `renameQueue` still emits `xxx.txt → yyy.txt` instead of `a.txt → yyy.txt`. The folder test fails because `renameQueue` emits a folder rename, not per-file entries.
+
+---
+
+## Task 3: Implement `collectRenames`, update `saveEdit`, remove `renameQueue`
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.ts`
+
+- [ ] **Step 1: Remove the `renameQueue` field**
+
+Delete this line (currently around line 72):
+
+```typescript
+private renameQueue: { type: 'file' | 'folder'; oldPath: string; newPath: string }[] = [];
+```
+
+- [ ] **Step 2: Add `collectRenames` private method**
+
+Add this method after `flatten` (currently around line 322):
+
+```typescript
+private collectRenames(
+  nodes: BbFileTreeNode[],
+  parentPath: string,
+): { oldPath: string; newPath: string }[] {
+  const result: { oldPath: string; newPath: string }[] = [];
+  for (const node of nodes) {
+    const currentPath = parentPath ? `${parentPath}/${node.name}` : node.name;
+    if (node.kind === 'file' && node.file) {
+      const genesisPath = normalizePath(node.file.path);
+      if (genesisPath !== currentPath) {
+        result.push({ oldPath: genesisPath, newPath: currentPath });
+      }
+    }
+    if (node.children) result.push(...this.collectRenames(node.children, currentPath));
+  }
+  return result;
+}
+```
+
+- [ ] **Step 3: Update `saveEdit` to use `collectRenames`**
+
+Replace the existing `saveEdit` method body:
+
+```typescript
+public saveEdit(): void {
+  const files = this.flatten(this.data, '');
+  const renames = this.collectRenames(this.data, '');
+  this.saved.emit({ files, renames });
+  this.originalFiles = [];
+  this.folderPriorityMemory.clear();
+  this.editMode.set(false);
+  this.editModeChange.emit(false);
+}
+```
+
+- [ ] **Step 4: Remove queue pushes from `onFileNameChange` and `onFolderNameChange`**
+
+Replace `onFileNameChange`:
+
+```typescript
+onFileNameChange(node: BbFileTreeNode): void {
+  const { oldPath, newPath } = this.deriveRenamePayload(node);
+  if (oldPath === newPath) return;
+  node.fullPath = newPath;
+}
+```
+
+Replace `onFolderNameChange`:
+
+```typescript
+onFolderNameChange(node: BbFileTreeNode): void {
+  const { oldPath, newPath } = this.deriveRenamePayload(node);
+  if (oldPath === newPath) return;
+  node.fullPath = newPath;
+  this.updateChildPaths(node.children ?? [], oldPath, newPath);
+}
+```
+
+- [ ] **Step 5: Remove `renameQueue` references from `enterEditMode` and `cancelEdit`**
+
+In `enterEditMode`, remove:
+
+```typescript
+this.renameQueue = [];
+```
+
+In `cancelEdit`, remove:
+
+```typescript
+this.renameQueue = [];
+```
+
+- [ ] **Step 6: Run tests — expect all tests to pass**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: `105 passed`, `1009 passed` (1005 original + 4 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/app/src/app/components/bb-file-tree/bb-file-tree.ts \
+        packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+git commit -m "$(cat <<'EOF'
+#80: fix multi-session rename by computing renames from genesis paths
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `sessionDirty` flag and write tests for it
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.ts`
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts`
+
+- [ ] **Step 1: Write failing tests for `sessionDirty`**
+
+Add the following `describe` block to `bb-file-tree.spec.ts`, after the `saveEdit renames` block:
+
+```typescript
+describe('sessionDirty', () => {
+  beforeEach(() => {
+    component.files = [makeFile('dir/a.txt'), makeFile('dir/b.txt')];
+    component.ngOnChanges();
+    component.enterEditMode();
+  });
+
+  it('should be false after enterEditMode', () => {
+    expect((component as any).sessionDirty).toBe(false);
+  });
+
+  it('should be true after onFileNameChange', () => {
+    const fileNode = component.data[0].children![0];
+    fileNode.name = 'z.txt';
+    component.onFileNameChange(fileNode);
+    expect((component as any).sessionDirty).toBe(true);
+  });
+
+  it('should be true after onFolderNameChange', () => {
+    const folderNode = component.data[0];
+    folderNode.name = 'other';
+    component.onFolderNameChange(folderNode);
+    expect((component as any).sessionDirty).toBe(true);
+  });
+
+  it('should be true after toggleFileSelection', () => {
+    const fileNode = component.data[0].children![0];
+    const event = { target: { checked: false } } as unknown as Event;
+    component.toggleFileSelection(fileNode.file!, event);
+    expect((component as any).sessionDirty).toBe(true);
+  });
+
+  it('should be true after toggleFolderSelection', () => {
+    const folderNode = component.data[0];
+    const event = { target: { checked: false } } as unknown as Event;
+    component.toggleFolderSelection(folderNode, event);
+    expect((component as any).sessionDirty).toBe(true);
+  });
+
+  it('should be true after setFolderPriority', () => {
+    component.setFolderPriority(component.data[0], 6);
+    expect((component as any).sessionDirty).toBe(true);
+  });
+
+  it('should reset to false on the next enterEditMode', () => {
+    const fileNode = component.data[0].children![0];
+    fileNode.name = 'z.txt';
+    component.onFileNameChange(fileNode);
+    expect((component as any).sessionDirty).toBe(true);
+
+    component.saveEdit();
+    component.enterEditMode();
+    expect((component as any).sessionDirty).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect the new block to fail**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: new `sessionDirty` tests fail (`sessionDirty` is not defined on the component).
+
+- [ ] **Step 3: Add `sessionDirty` field and wire it up**
+
+In `bb-file-tree.ts`, add the field next to `autoEditTriggered`:
+
+```typescript
+private sessionDirty = false;
+```
+
+In `enterEditMode()`, reset it:
+
+```typescript
+public enterEditMode(): void {
+  this.sessionDirty = false;
+  this.originalFiles = structuredClone(this.files);
+  this.folderPriorityMemory.clear();
+  this.editMode.set(true);
+  this.editModeChange.emit(true);
+}
+```
+
+Add `this.sessionDirty = true;` as the last line of each change handler:
+
+```typescript
+onFileNameChange(node: BbFileTreeNode): void {
+  const { oldPath, newPath } = this.deriveRenamePayload(node);
+  if (oldPath === newPath) return;
+  node.fullPath = newPath;
+  this.sessionDirty = true;
+}
+
+onFolderNameChange(node: BbFileTreeNode): void {
+  const { oldPath, newPath } = this.deriveRenamePayload(node);
+  if (oldPath === newPath) return;
+  node.fullPath = newPath;
+  this.updateChildPaths(node.children ?? [], oldPath, newPath);
+  this.sessionDirty = true;
+}
+
+toggleFolderSelection(node: BbFileTreeNode, event: Event): void {
+  const checked = (event.target as HTMLInputElement).checked;
+  if (checked) {
+    const restored = this.folderPriorityMemory.get(node.fullPath) ?? 1;
+    this.updateRecursive(node, (f) => (f.priority = restored));
+  } else {
+    this.folderPriorityMemory.set(node.fullPath, this.getDominantFolderPriority(node));
+    this.updateRecursive(node, (f) => (f.priority = 0));
+  }
+  this.sessionDirty = true;
+  this.calculateStats();
+}
+
+setFolderPriority(node: BbFileTreeNode, priority: number): void {
+  this.updateRecursive(node, (f) => {
+    if (f.priority !== 0) f.priority = priority;
+  });
+  this.sessionDirty = true;
+  this.calculateStats();
+}
+
+toggleFileSelection(f: TorrentFileEntry, event: Event): void {
+  const checked = (event.target as HTMLInputElement).checked;
+  f.priority = checked ? 1 : 0;
+  this.sessionDirty = true;
+  this.calculateStats();
+}
+```
+
+- [ ] **Step 4: Run tests — expect all to pass**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/app/components/bb-file-tree/bb-file-tree.ts \
+        packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+git commit -m "$(cat <<'EOF'
+#80: track sessionDirty flag across edit-mode change handlers
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add i18n keys for the cancel confirm dialog
+
+**Files:**
+
+- Modify: `public/i18n/us.json`
+- Modify: `public/i18n/hu.json`
+
+- [ ] **Step 1: Add English keys to `us.json`**
+
+In `public/i18n/us.json`, inside `components.bb-file-tree`, add a `confirm` key after `priority-option`:
+
+```json
+"confirm": {
+  "cancel": {
+    "title": "Discard changes",
+    "message": "You have unsaved changes. Are you sure you want to discard them?"
+  }
+}
+```
+
+The `bb-file-tree` object should look like:
+
+```json
+"bb-file-tree": {
+  "stats": {
+    "folders": "folders",
+    "of": "of",
+    "files": "files"
+  },
+  "priority-option": {
+    "skipped": "Skipped",
+    "normal": "Normal",
+    "high": "High",
+    "max": "Max"
+  },
+  "confirm": {
+    "cancel": {
+      "title": "Discard changes",
+      "message": "You have unsaved changes. Are you sure you want to discard them?"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Add Hungarian keys to `hu.json`**
+
+In `public/i18n/hu.json`, add the same structure:
+
+```json
+"confirm": {
+  "cancel": {
+    "title": "Változtatások elvetése",
+    "message": "Nem mentett változtatásaid vannak. Biztosan elveted őket?"
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add public/i18n/us.json public/i18n/hu.json
+git commit -m "$(cat <<'EOF'
+#80: add i18n keys for file-tree cancel confirm dialog
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add cancel confirm guard to `cancelEdit()`
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.ts`
+- Modify: `packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts`
+
+- [ ] **Step 1: Write failing tests for the cancel confirm guard**
+
+First add `ConfirmService` to the import at the very top of `bb-file-tree.spec.ts` (with the other imports):
+
+```typescript
+import { ConfirmService } from '../../services/confirm.service';
+```
+
+Then update the `TestBed` setup to add a `ConfirmService` mock. Declare the mock variable at the top of `describe('BbFileTree')` and wire it into `providers`:
+
+```typescript
+// At the top of describe('BbFileTree'):
+let mockConfirmService: { confirm: ReturnType<typeof vi.fn> };
+
+beforeEach(async () => {
+  mockConfirmService = { confirm: vi.fn().mockResolvedValue(true) };
+
+  await TestBed.configureTestingModule({
+    imports: [BbFileTree],
+    providers: [{ provide: ConfirmService, useValue: mockConfirmService }],
+  }).compileComponents();
+
+  fixture = TestBed.createComponent(BbFileTree);
+  component = fixture.componentInstance;
+  component.files = [];
+  fixture.detectChanges();
+});
+```
+
+Then update the two existing `cancelEdit` tests that need to be awaited (they will start failing because `cancelEdit` is not yet async):
+
+```typescript
+it('should set editMode to false on cancelEdit', async () => {
+  component.enterEditMode();
+  await component.cancelEdit();
+  expect(component.editMode()).toBe(false);
+});
+
+it('should emit editModeChange(false) on cancelEdit', async () => {
+  component.enterEditMode();
+  const spy = vi.fn();
+  component.editModeChange.subscribe(spy);
+  await component.cancelEdit();
+  expect(spy).toHaveBeenCalledWith(false);
+});
+```
+
+Then add a new describe block for the confirm guard:
+
+```typescript
+describe('cancelEdit confirm guard', () => {
+  beforeEach(() => {
+    component.files = [makeFile('a.txt')];
+    component.ngOnChanges();
+    component.enterEditMode();
+  });
+
+  it('should skip confirm and cancel immediately when session is not dirty', async () => {
+    await component.cancelEdit();
+    expect(mockConfirmService.confirm).not.toHaveBeenCalled();
+    expect(component.editMode()).toBe(false);
+  });
+
+  it('should show confirm when session is dirty', async () => {
+    const node = component.data[0];
+    node.name = 'z.txt';
+    component.onFileNameChange(node);
+
+    mockConfirmService.confirm.mockResolvedValue(true);
+    await component.cancelEdit();
+
+    expect(mockConfirmService.confirm).toHaveBeenCalledWith(
+      'components.bb-file-tree.confirm.cancel.title',
+      'components.bb-file-tree.confirm.cancel.message',
+    );
+    expect(component.editMode()).toBe(false);
+  });
+
+  it('should not cancel when user declines the confirm', async () => {
+    const node = component.data[0];
+    node.name = 'z.txt';
+    component.onFileNameChange(node);
+
+    mockConfirmService.confirm.mockResolvedValue(false);
+    await component.cancelEdit();
+
+    expect(component.editMode()).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect new tests to fail**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: the two updated `cancelEdit` tests and the three new `cancelEdit confirm guard` tests fail because `cancelEdit` is still synchronous and `ConfirmService` is not injected.
+
+- [ ] **Step 3: Inject `ConfirmService` and make `cancelEdit` async**
+
+In `bb-file-tree.ts`, add `ConfirmService` to imports and inject it:
+
+```typescript
+import { ConfirmService } from '../../services/confirm.service';
+```
+
+Add to the class fields (alongside other `inject` calls):
+
+```typescript
+private readonly confirmService = inject(ConfirmService);
+```
+
+Replace `cancelEdit` with the async version:
+
+```typescript
+public async cancelEdit(): Promise<void> {
+  if (this.sessionDirty) {
+    const confirmed = await this.confirmService.confirm(
+      'components.bb-file-tree.confirm.cancel.title',
+      'components.bb-file-tree.confirm.cancel.message',
+    );
+    if (!confirmed) return;
+  }
+  for (let i = 0; i < this.originalFiles.length && i < this.files.length; i++) {
+    this.files[i].priority = this.originalFiles[i].priority;
+  }
+  const expandedPaths = new Set<string>();
+  this.treeControl.expansionModel.selected.forEach((n) => expandedPaths.add(n.fullPath));
+  const result = buildTree(this.files);
+  this.data = result.nodes;
+  this.totalFiles.set(this.files.length);
+  this.calculateStats();
+  if (this.expandAll) this.expandAllNodes();
+  else this.restoreExpansionState(this.data, expandedPaths);
+  this.originalFiles = [];
+  this.folderPriorityMemory.clear();
+  this.sessionDirty = false;
+  this.editMode.set(false);
+  this.editModeChange.emit(false);
+}
+```
+
+- [ ] **Step 4: Run tests — expect all to pass**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/app/components/bb-file-tree/bb-file-tree.ts \
+        packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+git commit -m "$(cat <<'EOF'
+#80: add confirm guard to cancelEdit when session has unsaved changes
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Run lint and verify everything is clean
+
+- [ ] **Step 1: Run lint**
+
+```bash
+cd /home/enisz/dev/bitbutler && npm run lint
+```
+
+Expected: no warnings or errors. If there are any, fix them (likely unused import or `item.type` reference remaining somewhere).
+
+- [ ] **Step 2: Run the full test suite one final time**
+
+```bash
+cd /home/enisz/dev/bitbutler/packages/app && npx ng test --watch=false
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run electron tests**
+
+```bash
+cd /home/enisz/dev/bitbutler && npm test
+```
+
+Expected: all 166 electron tests pass.

--- a/docs/superpowers/specs/2026-05-13-file-tree-rename-design.md
+++ b/docs/superpowers/specs/2026-05-13-file-tree-rename-design.md
@@ -1,0 +1,170 @@
+# File Tree Rename Fix — Design Spec
+
+**Date:** 2026-05-13
+**Branch:** 80-file-tree-component-refactor
+**Issue:** Multi-session rename bug in `add-torrent` modal; cancel has no unsaved-changes guard.
+
+---
+
+## Problem
+
+### Bug: multi-session rename chain breaks in `add-torrent`
+
+`bb-file-tree` tracks renames via `renameQueue` — an array of incremental `{oldPath, newPath}` pairs accumulated during a single edit session. On `saveEdit()` the queue is emitted and cleared.
+
+`add-torrent.ts` stores the latest save event in `savedFileState`, replacing it on each save:
+
+```typescript
+public onTreeSaved(event: FileTreeSaveEvent): void {
+  this.savedFileState = event;  // overwrites previous session's renames
+}
+```
+
+When the user edits and saves twice before submitting:
+
+- Session 1: renames `original → xxx`; `savedFileState = {renames: [{old: original, new: xxx}]}`
+- Session 2: `node.fullPath` is still `xxx` from session 1. Rename produces `{old: xxx, new: yyy}`. `savedFileState` is overwritten: `{renames: [{old: xxx, new: yyy}]}`
+- Submit: tries to rename `xxx → yyy` in qBittorrent, but qBittorrent has `original` → **error**
+
+### Why `content.ts` is unaffected
+
+In `content.ts`, saves are applied immediately to qBittorrent. After each save, the polling loop refreshes `content()`, which flows into `[files]` and triggers `ngOnChanges`. The tree rebuilds with fresh server-side paths as the new genesis. Every edit session starts from the current qBittorrent state, so the wrong-oldPath problem never occurs.
+
+---
+
+## Root Cause
+
+`renameQueue` expresses renames as incremental operations relative to the state at the _start of the current session_. In `add-torrent`, where `[files]` never changes, this means session 2's `oldPath` references session 1's end-state rather than the original torrent path that qBittorrent actually has.
+
+---
+
+## Solution
+
+### Key insight
+
+`node.file` is a reference to the original `TorrentFileEntry` from `@Input() files`. Its `.path` property is **never mutated** by any rename logic — only `node.name` and `node.fullPath` change. Meanwhile, `flatten()` reconstructs full paths by walking `node.name` from root to leaf.
+
+Therefore:
+
+- `node.file.path` = **genesis path** (what qBittorrent has, or had at last session start in `content.ts`)
+- `flatten()` path = **current path** (what the user has set in the tree)
+
+Comparing them in `saveEdit()` always yields the complete effective rename set, regardless of how many edit sessions have occurred.
+
+### Why this works in both contexts
+
+**`add-torrent`:** `[files]` never changes. `node.file.path` always holds the original torrent path. Two edit sessions → session 2's save still emits `{old: original, new: yyy}`. `savedFileState` can simply be replaced, no accumulation needed.
+
+**`content.ts`:** After each save, polling refreshes `[files]` → `ngOnChanges` rebuilds the tree → new `node.file.path` values reflect the post-rename qBittorrent state → next session's genesis is correct.
+
+---
+
+## Changes
+
+### 1. `FileTreeSaveEvent` — remove `type` from renames
+
+All renames are expressed as file renames. The `type: 'file' | 'folder'` distinction is dropped.
+
+```typescript
+export type FileTreeSaveEvent = {
+  files: TorrentFileEntry[];
+  renames: { oldPath: string; newPath: string }[];
+};
+```
+
+### 2. `bb-file-tree.ts`
+
+**Remove `renameQueue`** and all usages in `enterEditMode`, `cancelEdit`, `saveEdit`, `onFileNameChange`, `onFolderNameChange`.
+
+**Keep `deriveRenamePayload` and `updateChildPaths`** — these maintain correct `node.fullPath` values within a session so nested folder renames chain properly when computing the final `flatten()` output.
+
+**Add `collectRenames()` private helper:**
+
+```typescript
+private collectRenames(
+  nodes: BbFileTreeNode[],
+  parentPath: string,
+): { oldPath: string; newPath: string }[] {
+  const result: { oldPath: string; newPath: string }[] = [];
+  for (const node of nodes) {
+    const currentPath = parentPath ? `${parentPath}/${node.name}` : node.name;
+    if (node.kind === 'file' && node.file) {
+      const genesisPath = normalizePath(node.file.path);
+      if (genesisPath !== currentPath) {
+        result.push({ oldPath: genesisPath, newPath: currentPath });
+      }
+    }
+    if (node.children) result.push(...this.collectRenames(node.children, currentPath));
+  }
+  return result;
+}
+```
+
+**Update `saveEdit()`:**
+
+```typescript
+public saveEdit(): void {
+  const files = this.flatten(this.data, '');
+  const renames = this.collectRenames(this.data, '');
+  this.saved.emit({ files, renames });
+  this.originalFiles = [];
+  this.editMode.set(false);
+  this.editModeChange.emit(false);
+}
+```
+
+**Add `sessionDirty` flag** — `false` on `enterEditMode()`, `true` on any change (`onFileNameChange`, `onFolderNameChange`, `toggleFileSelection`, `toggleFolderSelection`, `setFolderPriority`).
+
+**Update `cancelEdit()` — add confirm guard:**
+
+Inject `ConfirmService`. Before canceling, if `sessionDirty`, show a confirm dialog. If the user declines, return without canceling.
+
+Add translation keys under `components.bb-file-tree.confirm.cancel`:
+
+- `title`: `"Discard changes"`
+- `message`: `"You have unsaved changes. Are you sure you want to discard them?"`
+
+### 3. `add-torrent.ts`
+
+**`onTreeSaved`:** no change — replacing `savedFileState` is correct now that `bb-file-tree` always emits genesis→current renames.
+
+**`tryRenameContentAfterAdd`:** remove the folder rename branch. Only call `renameTorrentFile`:
+
+```typescript
+for (const item of this.savedFileState?.renames ?? []) {
+  await this.qbService.renameTorrentFile(serverId, hash, item.oldPath, item.newPath);
+}
+```
+
+### 4. `content.ts`
+
+**`onSaved`:** remove the folder rename branch. Only call `renameTorrentFile`:
+
+```typescript
+for (const item of event.renames) {
+  await this.qbService.renameTorrentFile(serverId, this.hash, item.oldPath, item.newPath);
+}
+```
+
+---
+
+## Files to change
+
+| File                                                                        | Change                                                                                                    |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `packages/app/src/app/components/bb-file-tree/bb-file-tree.ts`              | Remove `renameQueue`; add `collectRenames`; update `saveEdit`; add `sessionDirty` + cancel confirm        |
+| `packages/app/src/app/components/bb-file-tree/bb-file-tree.html`            | Wire cancel confirm (no template changes needed — `cancelEdit` is already async-capable via button click) |
+| `packages/app/src/app/components/add-torrent/add-torrent.ts`                | Remove folder rename branch in `tryRenameContentAfterAdd`                                                 |
+| `packages/app/src/app/components/modals/torrent-details/content/content.ts` | Remove folder rename branch in `onSaved`                                                                  |
+| `public/i18n/us.json`                                                       | Add cancel confirm translation keys                                                                       |
+| `public/i18n/hu.json`                                                       | Add cancel confirm translation keys (Hungarian)                                                           |
+
+---
+
+## What is not changing
+
+- `onTreeSaved` in `add-torrent.ts` — no accumulation logic needed
+- `originalFiles` tracking — still needed for priority restore on cancel
+- `updateChildPaths` / `deriveRenamePayload` — still needed for correct intra-session path management
+- `content.ts` polling / `ngOnChanges` rebuild — this is what makes the genesis reset work correctly in that context; no changes needed
+- The faRotateLeft button already in the template — left as-is (wired up to nothing for now; can be addressed in a future issue)

--- a/packages/app/src/app/components/add-torrent/add-torrent.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.ts
@@ -463,11 +463,7 @@ export class AddTorrent implements OnInit {
       await pollForTorrent();
 
       for (const item of this.savedFileState?.renames ?? []) {
-        if (item.type === 'folder') {
-          await this.qbService.renameTorrentFolder(serverId, hash, item.oldPath, item.newPath);
-        } else {
-          await this.qbService.renameTorrentFile(serverId, hash, item.oldPath, item.newPath);
-        }
+        await this.qbService.renameTorrentFile(serverId, hash, item.oldPath, item.newPath);
       }
 
       const savedFiles = this.savedFileState?.files ?? null;

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -48,10 +48,6 @@
         >
           <fa-icon [icon]="icon.faCheck"></fa-icon>
         </button>
-        <button type="button" class="btn btn-sm btn-link" placement="top">
-          <fa-icon [icon]="icon.faRotateLeft"></fa-icon>
-        </button>
-
         <button
           type="button"
           class="btn btn-sm btn-link text-danger"

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -48,6 +48,9 @@
         >
           <fa-icon [icon]="icon.faCheck"></fa-icon>
         </button>
+        <button type="button" class="btn btn-sm btn-link" placement="top">
+          <fa-icon [icon]="icon.faRotateLeft"></fa-icon>
+        </button>
 
         <button
           type="button"

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -214,7 +214,7 @@
                 [clearable]="false"
                 appendTo="body"
                 [(ngModel)]="f.priority"
-                (ngModelChange)="calculateStats()"
+                (ngModelChange)="onFilePriorityChange()"
               ></ng-select>
             } @else {
               <span class="bb-skipped-label">{{

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
@@ -284,4 +284,60 @@ describe('BbFileTree', () => {
       );
     });
   });
+
+  describe('sessionDirty', () => {
+    beforeEach(() => {
+      component.files = [makeFile('dir/a.txt'), makeFile('dir/b.txt')];
+      component.ngOnChanges();
+      component.enterEditMode();
+    });
+
+    it('should be false after enterEditMode', () => {
+      expect((component as any).sessionDirty).toBe(false);
+    });
+
+    it('should be true after onFileNameChange', () => {
+      const fileNode = component.data[0].children![0];
+      fileNode.name = 'z.txt';
+      component.onFileNameChange(fileNode);
+      expect((component as any).sessionDirty).toBe(true);
+    });
+
+    it('should be true after onFolderNameChange', () => {
+      const folderNode = component.data[0];
+      folderNode.name = 'other';
+      component.onFolderNameChange(folderNode);
+      expect((component as any).sessionDirty).toBe(true);
+    });
+
+    it('should be true after toggleFileSelection', () => {
+      const fileNode = component.data[0].children![0];
+      const event = { target: { checked: false } } as unknown as Event;
+      component.toggleFileSelection(fileNode.file!, event);
+      expect((component as any).sessionDirty).toBe(true);
+    });
+
+    it('should be true after toggleFolderSelection', () => {
+      const folderNode = component.data[0];
+      const event = { target: { checked: false } } as unknown as Event;
+      component.toggleFolderSelection(folderNode, event);
+      expect((component as any).sessionDirty).toBe(true);
+    });
+
+    it('should be true after setFolderPriority', () => {
+      component.setFolderPriority(component.data[0], 6);
+      expect((component as any).sessionDirty).toBe(true);
+    });
+
+    it('should reset to false on the next enterEditMode', () => {
+      const fileNode = component.data[0].children![0];
+      fileNode.name = 'z.txt';
+      component.onFileNameChange(fileNode);
+      expect((component as any).sessionDirty).toBe(true);
+
+      component.saveEdit();
+      component.enterEditMode();
+      expect((component as any).sessionDirty).toBe(false);
+    });
+  });
 });

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TorrentFileEntry } from '../../models/torrent-draft.model';
+import { ConfirmService } from '../../services/confirm.service';
 import { BbFileTree, BbFileTreeNode, FileTreeSaveEvent } from './bb-file-tree';
 
 const makeFile = (path: string, priority = 1, length = 1000): TorrentFileEntry => ({
@@ -11,10 +12,14 @@ const makeFile = (path: string, priority = 1, length = 1000): TorrentFileEntry =
 describe('BbFileTree', () => {
   let component: BbFileTree;
   let fixture: ComponentFixture<BbFileTree>;
+  let mockConfirmService: { confirm: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
+    mockConfirmService = { confirm: vi.fn().mockResolvedValue(true) };
+
     await TestBed.configureTestingModule({
       imports: [BbFileTree],
+      providers: [{ provide: ConfirmService, useValue: mockConfirmService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BbFileTree);
@@ -176,17 +181,17 @@ describe('BbFileTree', () => {
       expect(spy).toHaveBeenCalledWith(true);
     });
 
-    it('should set editMode to false on cancelEdit', () => {
+    it('should set editMode to false on cancelEdit', async () => {
       component.enterEditMode();
-      component.cancelEdit();
+      await component.cancelEdit();
       expect(component.editMode()).toBe(false);
     });
 
-    it('should emit editModeChange(false) on cancelEdit', () => {
+    it('should emit editModeChange(false) on cancelEdit', async () => {
       component.enterEditMode();
       const spy = vi.fn();
       component.editModeChange.subscribe(spy);
-      component.cancelEdit();
+      await component.cancelEdit();
       expect(spy).toHaveBeenCalledWith(false);
     });
 
@@ -338,6 +343,46 @@ describe('BbFileTree', () => {
       component.saveEdit();
       component.enterEditMode();
       expect((component as any).sessionDirty).toBe(false);
+    });
+  });
+
+  describe('cancelEdit confirm guard', () => {
+    beforeEach(() => {
+      component.files = [makeFile('a.txt')];
+      component.ngOnChanges();
+      component.enterEditMode();
+    });
+
+    it('should skip confirm and cancel immediately when session is not dirty', async () => {
+      await component.cancelEdit();
+      expect(mockConfirmService.confirm).not.toHaveBeenCalled();
+      expect(component.editMode()).toBe(false);
+    });
+
+    it('should show confirm when session is dirty', async () => {
+      const node = component.data[0];
+      node.name = 'z.txt';
+      component.onFileNameChange(node);
+
+      mockConfirmService.confirm.mockResolvedValue(true);
+      await component.cancelEdit();
+
+      expect(mockConfirmService.confirm).toHaveBeenCalledWith(
+        'components.bb-file-tree.confirm.cancel.title',
+        'components.bb-file-tree.confirm.cancel.message',
+      );
+      expect(component.editMode()).toBe(false);
+    });
+
+    it('should not cancel when user declines the confirm', async () => {
+      const node = component.data[0];
+      node.name = 'z.txt';
+      component.onFileNameChange(node);
+
+      mockConfirmService.confirm.mockResolvedValue(false);
+      await component.cancelEdit();
+
+      expect(component.editMode()).toBe(true);
     });
   });
 });

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TorrentFileEntry } from '../../models/torrent-draft.model';
-import { BbFileTree, BbFileTreeNode } from './bb-file-tree';
+import { BbFileTree, BbFileTreeNode, FileTreeSaveEvent } from './bb-file-tree';
 
 const makeFile = (path: string, priority = 1, length = 1000): TorrentFileEntry => ({
   path,
@@ -202,6 +202,86 @@ describe('BbFileTree', () => {
       component.enterEditMode();
       component.saveEdit();
       expect(component.editMode()).toBe(false);
+    });
+  });
+
+  describe('saveEdit renames', () => {
+    beforeEach(() => {
+      component.files = [makeFile('dir/a.txt'), makeFile('dir/b.txt')];
+      component.ngOnChanges();
+    });
+
+    it('should emit empty renames when no files were renamed', () => {
+      component.enterEditMode();
+      const spy = vi.fn();
+      component.saved.subscribe(spy);
+      component.saveEdit();
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ renames: [] }));
+    });
+
+    it('should emit genesis-to-current rename when a file is renamed', () => {
+      component.enterEditMode();
+      const fileNode = component.data[0].children![0]; // dir/a.txt
+      fileNode.name = 'z.txt';
+      component.onFileNameChange(fileNode);
+
+      const spy = vi.fn();
+      component.saved.subscribe(spy);
+      component.saveEdit();
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          renames: [{ oldPath: 'dir/a.txt', newPath: 'dir/z.txt' }],
+        }),
+      );
+    });
+
+    it('should emit correct rename after two edit sessions (multi-session bug)', () => {
+      component.files = [makeFile('a.txt')];
+      component.ngOnChanges();
+
+      // Session 1: a.txt → xxx.txt
+      component.enterEditMode();
+      const node = component.data[0];
+      node.name = 'xxx.txt';
+      component.onFileNameChange(node);
+      component.saveEdit();
+
+      // Session 2: xxx.txt → yyy.txt
+      component.enterEditMode();
+      node.name = 'yyy.txt';
+      component.onFileNameChange(node);
+
+      const spy = vi.fn();
+      component.saved.subscribe(spy);
+      component.saveEdit();
+
+      // Must emit genesis (a.txt) → current (yyy.txt), not stale (xxx.txt) → current
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          renames: [{ oldPath: 'a.txt', newPath: 'yyy.txt' }],
+        }),
+      );
+    });
+
+    it('should emit one rename per file when a folder is renamed', () => {
+      component.enterEditMode();
+      const folderNode = component.data[0]; // dir
+      folderNode.name = 'newdir';
+      component.onFolderNameChange(folderNode);
+
+      const spy = vi.fn();
+      component.saved.subscribe(spy);
+      component.saveEdit();
+
+      const event = spy.mock.calls[0][0] as FileTreeSaveEvent;
+      expect(event.renames).toHaveLength(2);
+      expect(event.renames).toEqual(
+        expect.arrayContaining([
+          { oldPath: 'dir/a.txt', newPath: 'newdir/a.txt' },
+          { oldPath: 'dir/b.txt', newPath: 'newdir/b.txt' },
+        ]),
+      );
     });
   });
 });

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -272,6 +272,11 @@ export class BbFileTree implements OnChanges {
     this.calculateStats();
   }
 
+  onFilePriorityChange(): void {
+    this.sessionDirty = true;
+    this.calculateStats();
+  }
+
   onRenameEnter(event: Event, node: BbFileTreeNode, type: 'file' | 'folder'): void {
     event.preventDefault();
     if (type === 'file') this.onFileNameChange(node);
@@ -279,10 +284,10 @@ export class BbFileTree implements OnChanges {
     this.saveEdit();
   }
 
-  onEscapeInInput(event: Event): void {
+  async onEscapeInInput(event: Event): Promise<void> {
     event.stopPropagation();
     event.preventDefault();
-    this.cancelEdit();
+    await this.cancelEdit();
   }
 
   onFileNameChange(node: BbFileTreeNode): void {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -70,6 +70,7 @@ export class BbFileTree implements OnChanges {
   public editMode = signal(false);
   private originalFiles: TorrentFileEntry[] = [];
   private autoEditTriggered = false;
+  private sessionDirty = false;
   private folderPriorityMemory = new Map<string, number>();
 
   public treeControl = new NestedTreeControl<BbFileTreeNode>((n) => n.children ?? []);
@@ -160,6 +161,7 @@ export class BbFileTree implements OnChanges {
   }
 
   public enterEditMode(): void {
+    this.sessionDirty = false;
     this.originalFiles = structuredClone(this.files);
     this.folderPriorityMemory.clear();
     this.editMode.set(true);
@@ -236,6 +238,7 @@ export class BbFileTree implements OnChanges {
       this.folderPriorityMemory.set(node.fullPath, this.getDominantFolderPriority(node));
       this.updateRecursive(node, (f) => (f.priority = 0));
     }
+    this.sessionDirty = true;
     this.calculateStats();
   }
 
@@ -243,6 +246,7 @@ export class BbFileTree implements OnChanges {
     this.updateRecursive(node, (f) => {
       if (f.priority !== 0) f.priority = priority;
     });
+    this.sessionDirty = true;
     this.calculateStats();
   }
 
@@ -254,6 +258,7 @@ export class BbFileTree implements OnChanges {
   toggleFileSelection(f: TorrentFileEntry, event: Event): void {
     const checked = (event.target as HTMLInputElement).checked;
     f.priority = checked ? 1 : 0;
+    this.sessionDirty = true;
     this.calculateStats();
   }
 
@@ -274,6 +279,7 @@ export class BbFileTree implements OnChanges {
     const { oldPath, newPath } = this.deriveRenamePayload(node);
     if (oldPath === newPath) return;
     node.fullPath = newPath;
+    this.sessionDirty = true;
   }
 
   onFolderNameChange(node: BbFileTreeNode): void {
@@ -281,6 +287,7 @@ export class BbFileTree implements OnChanges {
     if (oldPath === newPath) return;
     node.fullPath = newPath;
     this.updateChildPaths(node.children ?? [], oldPath, newPath);
+    this.sessionDirty = true;
   }
 
   private deriveRenamePayload(node: BbFileTreeNode): { oldPath: string; newPath: string } {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -69,7 +69,6 @@ export class BbFileTree implements OnChanges {
 
   public editMode = signal(false);
   private originalFiles: TorrentFileEntry[] = [];
-  private renameQueue: { oldPath: string; newPath: string }[] = [];
   private autoEditTriggered = false;
   private folderPriorityMemory = new Map<string, number>();
 
@@ -162,7 +161,6 @@ export class BbFileTree implements OnChanges {
 
   public enterEditMode(): void {
     this.originalFiles = structuredClone(this.files);
-    this.renameQueue = [];
     this.folderPriorityMemory.clear();
     this.editMode.set(true);
     this.editModeChange.emit(true);
@@ -180,7 +178,6 @@ export class BbFileTree implements OnChanges {
     this.calculateStats();
     if (this.expandAll) this.expandAllNodes();
     else this.restoreExpansionState(this.data, expandedPaths);
-    this.renameQueue = [];
     this.originalFiles = [];
     this.folderPriorityMemory.clear();
     this.editMode.set(false);
@@ -189,8 +186,8 @@ export class BbFileTree implements OnChanges {
 
   public saveEdit(): void {
     const files = this.flatten(this.data, '');
-    this.saved.emit({ files, renames: [...this.renameQueue] });
-    this.renameQueue = [];
+    const renames = this.collectRenames(this.data, '');
+    this.saved.emit({ files, renames });
     this.originalFiles = [];
     this.folderPriorityMemory.clear();
     this.editMode.set(false);
@@ -276,14 +273,12 @@ export class BbFileTree implements OnChanges {
   onFileNameChange(node: BbFileTreeNode): void {
     const { oldPath, newPath } = this.deriveRenamePayload(node);
     if (oldPath === newPath) return;
-    this.renameQueue.push({ oldPath, newPath });
     node.fullPath = newPath;
   }
 
   onFolderNameChange(node: BbFileTreeNode): void {
     const { oldPath, newPath } = this.deriveRenamePayload(node);
     if (oldPath === newPath) return;
-    this.renameQueue.push({ oldPath, newPath });
     node.fullPath = newPath;
     this.updateChildPaths(node.children ?? [], oldPath, newPath);
   }
@@ -317,6 +312,24 @@ export class BbFileTree implements OnChanges {
         result.push({ ...node.file, path: currentPath });
       }
       if (node.children) result = result.concat(this.flatten(node.children, currentPath));
+    }
+    return result;
+  }
+
+  private collectRenames(
+    nodes: BbFileTreeNode[],
+    parentPath: string,
+  ): { oldPath: string; newPath: string }[] {
+    const result: { oldPath: string; newPath: string }[] = [];
+    for (const node of nodes) {
+      const currentPath = parentPath ? `${parentPath}/${node.name}` : node.name;
+      if (node.kind === 'file' && node.file) {
+        const genesisPath = normalizePath(node.file.path);
+        if (genesisPath !== currentPath) {
+          result.push({ oldPath: genesisPath, newPath: currentPath });
+        }
+      }
+      if (node.children) result.push(...this.collectRenames(node.children, currentPath));
     }
     return result;
   }

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -32,7 +32,7 @@ export type BbFileTreeNode = {
 
 export type FileTreeSaveEvent = {
   files: TorrentFileEntry[];
-  renames: { type: 'file' | 'folder'; oldPath: string; newPath: string }[];
+  renames: { oldPath: string; newPath: string }[];
 };
 
 @Component({
@@ -69,7 +69,7 @@ export class BbFileTree implements OnChanges {
 
   public editMode = signal(false);
   private originalFiles: TorrentFileEntry[] = [];
-  private renameQueue: { type: 'file' | 'folder'; oldPath: string; newPath: string }[] = [];
+  private renameQueue: { oldPath: string; newPath: string }[] = [];
   private autoEditTriggered = false;
   private folderPriorityMemory = new Map<string, number>();
 
@@ -276,14 +276,14 @@ export class BbFileTree implements OnChanges {
   onFileNameChange(node: BbFileTreeNode): void {
     const { oldPath, newPath } = this.deriveRenamePayload(node);
     if (oldPath === newPath) return;
-    this.renameQueue.push({ type: 'file', oldPath, newPath });
+    this.renameQueue.push({ oldPath, newPath });
     node.fullPath = newPath;
   }
 
   onFolderNameChange(node: BbFileTreeNode): void {
     const { oldPath, newPath } = this.deriveRenamePayload(node);
     if (oldPath === newPath) return;
-    this.renameQueue.push({ type: 'folder', oldPath, newPath });
+    this.renameQueue.push({ oldPath, newPath });
     node.fullPath = newPath;
     this.updateChildPaths(node.children ?? [], oldPath, newPath);
   }

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faCheck, faEdit, faX } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faEdit, faRotateLeft, faX } from '@fortawesome/free-solid-svg-icons';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -99,7 +99,7 @@ export class BbFileTree implements OnChanges {
     },
   ];
 
-  public icon = { faEdit, faCheck, faX };
+  public icon = { faEdit, faCheck, faRotateLeft, faX };
 
   trackByPath = (_index: number, node: BbFileTreeNode): string =>
     `${this.editMode()}:${node.fullPath}`;

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -20,6 +20,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../directives/tooltip-overflow';
 import { TorrentFileEntry } from '../../models/torrent-draft.model';
 import { FilesizePipe } from '../../pipes/filesize-pipe';
+import { ConfirmService } from '../../services/confirm.service';
 import { BbProgress } from '../bb-progress/bb-progress';
 
 export type BbFileTreeNode = {
@@ -76,6 +77,7 @@ export class BbFileTree implements OnChanges {
   public treeControl = new NestedTreeControl<BbFileTreeNode>((n) => n.children ?? []);
   public data: BbFileTreeNode[] = [];
   private readonly translateService = inject(TranslateService);
+  private readonly confirmService = inject(ConfirmService);
 
   public totalFiles = signal(0);
   public allFolders = signal(0);
@@ -168,7 +170,14 @@ export class BbFileTree implements OnChanges {
     this.editModeChange.emit(true);
   }
 
-  public cancelEdit(): void {
+  public async cancelEdit(): Promise<void> {
+    if (this.sessionDirty) {
+      const confirmed = await this.confirmService.confirm(
+        'components.bb-file-tree.confirm.cancel.title',
+        'components.bb-file-tree.confirm.cancel.message',
+      );
+      if (!confirmed) return;
+    }
     for (let i = 0; i < this.originalFiles.length && i < this.files.length; i++) {
       this.files[i].priority = this.originalFiles[i].priority;
     }
@@ -182,6 +191,7 @@ export class BbFileTree implements OnChanges {
     else this.restoreExpansionState(this.data, expandedPaths);
     this.originalFiles = [];
     this.folderPriorityMemory.clear();
+    this.sessionDirty = false;
     this.editMode.set(false);
     this.editModeChange.emit(false);
   }

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faCheck, faEdit, faRotateLeft, faX } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faEdit, faX } from '@fortawesome/free-solid-svg-icons';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -101,7 +101,7 @@ export class BbFileTree implements OnChanges {
     },
   ];
 
-  public icon = { faEdit, faCheck, faRotateLeft, faX };
+  public icon = { faEdit, faCheck, faX };
 
   trackByPath = (_index: number, node: BbFileTreeNode): string =>
     `${this.editMode()}:${node.fullPath}`;

--- a/packages/app/src/app/components/modals/torrent-details/content/content.spec.ts
+++ b/packages/app/src/app/components/modals/torrent-details/content/content.spec.ts
@@ -23,7 +23,6 @@ describe('Content', () => {
           useValue: {
             torrentContents: vi.fn().mockResolvedValue([]),
             renameTorrentFile: vi.fn(),
-            renameTorrentFolder: vi.fn(),
             setFilePriority: vi.fn(),
           },
         },

--- a/packages/app/src/app/components/modals/torrent-details/content/content.ts
+++ b/packages/app/src/app/components/modals/torrent-details/content/content.ts
@@ -87,11 +87,7 @@ export class Content implements TorrentDetailTabComponent, OnChanges, OnInit {
 
     try {
       for (const item of event.renames) {
-        if (item.type === 'folder') {
-          await this.qbService.renameTorrentFolder(serverId, this.hash, item.oldPath, item.newPath);
-        } else {
-          await this.qbService.renameTorrentFile(serverId, this.hash, item.oldPath, item.newPath);
-        }
+        await this.qbService.renameTorrentFile(serverId, this.hash, item.oldPath, item.newPath);
       }
 
       for (const file of event.files) {

--- a/packages/app/src/app/services/confirm.service.ts
+++ b/packages/app/src/app/services/confirm.service.ts
@@ -16,8 +16,8 @@ export class ConfirmService {
   public confirm(
     title: string | ParamWithData,
     message: string | ParamWithData,
-    btnOkText: string = 'global.button.ok',
-    btnCancelText: string = 'global.button.cancel',
+    btnOkText: string = 'general.button.ok',
+    btnCancelText: string = 'general.button.cancel',
     dialogSize: 'sm' | 'md' | 'lg' | 'xl' = 'md',
   ): Promise<boolean> {
     const modalRef = this.modalService.open(Confirm, { size: dialogSize });

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -149,6 +149,12 @@
         "normal": "Normál",
         "high": "Magas",
         "max": "Maximum"
+      },
+      "confirm": {
+        "cancel": {
+          "title": "Változtatások elvetése",
+          "message": "Nem mentett változtatásaid vannak. Biztosan elveted őket?"
+        }
       }
     },
     "bb-popover": {},

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -149,6 +149,12 @@
         "normal": "Normal",
         "high": "High",
         "max": "Max"
+      },
+      "confirm": {
+        "cancel": {
+          "title": "Discard changes",
+          "message": "You have unsaved changes. Are you sure you want to discard them?"
+        }
       }
     },
     "bb-popover": {},


### PR DESCRIPTION
## Issue ID

Fixes #80

## Description

Fixes a bug in `bb-file-tree` where renaming files multiple times before adding a torrent would fail with a "No such folder" error. When the user entered edit mode, renamed a file, saved, then renamed again and saved, only the second session's rename was applied at submit time - but qBittorrent still had the original filename, so the rename failed silently and the file kept its original name.

**Root cause:** `saveEdit()` emitted the current session's rename queue, which referenced the end-state of the previous session as `oldPath`. `add-torrent` overwrote `savedFileState` on each save, losing the first session's rename entirely. The result: qBittorrent received `{old: "name-after-first-edit", new: "final-name"}` but only knew `"original-name"`.

**Fix:** Remove `renameQueue` and replace it with `collectRenames()`, which walks the tree at save time and compares each leaf node's `node.file.path` (the original input path, never mutated) against the path reconstructed from the current `node.name` values. This always produces a correct genesis→current rename set regardless of how many edit sessions occurred. The fix works correctly in both `add-torrent` (buffered, applied after add) and `content.ts` (immediate, polling resets genesis between sessions).

**Also:**

- `FileTreeSaveEvent.renames` no longer carries a `type: 'file' | 'folder'` distinction - all renames are expressed as file renames, and callers are simplified to a single `renameTorrentFile` call
- `cancelEdit()` now shows a confirmation dialog (via `ConfirmService`) when the session has unsaved changes, guarded by a new `sessionDirty` flag that is set by all change handlers including per-file priority changes and Escape key
- 14 new tests added covering multi-session rename correctness, `sessionDirty` tracking, and the cancel confirm guard
