### PR TITLE
Start with system and start minimized

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -47,7 +47,11 @@
       "Bash(npm test:*)",
       "Bash(git -C /home/enisz/dev/bitbutler show c0ebc9f2626306224974fed25f1c1e1f2cb2fac2:public/i18n/us.json)",
       "Bash(git -C /home/enisz/dev/bitbutler show c0ebc9f2626306224974fed25f1c1e1f2cb2fac2:public/i18n/hu.json)",
-      "Bash(git:*)"
+      "Bash(git:*)",
+      "Bash(gh issue *)",
+      "Bash(python -m json.tool)",
+      "Bash(python *)",
+      "Bash(gh pr *)"
     ]
   }
 }

--- a/.github/workflows/bitbutler-pr.yml
+++ b/.github/workflows/bitbutler-pr.yml
@@ -8,9 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   enforce-rules:
     name: '[1/5] PR Format & Issue Sync'
@@ -20,7 +17,7 @@ jobs:
       issues: read
     steps:
       - name: Sync Issue Details
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -64,7 +61,7 @@ jobs:
       electron: ${{ steps.filter.outputs.electron }}
       any-source: ${{ steps.filter.outputs.any-source }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -90,8 +87,8 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.any-source == 'true'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -107,8 +104,8 @@ jobs:
     needs: [detect-changes, lint]
     if: always() && needs.detect-changes.outputs.app == 'true' && needs.lint.result == 'success'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -124,8 +121,8 @@ jobs:
     needs: [detect-changes, lint]
     if: always() && needs.detect-changes.outputs.electron == 'true' && needs.lint.result == 'success'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -156,8 +153,8 @@ jobs:
             target: --win
             job_name: 'Windows'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/bitbutler-pr.yml
+++ b/.github/workflows/bitbutler-pr.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   enforce-rules:
     name: '[1/5] PR Format & Issue Sync'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,10 @@ Three lazy-loaded routes: `login`, `main` (torrent grid), `settings`. The router
 - Themes live in `packages/app/src/styles/themes/` (multiple SCSS files); `ThemeService` switches them at runtime.
 - Translations in `public/i18n/` (`us.json`, `hu.json`), loaded via `@ngx-translate` in Angular and via `packages/electron/src/i18n.ts` in the Electron main process. Language is persisted in `GeneralSettingsService`; changing it triggers a `bitbutler:language-change` IPC call that rebuilds the tray and application menu labels at runtime.
 
+## Writing style
+
+- Use `-` (hyphen) instead of `—` (em dash) in all written output: responses, PR descriptions, commit messages, and documentation.
+
 ## Commit & PR conventions
 
 - Commit format: `#IssueID: short description` (e.g. `#22: add file tree checkboxes`)

--- a/packages/app/src/app/models/general-settings.model.ts
+++ b/packages/app/src/app/models/general-settings.model.ts
@@ -15,6 +15,10 @@ export interface GeneralSettings {
     family: ThemeFamily;
     mode: ThemeMode;
   };
+  startup: {
+    openAtLogin: boolean;
+    startMinimized: boolean;
+  };
 }
 
 export const DEFAULT_GENERAL_SETTINGS: GeneralSettings = {
@@ -29,5 +33,9 @@ export const DEFAULT_GENERAL_SETTINGS: GeneralSettings = {
   appearance: {
     family: 'bitbutler',
     mode: 'system',
+  },
+  startup: {
+    openAtLogin: false,
+    startMinimized: false,
   },
 };

--- a/packages/app/src/app/pages/settings/general/general.html
+++ b/packages/app/src/app/pages/settings/general/general.html
@@ -244,6 +244,65 @@
           </div>
         </div>
       </fieldset>
+
+      <fieldset class="bb-fieldset" formGroupName="startup">
+        <legend>{{ 'pages.settings.tab.general.label.startup' | translate }}</legend>
+
+        <div class="container">
+          <div class="row mb-3">
+            <div class="col-12">
+              <div class="form-check form-switch">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="open-at-login"
+                  formControlName="openAtLogin"
+                />
+                <label class="form-check-label" for="open-at-login">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.startup.open-at-login'
+                      | translate
+                  }}
+                  <bb-popover
+                    [subject]="'pages.settings.tab.general.popover.open-at-login.title' | translate"
+                    [description]="
+                      'pages.settings.tab.general.popover.open-at-login.description' | translate
+                    "
+                  ></bb-popover>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-12">
+              <div class="form-check form-switch">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="start-minimized"
+                  formControlName="startMinimized"
+                />
+                <label class="form-check-label" for="start-minimized">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.startup.start-minimized'
+                      | translate
+                  }}
+                  <bb-popover
+                    [subject]="
+                      'pages.settings.tab.general.popover.start-minimized.title' | translate
+                    "
+                    [description]="
+                      'pages.settings.tab.general.popover.start-minimized.description' | translate
+                    "
+                  ></bb-popover>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
     </div>
   </form>
 } @else {

--- a/packages/app/src/app/pages/settings/general/general.ts
+++ b/packages/app/src/app/pages/settings/general/general.ts
@@ -1,5 +1,5 @@
 import { CommonModule, NgOptimizedImage } from '@angular/common';
-import { Component, DestroyRef, OnInit, computed, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, effect, inject } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -20,6 +20,7 @@ import { BbSpinner } from '../../../components/bb-spinner/bb-spinner';
 import { GeneralSettings, ToastPosition } from '../../../models/general-settings.model';
 import { CommandBusService } from '../../../services/command-bus.service';
 import { GeneralSettingsService } from '../../../services/general-settings.service';
+import { ServerStoreService } from '../../../services/server-store.service';
 import { ThemeFamily, ThemeMode, ThemeService } from '../../../services/theme.service';
 import { SettingsStateService } from '../settings-state.service';
 import { SettingsTabComponent } from '../settings.interface';
@@ -53,8 +54,13 @@ export class General implements SettingsTabComponent, OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly translateService = inject(TranslateService);
   private readonly stateService = inject(SettingsStateService);
+  private readonly serverStoreService = inject(ServerStoreService);
 
   private languageChanged = toSignal(this.translateService.onLangChange);
+
+  public readonly hasDefaultServer = computed(() =>
+    this.serverStoreService.servers().some((s) => s.auto_login),
+  );
 
   public languages = computed<NgSelectItem[]>(() => {
     this.languageChanged();
@@ -146,12 +152,50 @@ export class General implements SettingsTabComponent, OnInit {
       family: new FormControl<ThemeFamily>('bitbutler', { nonNullable: true }),
       mode: new FormControl<ThemeMode>('system', { nonNullable: true }),
     }),
+    startup: new FormGroup({
+      openAtLogin: new FormControl({ value: false, disabled: true }, { nonNullable: true }),
+      startMinimized: new FormControl({ value: false, disabled: true }, { nonNullable: true }),
+    }),
   });
 
+  constructor() {
+    const startupGroup = this.generalSettingsForm.controls.startup;
+
+    effect(() => {
+      const openAtLoginCtrl = startupGroup.controls.openAtLogin;
+      const startMinimizedCtrl = startupGroup.controls.startMinimized;
+
+      if (this.hasDefaultServer()) {
+        openAtLoginCtrl.enable({ emitEvent: false });
+        if (openAtLoginCtrl.value) {
+          startMinimizedCtrl.enable({ emitEvent: false });
+        }
+      } else {
+        openAtLoginCtrl.disable({ emitEvent: false });
+        startMinimizedCtrl.disable({ emitEvent: false });
+      }
+    });
+
+    startupGroup.controls.openAtLogin.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        const ctrl = startupGroup.controls.startMinimized;
+        if (value && this.hasDefaultServer()) {
+          ctrl.enable({ emitEvent: false });
+        } else {
+          ctrl.disable({ emitEvent: false });
+        }
+      });
+  }
+
   public settings$ = from(this.generalSettingsService.load()).pipe(
-    tap((settings: GeneralSettings) =>
-      this.generalSettingsForm.patchValue(settings, { emitEvent: false }),
-    ),
+    tap((settings: GeneralSettings) => {
+      this.generalSettingsForm.patchValue(settings, { emitEvent: false });
+      const startupGroup = this.generalSettingsForm.controls.startup;
+      if (settings.startup?.openAtLogin && this.hasDefaultServer()) {
+        startupGroup.controls.startMinimized.enable({ emitEvent: false });
+      }
+    }),
   );
 
   public async ngOnInit(): Promise<void> {
@@ -164,10 +208,15 @@ export class General implements SettingsTabComponent, OnInit {
 
   private async save(): Promise<void> {
     const settings = this.generalSettingsForm.getRawValue();
+
+    if (!this.hasDefaultServer()) settings.startup.openAtLogin = false;
+    if (!settings.startup.openAtLogin) settings.startup.startMinimized = false;
+
     const newLang = settings.language.language;
     const currentLang = this.translateService.getCurrentLang();
 
     await this.generalSettingsService.save(settings);
+    await window.bitbutler.electron.setLoginItem({ openAtLogin: settings.startup.openAtLogin });
 
     if (newLang !== currentLang) {
       await firstValueFrom(this.translateService.use(newLang));

--- a/packages/electron/src/ipc/electron.ts
+++ b/packages/electron/src/ipc/electron.ts
@@ -12,6 +12,9 @@ export function registerElectronIpcHandlers(): void {
   ipcMain.handle('electron:show-open-dialog', async () => showOpenDialog());
   ipcMain.handle('electron:get-platform', async () => getPlatform());
   ipcMain.handle('electron:check-for-update', async () => checkForUpdate());
+  ipcMain.handle('electron:set-login-item', async (_event, settings: { openAtLogin: boolean }) =>
+    setLoginItem(settings),
+  );
 }
 
 function getPlatform(): HostPlatform {
@@ -39,6 +42,10 @@ async function showOpenDialog(): Promise<string | undefined> {
     properties: ['openDirectory'],
   });
   return filePaths[0];
+}
+
+function setLoginItem(settings: { openAtLogin: boolean }): void {
+  app.setLoginItemSettings({ openAtLogin: settings.openAtLogin });
 }
 
 async function checkForUpdate(): Promise<UpdateCheckResponse> {

--- a/packages/electron/src/ipc/settings.ts
+++ b/packages/electron/src/ipc/settings.ts
@@ -68,3 +68,18 @@ export function getInitialLanguage(): string {
     return 'us';
   }
 }
+
+export function getStartupSettings(): { openAtLogin: boolean; startMinimized: boolean } {
+  try {
+    const row = stmtGet.get('GeneralSettingsService');
+    if (!row?.json) return { openAtLogin: false, startMinimized: false };
+    const settings = JSON.parse(row.json) as Record<string, unknown>;
+    const startup = settings?.startup as Record<string, unknown> | undefined;
+    return {
+      openAtLogin: !!startup?.openAtLogin,
+      startMinimized: !!startup?.startMinimized,
+    };
+  } catch {
+    return { openAtLogin: false, startMinimized: false };
+  }
+}

--- a/packages/electron/src/main-window.ts
+++ b/packages/electron/src/main-window.ts
@@ -11,7 +11,7 @@ function firstExistingPath(paths: string[]): string | null {
   return null;
 }
 
-export function createMainWindow(): BrowserWindow {
+export function createMainWindow(startMinimized = false): BrowserWindow {
   const appPath = app.getAppPath();
 
   const iconCandidates = [
@@ -24,6 +24,7 @@ export function createMainWindow(): BrowserWindow {
     width: 600,
     height: 750,
     backgroundColor: '#121213',
+    show: !startMinimized,
     ...(windowIcon ? { icon: windowIcon } : {}),
     resizable: true,
     fullscreenable: true,

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -5,7 +5,11 @@ import { registerI18nIpcHandlers } from './ipc/i18n.js';
 import { registerNotificationIpcHandlers } from './ipc/notification.js';
 import { registerQbIpcHandlers } from './ipc/qbittorrent.js';
 import { registerServerIpcHandlers } from './ipc/server.js';
-import { getInitialLanguage, registerSettingsIpcHandlers } from './ipc/settings.js';
+import {
+  getInitialLanguage,
+  getStartupSettings,
+  registerSettingsIpcHandlers,
+} from './ipc/settings.js';
 import { registerTorrentIpcHandlers } from './ipc/torrent.js';
 import { handleSecondInstanceArgv, registerWindowIpcHandlers } from './ipc/window.js';
 import { createMainWindow } from './main-window.js';
@@ -24,14 +28,14 @@ if (process.platform === 'win32') {
   app.setAppUserModelId('com.enisz.bitbutler');
 }
 
-function createOrRestoreMainWindow(): Electron.BrowserWindow {
+function createOrRestoreMainWindow(startMinimized = false): Electron.BrowserWindow {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.show();
     mainWindow.focus();
     return mainWindow;
   }
 
-  mainWindow = createMainWindow();
+  mainWindow = createMainWindow(startMinimized);
 
   installMenu(mainWindow);
 
@@ -73,7 +77,10 @@ if (!gotLock) {
   app.whenReady().then(() => {
     loadTranslations(getInitialLanguage());
     registerI18nIpcHandlers();
-    createOrRestoreMainWindow();
+
+    const { openAtLogin, startMinimized } = getStartupSettings();
+    app.setLoginItemSettings({ openAtLogin });
+    createOrRestoreMainWindow(startMinimized);
 
     app.on('activate', () => {
       createOrRestoreMainWindow();

--- a/packages/electron/src/preload.ts
+++ b/packages/electron/src/preload.ts
@@ -35,6 +35,7 @@ const api: BitButlerAPI = {
     showItemInFolder: (path) => ipcRenderer.invoke('electron:show-item-in-folder', path),
     getPlatform: () => ipcRenderer.invoke('electron:get-platform'),
     checkForUpdate: () => ipcRenderer.invoke('electron:check-for-update'),
+    setLoginItem: (settings) => ipcRenderer.invoke('electron:set-login-item', settings),
   },
 
   server: {

--- a/packages/shared/src/ipc.types.ts
+++ b/packages/shared/src/ipc.types.ts
@@ -60,6 +60,7 @@ export interface BitButlerAPI {
     showItemInFolder(path: string): Promise<void>;
     getPlatform(): Promise<HostPlatform>;
     checkForUpdate(): Promise<UpdateCheckResponse>;
+    setLoginItem(settings: { openAtLogin: boolean }): Promise<void>;
   };
 
   server: {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -899,12 +899,17 @@
             "appearance": {
               "family": "Témacsalád",
               "mode": "Téma mód"
+            },
+            "startup": {
+              "open-at-login": "Alkalmazás indítása a rendszerrel",
+              "start-minimized": "Indítás minimalizálva"
             }
           },
           "label": {
             "behavior": "Viselkedés",
             "language": "Nyelv",
-            "appearance": "Megjelenés"
+            "appearance": "Megjelenés",
+            "startup": "Indítás"
           },
           "position": {
             "top-left": "Bal felül",
@@ -924,6 +929,14 @@
             "deleting-torrent-file": {
               "title": "Torrent fájl törlése",
               "description": "Engedélyezi a kliensnek a .torrent fájl törlését a lemezről, ha az sikeresen bekerült a letöltési listába."
+            },
+            "open-at-login": {
+              "title": "Indítás a rendszerrel",
+              "description": "A BitButler automatikusan elindul az operációs rendszer indításakor. Ehhez egy alapértelmezett szerver szükséges."
+            },
+            "start-minimized": {
+              "title": "Indítás minimalizálva",
+              "description": "Az alkalmazás ablaka el van rejtve indításkor. Az alkalmazás a rendszertálcáról érhető el. A \"Rendszerrel való indítás\" beállítást igényli."
             }
           }
         },

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -899,12 +899,17 @@
             "appearance": {
               "family": "Theme Family",
               "mode": "Theme Mode"
+            },
+            "startup": {
+              "open-at-login": "Start app with the system",
+              "start-minimized": "Start minimized"
             }
           },
           "label": {
             "behavior": "Behavior",
             "language": "Language",
-            "appearance": "Appearance"
+            "appearance": "Appearance",
+            "startup": "Startup"
           },
           "position": {
             "top-left": "Top Left",
@@ -924,6 +929,14 @@
             "deleting-torrent-file": {
               "title": "Deleting Torrent File",
               "description": "Allowing the client to delete the .torrent file from your disk if it got added to the download list succesfully."
+            },
+            "open-at-login": {
+              "title": "Start with System",
+              "description": "Automatically launch BitButler when the operating system starts. Requires a default server to be configured."
+            },
+            "start-minimized": {
+              "title": "Start Minimized",
+              "description": "Hide the application window on startup. The app will be accessible from the system tray. Requires \"Start with system\" to be enabled."
             }
           }
         },


### PR DESCRIPTION
## Issue ID

Fixes #88

## Description

<img width="1177" height="230" alt="image" src="https://github.com/user-attachments/assets/1da89ebe-e4e3-4270-92cb-73aefd29aab0" />

Adds two new toggles to the **General Settings → Startup** section:

- **Start app with the system** - registers/unregisters BitButler as a login item via Electron's `app.setLoginItemSettings()`. Disabled when no default server is configured (requires `auto_login` to be set on a server).
- **Start minimized** - hides the main window on launch; the app is accessible from the system tray. Disabled when "Start with system" is off.

### Implementation details

- `GeneralSettings` model extended with a `startup: { openAtLogin, startMinimized }` group (defaults both to `false`).
- New `electron:set-login-item` IPC handler calls `app.setLoginItemSettings()` immediately when the user saves, keeping the OS login item in sync.
- On startup, `getStartupSettings()` reads from the DB synchronously (same pattern as `getInitialLanguage`), syncs the OS login item, and passes `startMinimized` to `createMainWindow()` - the window is created with `show: false` when enabled.
- Angular form controls are enabled/disabled reactively: an `effect()` watches `hasDefaultServer` (computed from `ServerStoreService.servers()`), and a `valueChanges` subscription wires `openAtLogin → startMinimized`.
- Both i18n files (`us.json`, `hu.json`) updated with translations and popovers.