### PR TITLE
Compact rows and floating filters toggles in torrent list grid settings

### DIFF
--- a/packages/app/src/app/models/torrent-list-grid.model.ts
+++ b/packages/app/src/app/models/torrent-list-grid.model.ts
@@ -7,6 +7,7 @@ export interface TorrentListGridSettings {
   filterModel: any;
   pagination: boolean;
   animateRows: boolean;
+  compactRows: boolean;
   rowDoubleClickAction: RowDoubleClickAction;
   pinnedTopHashes: string[];
   pinnedBottomHashes: string[];
@@ -30,6 +31,7 @@ export const DEFAULT_TORRENT_LIST_GRID_SETTINGS: TorrentListGridSettings = {
   filterModel: {},
   pagination: false,
   animateRows: true,
+  compactRows: false,
   rowDoubleClickAction: 'DETAILS',
   pinnedTopHashes: [],
   pinnedBottomHashes: [],

--- a/packages/app/src/app/pages/main/grid/grid.html
+++ b/packages/app/src/app/pages/main/grid/grid.html
@@ -1,5 +1,1 @@
-<ag-grid-angular
-  class="w-100 h-100"
-  [gridOptions]="gridOptions"
-  [theme]="theme() === 'dark' ? bbDark : bbLight"
-/>
+<ag-grid-angular class="w-100 h-100" [gridOptions]="gridOptions" [theme]="currentTheme()" />

--- a/packages/app/src/app/pages/main/grid/grid.spec.ts
+++ b/packages/app/src/app/pages/main/grid/grid.spec.ts
@@ -47,7 +47,7 @@ describe('Grid', () => {
       init: vi.fn(),
     };
 
-    themeServiceMock = { effectiveMode: signal<'dark' | 'light'>('dark').asReadonly() as any };
+    themeServiceMock = { effectiveMode: signal<'dark' | 'light'>('dark') };
 
     gridStateServiceMock = {
       restore: vi.fn().mockResolvedValue(undefined),
@@ -139,12 +139,16 @@ describe('Grid', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should expose bbDark from app constants', () => {
-    expect(component.bbDark).toBe(GRID_DARK_THEME);
+  it('currentTheme should return dark theme when effectiveMode is dark', () => {
+    themeServiceMock.effectiveMode.set('dark');
+    fixture.detectChanges();
+    expect(component.currentTheme()).toBe(GRID_DARK_THEME);
   });
 
-  it('should expose bbLight from app constants', () => {
-    expect(component.bbLight).toBe(GRID_LIGHT_THEME);
+  it('currentTheme should return light theme when effectiveMode is light', () => {
+    themeServiceMock.effectiveMode.set('light');
+    fixture.detectChanges();
+    expect(component.currentTheme()).toBe(GRID_LIGHT_THEME);
   });
 
   it('theme should be the signal from ThemeService.effectiveMode', () => {

--- a/packages/app/src/app/pages/main/grid/grid.spec.ts
+++ b/packages/app/src/app/pages/main/grid/grid.spec.ts
@@ -141,13 +141,11 @@ describe('Grid', () => {
 
   it('currentTheme should return dark theme when effectiveMode is dark', () => {
     themeServiceMock.effectiveMode.set('dark');
-    fixture.detectChanges();
     expect(component.currentTheme()).toBe(GRID_DARK_THEME);
   });
 
   it('currentTheme should return light theme when effectiveMode is light', () => {
     themeServiceMock.effectiveMode.set('light');
-    fixture.detectChanges();
     expect(component.currentTheme()).toBe(GRID_LIGHT_THEME);
   });
 

--- a/packages/app/src/app/pages/main/grid/grid.ts
+++ b/packages/app/src/app/pages/main/grid/grid.ts
@@ -4,8 +4,10 @@ import {
   DestroyRef,
   HostListener,
   ViewChild,
+  computed,
   effect,
   inject,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
@@ -75,8 +77,12 @@ export class Grid implements AfterViewInit {
 
   public readonly theme = this.themeService.effectiveMode;
   public gridOptions: GridOptions<Torrent>;
-  public readonly bbDark = GRID_DARK_THEME;
-  public readonly bbLight = GRID_LIGHT_THEME;
+
+  private readonly compactRows = signal(false);
+  public readonly currentTheme = computed(() => {
+    const base = this.theme() === 'dark' ? GRID_DARK_THEME : GRID_LIGHT_THEME;
+    return this.compactRows() ? base.withParams({ spacing: 4 }) : base;
+  });
 
   @HostListener('window:keyup', ['$event'])
   public onKeyUp(event: KeyboardEvent): void {
@@ -211,6 +217,7 @@ export class Grid implements AfterViewInit {
 
     this.api.setGridOption('pagination', settings.pagination);
     this.api.setGridOption('animateRows', settings.animateRows);
+    this.compactRows.set(settings.compactRows ?? false);
 
     this.gridPinService.applyPinnedState(
       settings.pinnedTopHashes ?? [],

--- a/packages/app/src/app/pages/settings/torrent-list-grid/torrent-list-grid.html
+++ b/packages/app/src/app/pages/settings/torrent-list-grid/torrent-list-grid.html
@@ -21,22 +21,23 @@
                 id="animateRows"
                 formControlName="animateRows"
               />
-              <label class="form-check-label" for="animateRows">{{
-                'pages.settings.tab.torrent-list-grid.torrent-list-grid-form.animate-rows'
-                  | translate
-              }}</label>
-              <bb-popover
-                [subject]="
-                  'pages.settings.tab.torrent-list-grid.popover.animate-rows.title' | translate
-                "
-                [description]="
-                  'pages.settings.tab.torrent-list-grid.popover.animate-rows.description'
+              <label class="form-check-label" for="animateRows">
+                {{
+                  'pages.settings.tab.torrent-list-grid.torrent-list-grid-form.animate-rows'
                     | translate
-                "
-              ></bb-popover>
+                }}
+                <bb-popover
+                  [subject]="
+                    'pages.settings.tab.torrent-list-grid.popover.animate-rows.title' | translate
+                  "
+                  [description]="
+                    'pages.settings.tab.torrent-list-grid.popover.animate-rows.description'
+                      | translate
+                  "
+                ></bb-popover>
+              </label>
             </div>
           </div>
-
           <div class="col-lg-6 col-12">
             <div class="form-check form-switch">
               <input
@@ -45,17 +46,74 @@
                 id="pagination"
                 formControlName="pagination"
               />
-              <label class="form-check-label" for="pagination">{{
-                'pages.settings.tab.torrent-list-grid.torrent-list-grid-form.pagination' | translate
-              }}</label>
-              <bb-popover
-                [subject]="
-                  'pages.settings.tab.torrent-list-grid.popover.pagination.title' | translate
-                "
-                [description]="
-                  'pages.settings.tab.torrent-list-grid.popover.pagination.description' | translate
-                "
-              ></bb-popover>
+              <label class="form-check-label" for="pagination">
+                {{
+                  'pages.settings.tab.torrent-list-grid.torrent-list-grid-form.pagination'
+                    | translate
+                }}
+                <bb-popover
+                  [subject]="
+                    'pages.settings.tab.torrent-list-grid.popover.pagination.title' | translate
+                  "
+                  [description]="
+                    'pages.settings.tab.torrent-list-grid.popover.pagination.description'
+                      | translate
+                  "
+                ></bb-popover>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col-lg-6 col-12">
+            <div class="form-check form-switch">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="compactRows"
+                formControlName="compactRows"
+              />
+              <label class="form-check-label" for="compactRows">
+                {{
+                  'pages.settings.tab.torrent-list-grid.torrent-list-grid-form.compact-rows'
+                    | translate
+                }}
+                <bb-popover
+                  [subject]="
+                    'pages.settings.tab.torrent-list-grid.popover.compact-rows.title' | translate
+                  "
+                  [description]="
+                    'pages.settings.tab.torrent-list-grid.popover.compact-rows.description'
+                      | translate
+                  "
+                ></bb-popover>
+              </label>
+            </div>
+          </div>
+          <div class="col-lg-6 col-12">
+            <div class="form-check form-switch">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="floatingFilters"
+                formControlName="floatingFilters"
+              />
+              <label class="form-check-label" for="floatingFilters">
+                {{
+                  'pages.settings.tab.torrent-list-grid.torrent-list-grid-form.floating-filters'
+                    | translate
+                }}
+                <bb-popover
+                  [subject]="
+                    'pages.settings.tab.torrent-list-grid.popover.floating-filters.title'
+                      | translate
+                  "
+                  [description]="
+                    'pages.settings.tab.torrent-list-grid.popover.floating-filters.description'
+                      | translate
+                  "
+                ></bb-popover>
+              </label>
             </div>
           </div>
         </div>

--- a/packages/app/src/app/pages/settings/torrent-list-grid/torrent-list-grid.ts
+++ b/packages/app/src/app/pages/settings/torrent-list-grid/torrent-list-grid.ts
@@ -63,6 +63,8 @@ export class TorrentListGrid implements SettingsTabComponent, OnInit {
     columns: new FormControl<string[]>([]),
     pagination: new FormControl(false),
     animateRows: new FormControl(false),
+    compactRows: new FormControl(false),
+    floatingFilters: new FormControl(false),
     rowDoubleClickAction: new FormControl<RowDoubleClickAction>('DETAILS'),
   });
 
@@ -119,6 +121,8 @@ export class TorrentListGrid implements SettingsTabComponent, OnInit {
         columns: visibleColIds,
         pagination: settings.pagination,
         animateRows: settings.animateRows,
+        compactRows: settings.compactRows ?? false,
+        floatingFilters: settings.floatingFilters ?? false,
         rowDoubleClickAction: settings.rowDoubleClickAction,
       },
       { emitEvent: false },
@@ -186,6 +190,8 @@ export class TorrentListGrid implements SettingsTabComponent, OnInit {
       ...settings,
       pagination: formValue.pagination ?? settings.pagination,
       animateRows: formValue.animateRows ?? settings.animateRows,
+      compactRows: formValue.compactRows ?? settings.compactRows,
+      floatingFilters: formValue.floatingFilters ?? settings.floatingFilters,
       rowDoubleClickAction: formValue.rowDoubleClickAction ?? settings.rowDoubleClickAction,
       columnState: newColumnState,
     });

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -1029,6 +1029,8 @@
           "torrent-list-grid-form": {
             "animate-rows": "Sorok animálása",
             "pagination": "Oldalszámozás",
+            "compact-rows": "Kompakt sorok",
+            "floating-filters": "Lebegő szűrők",
             "row-double-click": {
               "title": "Dupla kattintás viselkedése",
               "value": {
@@ -1052,6 +1054,14 @@
             "pagination": {
               "title": "Torrent lista oldalszámozás",
               "description": "A torrent lista beállítható oldalszámozásra. A túl sok torrent a listában lassíthatja a teljesítményt; ha ilyen hibát észlelsz, próbáld meg bekapcsolni az oldalszámozást."
+            },
+            "compact-rows": {
+              "title": "Kompakt sorok",
+              "description": "Csökkenti a sorok magasságát és a cellák belső margóját a torrent listában, hogy több adat férjen el egyszerre."
+            },
+            "floating-filters": {
+              "title": "Lebegő szűrők",
+              "description": "Egy szűrősor jelenik meg az oszlopfejlécek alatt. Ez az oszlopfejléc helyi menüjéből is kapcsolható oszloponként."
             },
             "double-click-behavior": {
               "title": "Dupla kattintás viselkedése",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -1029,6 +1029,8 @@
           "torrent-list-grid-form": {
             "animate-rows": "Animate Rows",
             "pagination": "Pagination",
+            "compact-rows": "Compact Rows",
+            "floating-filters": "Floating Filters",
             "row-double-click": {
               "title": "Row double click behavior",
               "value": {
@@ -1052,6 +1054,14 @@
             "pagination": {
               "title": "Torrent List Pagination",
               "description": "The torrent list can be set to use pagination. Having too many torrents in your list may impact performance. If you have issues, you may try enabling pagination."
+            },
+            "compact-rows": {
+              "title": "Compact Rows",
+              "description": "Reduces the row height and cell padding in the torrent list for a denser view."
+            },
+            "floating-filters": {
+              "title": "Floating Filters",
+              "description": "Shows an inline filter row beneath the column headers. This can also be toggled per-column from the column header context menu."
             },
             "double-click-behavior": {
               "title": "Double Click Behavior",


### PR DESCRIPTION
## Issue ID

Fixes #96

## Description

Adds two new toggles to the Torrent List Grid settings page and refactors the Grid Options fieldset layout.

**Compact Rows** - reduces ag-grid row height and cell padding by applying `.withParams({ spacing: 4 })` on top of the active dark/light theme via a `computed()` signal. No extra theme constants needed.

**Floating Filters** - exposes the existing `floatingFilters` setting (previously only togglable from the column header context menu) as a persistent switch on the settings page.

**Layout** - Grid Options switches are now arranged in a two-column layout (`col-lg-6`) with popovers moved inside labels, consistent with the rest of the settings pages.