### PR TITLE
Move button-bar tooltips to bottom and dismiss on click

### DIFF
--- a/packages/app/src/app/pages/main/button-bar/button-bar.html
+++ b/packages/app/src/app/pages/main/button-bar/button-bar.html
@@ -21,6 +21,8 @@
             placement="bottom"
             container="body"
             [disableTooltip]="!compact"
+            #groupTooltip="ngbTooltip"
+            (click)="groupTooltip.close()"
           >
             <span class="bb-tool__icon" aria-hidden="true">
               @if (e.icon) {
@@ -71,11 +73,12 @@
           [class.bb-tool--info]="e.variant === 'info'"
           [class.bb-tool--warning]="e.variant === 'warning'"
           [class.bb-tool--danger]="e.variant === 'danger'"
-          (click)="onClick(e.id)"
           [ngbTooltip]="e.label | translate"
           placement="bottom"
           container="body"
           [disableTooltip]="!compact"
+          #actionTooltip="ngbTooltip"
+          (click)="onClick(e.id); actionTooltip.close()"
         >
           <span class="bb-tool__icon" aria-hidden="true">
             @if (e.icon) {

--- a/packages/app/src/app/pages/main/button-bar/button-bar.scss
+++ b/packages/app/src/app/pages/main/button-bar/button-bar.scss
@@ -267,7 +267,7 @@
   }
 
   .bb-tool__caret {
-    margin-left: 3px;
+    margin-left: 6px;
   }
 }
 


### PR DESCRIPTION
## Issue ID

Fixes #98

## Description

- Tooltips on button-bar buttons now use `placement="bottom"` so they appear below the toolbar and stay within the app window boundary
- Tooltips are dismissed on click via `ngbTooltip` template reference (`#groupTooltip` / `#actionTooltip`), preventing them from overlapping the dropdown menu that opens after clicking
- Increased caret `margin-left` from `3px` to `6px` in compact mode for better spacing between the icon and the chevron