### PR TITLE
Show torrent count and disk space in delete dialog

### DIFF
--- a/packages/app/src/app/components/modals/delete-torrent/delete-torrent.html
+++ b/packages/app/src/app/components/modals/delete-torrent/delete-torrent.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="modal-body">
-  <p>{{ 'components.modals.delete-torrent.message' | translate }}</p>
+  <p>{{ 'components.modals.delete-torrent.message' | translate: { count: selected().length } }}</p>
   <form [formGroup]="deleteForm">
     <div
       class="form-check"
@@ -25,6 +25,14 @@
         {{ 'components.modals.delete-torrent.delete-form.confirmation' | translate }}</label
       >
     </div>
+    @if (deleteForm.get('removeFiles')?.value) {
+      <p class="mt-2 mb-0 text-danger">
+        {{
+          'components.modals.delete-torrent.disk-space'
+            | translate: { size: totalSize() | fileSize }
+        }}
+      </p>
+    }
   </form>
 </div>
 

--- a/packages/app/src/app/components/modals/delete-torrent/delete-torrent.ts
+++ b/packages/app/src/app/components/modals/delete-torrent/delete-torrent.ts
@@ -1,15 +1,16 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, Input, OnInit, computed, inject } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { AutofocusDirective } from '../../../directives/autofocus';
+import { FilesizePipe } from '../../../pipes/filesize-pipe';
 import { SelectionStoreService } from '../../../services/selection-store.service';
 
 @Component({
   selector: 'app-delete-torrent',
   standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, AutofocusDirective, TranslatePipe],
+  imports: [ReactiveFormsModule, CommonModule, AutofocusDirective, TranslatePipe, FilesizePipe],
   templateUrl: './delete-torrent.html',
   styleUrl: './delete-torrent.scss',
 })
@@ -20,6 +21,7 @@ export class DeleteTorrent implements OnInit {
   private readonly selectionStore = inject(SelectionStoreService);
 
   readonly selected = this.selectionStore.selected;
+  readonly totalSize = computed(() => this.selected().reduce((sum, t) => sum + t.size, 0));
 
   public deleteForm!: FormGroup;
 

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -185,7 +185,8 @@
       },
       "delete-torrent": {
         "title": "Torrent törlése",
-        "message": "Biztosan el akarod távolítani a kijelölt torrent(ek)et a listából?",
+        "message": "Biztosan el akarod távolítani a(z) {{count}} kijelölt torrent(ek)et a listából?",
+        "disk-space": "Ez {{size}} tárhelyet szabadít fel a lemezről.",
         "delete-form": {
           "confirmation": "A fájlok törlése a lemezről is"
         }

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -185,7 +185,8 @@
       },
       "delete-torrent": {
         "title": "Delete Torrent",
-        "message": "Are you sure you want to remove the selected torrent(s) from the list?",
+        "message": "Are you sure you want to remove {{count}} torrent(s) from the list?",
+        "disk-space": "This will free up {{size}} of disk space.",
         "delete-form": {
           "confirmation": "Remove the files as well"
         }


### PR DESCRIPTION
## Issue ID

Fixes #90

## Description

<img width="528" height="292" alt="image" src="https://github.com/user-attachments/assets/1fc186e1-9d11-4d13-bbfc-422bbceb1a08" />

Enhances the delete torrent dialog to display the number of torrents being deleted and the total disk space that will be freed, giving users better context before confirming a deletion.