### PR TITLE
Show system notification when minimized, toast when in foreground

### DIFF
--- a/packages/app/src/app/app.ts
+++ b/packages/app/src/app/app.ts
@@ -22,6 +22,7 @@ import { TorrentFinishedEvent, TorrentStoreService } from './services/torrent-st
 import { TransferLimitCommandHandlerService } from './services/transfer-limit-command-handler.service';
 import { UiCommandHandlerService } from './services/ui-command-handler.service';
 import { UpdateCommandHandlerService } from './services/update-command-handler.service';
+import { WindowService } from './services/window.service';
 
 @Component({
   selector: 'app-root',
@@ -48,6 +49,7 @@ export class App implements OnInit {
   private readonly updateCommandHandlerService = inject(UpdateCommandHandlerService);
   private readonly translateService = inject(TranslateService);
   private readonly timeagoIntl = inject(TimeagoIntl);
+  private readonly windowService = inject(WindowService);
 
   public isDev$ = this.electronService.isDev();
   private updateCheckedOnStartup = false;
@@ -91,8 +93,11 @@ export class App implements OnInit {
       .subscribe((event: TorrentFinishedEvent) => {
         const message = this.translateService.instant('app.success.finished-downloading');
 
-        this.notificationService.send(message, event.torrent.name);
-        this.toastService.success(event.torrent.name, message);
+        if (this.windowService.state.isMinimized) {
+          this.notificationService.send(message, event.torrent.name);
+        } else {
+          this.toastService.success(event.torrent.name, message);
+        }
       });
 
     this.generalSettingsService

--- a/packages/app/src/app/services/window.service.ts
+++ b/packages/app/src/app/services/window.service.ts
@@ -22,6 +22,10 @@ export class WindowService {
     });
   }
 
+  public get state(): WindowState {
+    return this.windowState.value;
+  }
+
   public windowStateAsObservable(): Observable<WindowState> {
     return this.windowState.asObservable();
   }


### PR DESCRIPTION
## Issue ID

Fixes #87

## Description

When a torrent finishes downloading, the app was showing both a system (OS-level) notification and an in-app toast simultaneously. This change makes the notification behaviour window-state aware:

- **App minimized / in background** — shows a system notification only (toast would not be visible anyway)
- **App in foreground** — shows a toast only (system notifications would overlap the app window)

### Implementation

- Added a synchronous `state` getter to `WindowService` (exposes `BehaviorSubject.value`) so the current window state can be read without subscribing to an observable.
- In `App.ngOnInit`, the `torrentStoreService.finished$` handler now branches on `windowService.state.isMinimized` to select the appropriate notification channel.