### PR TITLE
Add Manage Servers modal with polished UX and reorganized menu structure

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -57,7 +57,8 @@
       "Bash(Get-ChildItem -Recurse -Filter \"*.spec.ts\" \"packages/app/src\")",
       "Bash(Select-String \"TranslateService\")",
       "Bash(Select-Object -First 3 -ExpandProperty Path)",
-      "Bash(npm start *)"
+      "Bash(npm start *)",
+      "Bash(Get-ChildItem *)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,4 +104,4 @@ Three lazy-loaded routes: `login`, `main` (torrent grid), `settings`. The router
 
 - **Feature branches:** Use the pattern `<issue-id>-<dash-separated-summary>` (e.g. `100-manage-labels-and-categories`).
 - **Issue templates:** When opening new issues, use the appropriate template from `.github/ISSUE_TEMPLATE/`.
-- **PR template:** PR descriptions must follow `.github/pull_request_template.md`.
+- **PR template:** ALWAYS read `.github/pull_request_template.md` before running `gh pr create` and use it as the exact structure for `--body`. Do not invent a different format.

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
@@ -48,7 +48,6 @@
 }
 
 .bb-file-tree {
-  user-select: none;
   border: none;
 }
 

--- a/packages/app/src/app/components/modals/manage-categories/manage-categories.html
+++ b/packages/app/src/app/components/modals/manage-categories/manage-categories.html
@@ -113,16 +113,22 @@
           </li>
         } @else {
           <li class="list-group-item d-flex align-items-center justify-content-between">
-            <div>
-              <div class="fw-semibold">{{ item.name }}</div>
-              <div class="small text-body-secondary">
+            <div class="overflow-hidden me-2">
+              <div class="fw-semibold text-truncate" [ngbTooltip]="item.name" bbTooltipOverflow>
+                {{ item.name }}
+              </div>
+              <div
+                class="small text-body-secondary text-truncate"
+                [ngbTooltip]="item.savePath"
+                bbTooltipOverflow
+              >
                 {{
                   item.savePath ||
                     ('components.modals.manage-categories.list.no-save-path' | translate)
                 }}
               </div>
             </div>
-            <div class="d-flex gap-1">
+            <div class="d-flex gap-1 flex-shrink-0">
               <button
                 type="button"
                 class="btn btn-link p-1"

--- a/packages/app/src/app/components/modals/manage-categories/manage-categories.html
+++ b/packages/app/src/app/components/modals/manage-categories/manage-categories.html
@@ -152,7 +152,11 @@
     </ul>
   } @else {
     <p class="text-body-secondary small mb-0">
-      {{ 'components.modals.manage-categories.empty' | translate }}
+      @if (filterControl.value) {
+        {{ 'components.modals.manage-categories.filter.no-match' | translate }}
+      } @else {
+        {{ 'components.modals.manage-categories.empty' | translate }}
+      }
     </p>
   }
 </div>

--- a/packages/app/src/app/components/modals/manage-categories/manage-categories.scss
+++ b/packages/app/src/app/components/modals/manage-categories/manage-categories.scss
@@ -4,7 +4,6 @@
 }
 
 .list-group-item {
-  user-select: none;
   transition: background-color 0.15s ease-in-out;
 
   &:hover {

--- a/packages/app/src/app/components/modals/manage-categories/manage-categories.scss
+++ b/packages/app/src/app/components/modals/manage-categories/manage-categories.scss
@@ -4,6 +4,7 @@
 }
 
 .list-group-item {
+  user-select: none;
   transition: background-color 0.15s ease-in-out;
 
   &:hover {

--- a/packages/app/src/app/components/modals/manage-categories/manage-categories.ts
+++ b/packages/app/src/app/components/modals/manage-categories/manage-categories.ts
@@ -7,6 +7,7 @@ import { faCheck, faX, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { AutofocusDirective } from '../../../directives/autofocus';
+import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { GuardableModal } from '../../../models/guardable-modal.interface';
 import { ConfirmService } from '../../../services/confirm.service';
 import { QbService } from '../../../services/qb.service';
@@ -32,6 +33,7 @@ interface CategoryItem {
     NgbTooltipModule,
     BbSpinner,
     AutofocusDirective,
+    TooltipOverflow,
     SavePathSelect,
   ],
   templateUrl: './manage-categories.html',

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -120,7 +120,11 @@
     </ul>
   } @else {
     <p class="text-body-secondary small mb-0">
-      {{ 'components.modals.manage-servers.empty' | translate }}
+      @if (filterControl.value) {
+        {{ 'components.modals.manage-servers.filter.no-match' | translate }}
+      } @else {
+        {{ 'components.modals.manage-servers.empty' | translate }}
+      }
     </p>
   }
 </div>

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -36,7 +36,7 @@
     <ul class="list-group">
       @for (server of filteredServers(); track server.id) {
         <li class="list-group-item d-flex align-items-center justify-content-between">
-          <div class="overflow-hidden me-2 d-flex align-items-center gap-2">
+          <div class="overflow-hidden me-2 d-flex align-items-center gap-3">
             @if (currentServerId() === server.id) {
               <fa-icon
                 [icon]="icon.faCircleCheck"

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -63,8 +63,8 @@
             </div>
           </div>
 
-          <div class="d-flex gap-1 flex-shrink-0 align-items-center">
-            @if (currentServerId() !== server.id) {
+          @if (currentServerId() !== server.id) {
+            <div class="d-flex gap-1 flex-shrink-0 align-items-center">
               <button
                 type="button"
                 class="btn btn-link p-1"
@@ -96,25 +96,8 @@
               >
                 <fa-icon [icon]="icon.faTrashCan" />
               </button>
-            } @else {
-              <span
-                [ngbTooltip]="'components.modals.manage-servers.tooltip.cannot-edit' | translate"
-                container="body"
-              >
-                <button type="button" class="btn btn-link p-1" disabled>
-                  <fa-icon [icon]="icon.faPencil" />
-                </button>
-              </span>
-              <span
-                [ngbTooltip]="'components.modals.manage-servers.tooltip.cannot-delete' | translate"
-                container="body"
-              >
-                <button type="button" class="btn btn-link text-danger p-1" disabled>
-                  <fa-icon [icon]="icon.faTrashCan" />
-                </button>
-              </span>
-            }
-          </div>
+            </div>
+          }
         </li>
       }
     </ul>

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -67,11 +67,12 @@
             @if (currentServerId() !== server.id) {
               <button
                 type="button"
-                class="btn btn-sm btn-outline-primary"
+                class="btn btn-link p-1"
+                [ngbTooltip]="'components.modals.manage-servers.button.connect' | translate"
                 (click)="switchTo(server)"
                 [disabled]="editing()"
               >
-                {{ 'components.modals.manage-servers.button.connect' | translate }}
+                <fa-icon [icon]="icon.faPlug" />
               </button>
               <button
                 type="button"

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -39,7 +39,7 @@
           <div class="overflow-hidden me-2 d-flex align-items-center gap-3">
             @if (currentServerId() === server.id) {
               <fa-icon
-                [icon]="icon.faCircleCheck"
+                [icon]="icon.faPlug"
                 class="text-success flex-shrink-0"
                 [ngbTooltip]="'components.modals.manage-servers.tooltip.active' | translate"
                 container="body"

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -72,10 +72,11 @@
                 (click)="switchTo(server)"
                 [disabled]="busy()"
               >
-                <fa-icon
-                  [icon]="connectingId() === server.id ? icon.faCircleNotch : icon.faPlug"
-                  [spin]="connectingId() === server.id"
-                />
+                @if (connectingId() === server.id) {
+                  <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+                } @else {
+                  <fa-icon [icon]="icon.faPlug" />
+                }
               </button>
               <button
                 type="button"

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -36,33 +36,69 @@
     <ul class="list-group">
       @for (server of filteredServers(); track server.id) {
         <li class="list-group-item d-flex align-items-center justify-content-between">
-          <div class="overflow-hidden me-2">
-            <div class="fw-medium text-truncate">{{ server.name || server.host }}</div>
-            <div class="text-body-secondary small text-truncate">
-              {{ server.protocol }}://{{ server.host }}:{{ server.port }}
+          <div class="overflow-hidden me-2 d-flex align-items-center gap-2">
+            <div class="overflow-hidden">
+              <div class="fw-medium text-truncate">{{ server.name || server.host }}</div>
+              <div class="text-body-secondary small text-truncate">
+                {{ server.protocol }}://{{ server.host }}:{{ server.port }}
+              </div>
             </div>
+            @if (currentServerId() === server.id) {
+              <fa-icon
+                [icon]="icon.faCircleCheck"
+                class="text-success flex-shrink-0"
+                [ngbTooltip]="'components.modals.manage-servers.tooltip.active' | translate"
+                container="body"
+              ></fa-icon>
+            }
           </div>
-          <div class="d-flex gap-1 flex-shrink-0">
-            <button
-              type="button"
-              class="btn btn-link p-1"
-              [ngbTooltip]="'general.button.edit' | translate"
-              [disableTooltip]="editing()"
-              (click)="openEditor(server.id)"
-              [disabled]="editing()"
-            >
-              <fa-icon [icon]="icon.faPencil" />
-            </button>
-            <button
-              type="button"
-              class="btn btn-link text-danger p-1"
-              [ngbTooltip]="'general.button.delete' | translate"
-              [disableTooltip]="editing()"
-              (click)="delete(server)"
-              [disabled]="editing()"
-            >
-              <fa-icon [icon]="icon.faTrashCan" />
-            </button>
+
+          <div class="d-flex gap-1 flex-shrink-0 align-items-center">
+            @if (currentServerId() !== server.id) {
+              <button
+                type="button"
+                class="btn btn-sm btn-outline-primary"
+                (click)="switchTo(server)"
+                [disabled]="editing()"
+              >
+                {{ 'components.modals.manage-servers.button.connect' | translate }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-link p-1"
+                [ngbTooltip]="'general.button.edit' | translate"
+                (click)="openEditor(server.id)"
+                [disabled]="editing()"
+              >
+                <fa-icon [icon]="icon.faPencil" />
+              </button>
+              <button
+                type="button"
+                class="btn btn-link text-danger p-1"
+                [ngbTooltip]="'general.button.delete' | translate"
+                (click)="delete(server)"
+                [disabled]="editing()"
+              >
+                <fa-icon [icon]="icon.faTrashCan" />
+              </button>
+            } @else {
+              <span
+                [ngbTooltip]="'components.modals.manage-servers.tooltip.cannot-edit' | translate"
+                container="body"
+              >
+                <button type="button" class="btn btn-link p-1" disabled>
+                  <fa-icon [icon]="icon.faPencil" />
+                </button>
+              </span>
+              <span
+                [ngbTooltip]="'components.modals.manage-servers.tooltip.cannot-delete' | translate"
+                container="body"
+              >
+                <button type="button" class="btn btn-link text-danger p-1" disabled>
+                  <fa-icon [icon]="icon.faTrashCan" />
+                </button>
+              </span>
+            }
           </div>
         </li>
       }

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -70,16 +70,19 @@
                 class="btn btn-link p-1"
                 [ngbTooltip]="'components.modals.manage-servers.button.connect' | translate"
                 (click)="switchTo(server)"
-                [disabled]="editing()"
+                [disabled]="busy()"
               >
-                <fa-icon [icon]="icon.faPlug" />
+                <fa-icon
+                  [icon]="connectingId() === server.id ? icon.faCircleNotch : icon.faPlug"
+                  [spin]="connectingId() === server.id"
+                />
               </button>
               <button
                 type="button"
                 class="btn btn-link p-1"
                 [ngbTooltip]="'general.button.edit' | translate"
                 (click)="openEditor(server.id)"
-                [disabled]="editing()"
+                [disabled]="busy()"
               >
                 <fa-icon [icon]="icon.faPencil" />
               </button>
@@ -88,7 +91,7 @@
                 class="btn btn-link text-danger p-1"
                 [ngbTooltip]="'general.button.delete' | translate"
                 (click)="delete(server)"
-                [disabled]="editing()"
+                [disabled]="busy()"
               >
                 <fa-icon [icon]="icon.faTrashCan" />
               </button>
@@ -122,12 +125,7 @@
 </div>
 
 <div class="modal-footer justify-content-between">
-  <button
-    type="button"
-    class="btn btn-outline-primary"
-    (click)="openEditor()"
-    [disabled]="editing()"
-  >
+  <button type="button" class="btn btn-outline-primary" (click)="openEditor()" [disabled]="busy()">
     {{ 'general.button.add-server' | translate }}
   </button>
   <button type="button" class="btn btn-secondary" (click)="activeModal.dismiss()">

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -37,12 +37,6 @@
       @for (server of filteredServers(); track server.id) {
         <li class="list-group-item d-flex align-items-center justify-content-between">
           <div class="overflow-hidden me-2 d-flex align-items-center gap-2">
-            <div class="overflow-hidden">
-              <div class="fw-medium text-truncate">{{ server.name || server.host }}</div>
-              <div class="text-body-secondary small text-truncate">
-                {{ server.protocol }}://{{ server.host }}:{{ server.port }}
-              </div>
-            </div>
             @if (currentServerId() === server.id) {
               <fa-icon
                 [icon]="icon.faCircleCheck"
@@ -51,6 +45,22 @@
                 container="body"
               ></fa-icon>
             }
+            <div class="overflow-hidden">
+              <div
+                class="fw-medium text-truncate"
+                [ngbTooltip]="server.name || server.host"
+                bbTooltipOverflow
+              >
+                {{ server.name || server.host }}
+              </div>
+              <div
+                class="text-body-secondary small text-truncate"
+                [ngbTooltip]="server.protocol + '://' + server.host + ':' + server.port"
+                bbTooltipOverflow
+              >
+                {{ server.protocol }}://{{ server.host }}:{{ server.port }}
+              </div>
+            </div>
           </div>
 
           <div class="d-flex gap-1 flex-shrink-0 align-items-center">

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -1,0 +1,89 @@
+<div class="modal-header">
+  <h5 class="modal-title">{{ 'components.modals.manage-servers.title' | translate }}</h5>
+  <button
+    type="button"
+    class="btn-close"
+    aria-label="Close"
+    (click)="activeModal.dismiss()"
+  ></button>
+</div>
+
+<div class="modal-body">
+  @if (hasServers()) {
+    <div class="mb-3">
+      <div class="bb-filter-input">
+        <input
+          type="text"
+          class="form-control"
+          [placeholder]="'components.modals.manage-servers.filter.placeholder' | translate"
+          [formControl]="filterControl"
+        />
+        @if (filterControl.value) {
+          <button
+            type="button"
+            class="bb-filter-clear"
+            (click)="clearFilter()"
+            aria-label="Clear filter"
+          >
+            <fa-icon [icon]="icon.faXmark"></fa-icon>
+          </button>
+        }
+      </div>
+    </div>
+  }
+
+  @if (filteredServers().length > 0) {
+    <ul class="list-group">
+      @for (server of filteredServers(); track server.id) {
+        <li class="list-group-item d-flex align-items-center justify-content-between">
+          <div class="overflow-hidden me-2">
+            <div class="fw-medium text-truncate">{{ server.name || server.host }}</div>
+            <div class="text-body-secondary small text-truncate">
+              {{ server.protocol }}://{{ server.host }}:{{ server.port }}
+            </div>
+          </div>
+          <div class="d-flex gap-1 flex-shrink-0">
+            <button
+              type="button"
+              class="btn btn-link p-1"
+              [ngbTooltip]="'general.button.edit' | translate"
+              [disableTooltip]="editing()"
+              (click)="openEditor(server.id)"
+              [disabled]="editing()"
+            >
+              <fa-icon [icon]="icon.faPencil" />
+            </button>
+            <button
+              type="button"
+              class="btn btn-link text-danger p-1"
+              [ngbTooltip]="'general.button.delete' | translate"
+              [disableTooltip]="editing()"
+              (click)="delete(server)"
+              [disabled]="editing()"
+            >
+              <fa-icon [icon]="icon.faTrashCan" />
+            </button>
+          </div>
+        </li>
+      }
+    </ul>
+  } @else {
+    <p class="text-body-secondary small mb-0">
+      {{ 'components.modals.manage-servers.empty' | translate }}
+    </p>
+  }
+</div>
+
+<div class="modal-footer justify-content-between">
+  <button
+    type="button"
+    class="btn btn-outline-primary"
+    (click)="openEditor()"
+    [disabled]="editing()"
+  >
+    {{ 'general.button.add-server' | translate }}
+  </button>
+  <button type="button" class="btn btn-secondary" (click)="activeModal.dismiss()">
+    {{ 'general.button.close' | translate }}
+  </button>
+</div>

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.scss
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.scss
@@ -1,0 +1,12 @@
+.list-group {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.list-group-item {
+  transition: background-color 0.15s ease-in-out;
+
+  &:hover {
+    background-color: var(--bb-hover-list-item-bg);
+  }
+}

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.scss
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.scss
@@ -4,7 +4,6 @@
 }
 
 .list-group-item {
-  user-select: none;
   transition: background-color 0.15s ease-in-out;
 
   &:hover {

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.scss
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.scss
@@ -4,6 +4,7 @@
 }
 
 .list-group-item {
+  user-select: none;
   transition: background-color 0.15s ease-in-out;
 
   &:hover {

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -6,6 +6,7 @@ import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
 import { faCircleCheck, faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
+import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { ServerRecord } from '../../../models/server.model';
 import { CommandBusService } from '../../../services/command-bus.service';
 import { ConfirmService } from '../../../services/confirm.service';
@@ -15,7 +16,13 @@ import { ServerEditor } from '../server-editor/server-editor';
 @Component({
   selector: 'app-manage-servers',
   standalone: true,
-  imports: [ReactiveFormsModule, TranslatePipe, FontAwesomeModule, NgbTooltipModule],
+  imports: [
+    ReactiveFormsModule,
+    TranslatePipe,
+    FontAwesomeModule,
+    NgbTooltipModule,
+    TooltipOverflow,
+  ],
   templateUrl: './manage-servers.html',
   styleUrl: './manage-servers.scss',
 })

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -3,7 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
-import { faCircleCheck, faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck, faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
@@ -33,7 +33,7 @@ export class ManageServers {
   private readonly modalService = inject(NgbModal);
   public readonly activeModal = inject(NgbActiveModal);
 
-  public readonly icon = { faPencil, faTrashCan, faXmark, faCircleCheck };
+  public readonly icon = { faPencil, faTrashCan, faXmark, faCircleCheck, faPlug };
   public readonly currentServerId = this.serverStoreService.currentServerId;
 
   public filterControl = new FormControl('');

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -1,0 +1,80 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
+import { faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslatePipe } from '@ngx-translate/core';
+import { ServerRecord } from '../../../models/server.model';
+import { CommandBusService } from '../../../services/command-bus.service';
+import { ConfirmService } from '../../../services/confirm.service';
+import { ServerStoreService } from '../../../services/server-store.service';
+import { ServerEditor } from '../server-editor/server-editor';
+
+@Component({
+  selector: 'app-manage-servers',
+  standalone: true,
+  imports: [ReactiveFormsModule, TranslatePipe, FontAwesomeModule, NgbTooltipModule],
+  templateUrl: './manage-servers.html',
+  styleUrl: './manage-servers.scss',
+})
+export class ManageServers {
+  private readonly serverStoreService = inject(ServerStoreService);
+  private readonly commandBusService = inject(CommandBusService);
+  private readonly confirmService = inject(ConfirmService);
+  private readonly modalService = inject(NgbModal);
+  public readonly activeModal = inject(NgbActiveModal);
+
+  public readonly icon = { faPencil, faTrashCan, faXmark };
+
+  public filterControl = new FormControl('');
+  public editing = signal(false);
+
+  private readonly filterValue = toSignal(this.filterControl.valueChanges, { initialValue: '' });
+
+  public readonly filteredServers = computed(() => {
+    const filter = (this.filterValue() ?? '').toLowerCase();
+    const servers = this.serverStoreService.servers();
+    if (!filter) return servers;
+    return servers.filter(
+      (s) => s.name.toLowerCase().includes(filter) || s.host.toLowerCase().includes(filter),
+    );
+  });
+
+  public readonly hasServers = computed(() => this.serverStoreService.servers().length > 0);
+
+  public clearFilter(): void {
+    this.filterControl.reset();
+  }
+
+  public async openEditor(id?: string): Promise<void> {
+    if (this.editing()) return;
+    this.editing.set(true);
+    const ref = this.modalService.open(ServerEditor, { size: 'lg' });
+    if (id) ref.componentInstance.id = id;
+    try {
+      const newId: string = await ref.result;
+      if (!id) {
+        this.commandBusService.emit({ type: 'SERVER_ADDED', id: newId });
+      }
+    } catch (_e) {
+    } finally {
+      this.editing.set(false);
+    }
+  }
+
+  public async delete(server: ServerRecord): Promise<void> {
+    const confirmed = await this.confirmService.confirm(
+      'components.modals.manage-servers.delete-confirm.title',
+      {
+        text: 'components.modals.manage-servers.delete-confirm.message',
+        data: { name: server.name || server.host },
+      },
+      'general.button.delete',
+    );
+    if (!confirmed) return;
+
+    this.commandBusService.emit({ type: 'SERVER_DELETED', id: server.id });
+  }
+}

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -3,7 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
-import { faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck, faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ServerRecord } from '../../../models/server.model';
@@ -26,7 +26,8 @@ export class ManageServers {
   private readonly modalService = inject(NgbModal);
   public readonly activeModal = inject(NgbActiveModal);
 
-  public readonly icon = { faPencil, faTrashCan, faXmark };
+  public readonly icon = { faPencil, faTrashCan, faXmark, faCircleCheck };
+  public readonly currentServerId = this.serverStoreService.currentServerId;
 
   public filterControl = new FormControl('');
   public editing = signal(false);
@@ -62,6 +63,11 @@ export class ManageServers {
     } finally {
       this.editing.set(false);
     }
+  }
+
+  public switchTo(server: ServerRecord): void {
+    this.activeModal.dismiss();
+    this.commandBusService.emit({ type: 'UI_SERVER_SWITCH', id: server.id });
   }
 
   public async delete(server: ServerRecord): Promise<void> {

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -3,7 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
-import { faCircleNotch, faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
@@ -38,7 +38,7 @@ export class ManageServers {
   private readonly modalService = inject(NgbModal);
   public readonly activeModal = inject(NgbActiveModal);
 
-  public readonly icon = { faPencil, faTrashCan, faXmark, faPlug, faCircleNotch };
+  public readonly icon = { faPencil, faTrashCan, faXmark, faPlug };
   public readonly currentServerId = this.serverStoreService.currentServerId;
 
   public filterControl = new FormControl('');

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -3,14 +3,16 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
-import { faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faCircleNotch, faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { ServerRecord } from '../../../models/server.model';
 import { CommandBusService } from '../../../services/command-bus.service';
 import { ConfirmService } from '../../../services/confirm.service';
+import { QbService } from '../../../services/qb.service';
 import { ServerStoreService } from '../../../services/server-store.service';
+import { ToastService } from '../../../services/toast.service';
 import { ServerEditor } from '../server-editor/server-editor';
 
 @Component({
@@ -30,14 +32,18 @@ export class ManageServers {
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly commandBusService = inject(CommandBusService);
   private readonly confirmService = inject(ConfirmService);
+  private readonly qbService = inject(QbService);
+  private readonly toastService = inject(ToastService);
+  private readonly translateService = inject(TranslateService);
   private readonly modalService = inject(NgbModal);
   public readonly activeModal = inject(NgbActiveModal);
 
-  public readonly icon = { faPencil, faTrashCan, faXmark, faPlug };
+  public readonly icon = { faPencil, faTrashCan, faXmark, faPlug, faCircleNotch };
   public readonly currentServerId = this.serverStoreService.currentServerId;
 
   public filterControl = new FormControl('');
   public editing = signal(false);
+  public connectingId = signal<string | null>(null);
 
   private readonly filterValue = toSignal(this.filterControl.valueChanges, { initialValue: '' });
 
@@ -52,12 +58,14 @@ export class ManageServers {
 
   public readonly hasServers = computed(() => this.serverStoreService.servers().length > 0);
 
+  public readonly busy = computed(() => this.editing() || !!this.connectingId());
+
   public clearFilter(): void {
     this.filterControl.reset();
   }
 
   public async openEditor(id?: string): Promise<void> {
-    if (this.editing()) return;
+    if (this.busy()) return;
     this.editing.set(true);
     const ref = this.modalService.open(ServerEditor, { size: 'lg' });
     if (id) ref.componentInstance.id = id;
@@ -72,9 +80,26 @@ export class ManageServers {
     }
   }
 
-  public switchTo(server: ServerRecord): void {
-    this.activeModal.dismiss();
-    this.commandBusService.emit({ type: 'UI_SERVER_SWITCH', id: server.id });
+  public async switchTo(server: ServerRecord): Promise<void> {
+    if (this.busy()) return;
+    this.connectingId.set(server.id);
+    try {
+      const hasSession = await this.qbService.hasCookie(server.id);
+      if (!hasSession) {
+        const loginRes = await this.qbService.login(server.id);
+        if (!loginRes.loggedIn) throw new Error('Login failed');
+      }
+      this.serverStoreService.select(server.id);
+      this.activeModal.dismiss();
+    } catch (err) {
+      this.toastService.danger(
+        this.translateService.instant('services.menu-bar-command-handler.error.failed-to-connect', {
+          name: server.name || server.host,
+        }),
+      );
+    } finally {
+      this.connectingId.set(null);
+    }
   }
 
   public async delete(server: ServerRecord): Promise<void> {

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.ts
@@ -3,7 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faTrashCan } from '@fortawesome/free-regular-svg-icons';
-import { faCircleCheck, faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faPencil, faPlug, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
@@ -33,7 +33,7 @@ export class ManageServers {
   private readonly modalService = inject(NgbModal);
   public readonly activeModal = inject(NgbActiveModal);
 
-  public readonly icon = { faPencil, faTrashCan, faXmark, faCircleCheck, faPlug };
+  public readonly icon = { faPencil, faTrashCan, faXmark, faPlug };
   public readonly currentServerId = this.serverStoreService.currentServerId;
 
   public filterControl = new FormControl('');

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.html
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.html
@@ -64,10 +64,10 @@
     <ul class="list-group">
       @for (tag of filteredTags(); track tag) {
         <li class="list-group-item d-flex align-items-center justify-content-between">
-          <span>{{ tag }}</span>
+          <span class="text-truncate me-2" [ngbTooltip]="tag" bbTooltipOverflow>{{ tag }}</span>
           <button
             type="button"
-            class="btn btn-link text-danger p-1"
+            class="btn btn-link text-danger p-1 flex-shrink-0"
             [ngbTooltip]="'general.button.delete' | translate"
             (click)="delete(tag)"
           >

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.html
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.html
@@ -78,7 +78,11 @@
     </ul>
   } @else {
     <p class="text-body-secondary small mb-0">
-      {{ 'components.modals.manage-tags.empty' | translate }}
+      @if (filterControl.value) {
+        {{ 'components.modals.manage-tags.filter.no-match' | translate }}
+      } @else {
+        {{ 'components.modals.manage-tags.empty' | translate }}
+      }
     </p>
   }
 </div>

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.html
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.html
@@ -31,7 +31,9 @@
       {{ 'general.button.add' | translate }}
     </button>
   </div>
-  <div class="form-text mb-3">{{ 'components.modals.manage-tags.add-form.hint' | translate }}</div>
+  <div class="form-text mb-3 mt-1 ms-2">
+    {{ 'components.modals.manage-tags.add-form.hint' | translate }}
+  </div>
 
   @if (!loading()) {
     <div class="mb-3">

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.scss
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.scss
@@ -4,7 +4,6 @@
 }
 
 .list-group-item {
-  user-select: none;
   transition: background-color 0.15s ease-in-out;
 
   &:hover {

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.scss
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.scss
@@ -4,6 +4,7 @@
 }
 
 .list-group-item {
+  user-select: none;
   transition: background-color 0.15s ease-in-out;
 
   &:hover {

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.ts
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.ts
@@ -7,6 +7,7 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { NgbActiveModal, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { AutofocusDirective } from '../../../directives/autofocus';
+import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { GuardableModal } from '../../../models/guardable-modal.interface';
 import { ConfirmService } from '../../../services/confirm.service';
 import { QbService } from '../../../services/qb.service';
@@ -25,6 +26,7 @@ import { BbSpinner } from '../../bb-spinner/bb-spinner';
     NgbTooltipModule,
     BbSpinner,
     AutofocusDirective,
+    TooltipOverflow,
   ],
   templateUrl: './manage-tags.html',
   styleUrl: './manage-tags.scss',

--- a/packages/app/src/app/components/modals/server-editor/server-editor.ts
+++ b/packages/app/src/app/components/modals/server-editor/server-editor.ts
@@ -16,6 +16,7 @@ import { filter } from 'rxjs';
 import { AutofocusDirective } from '../../../directives/autofocus';
 import { NewServer, ServerRecord } from '../../../models/server.model';
 import { CommandBusService } from '../../../services/command-bus.service';
+import { ServerStoreService } from '../../../services/server-store.service';
 import { ServerService } from '../../../services/server.service';
 import { BbPopover } from '../../bb-popover/bb-popover';
 import { ServerProtocol } from './server-editor.interface';
@@ -37,6 +38,7 @@ import { ServerProtocol } from './server-editor.interface';
 export class ServerEditor implements OnInit {
   private readonly activeModal = inject(NgbActiveModal);
   private readonly serverService = inject(ServerService);
+  private readonly serverStoreService = inject(ServerStoreService);
   private readonly commandBusService = inject(CommandBusService);
 
   @Input() public id: string | null = null;
@@ -135,6 +137,9 @@ export class ServerEditor implements OnInit {
           });
         })
         .catch();
+    } else {
+      const hasDefault = this.serverStoreService.servers().some((s) => s.auto_login);
+      this.editorForm.patchValue({ autoLogin: !hasDefault });
     }
   }
 

--- a/packages/app/src/app/models/command.model.ts
+++ b/packages/app/src/app/models/command.model.ts
@@ -35,7 +35,8 @@ export type UiCommand =
   | { type: 'UI_TORRENT_UNPIN' }
   | { type: 'UI_MANAGE_TAGS' }
   | { type: 'UI_MANAGE_CATEGORIES' }
-  | { type: 'UI_MANAGE_SERVERS' };
+  | { type: 'UI_MANAGE_SERVERS' }
+  | { type: 'UI_SERVER_SWITCH'; id: string };
 
 export type TorrentCommand =
   | { type: 'TORRENT_DELETE_CONFIRM'; removeFiles: boolean }

--- a/packages/app/src/app/models/command.model.ts
+++ b/packages/app/src/app/models/command.model.ts
@@ -34,7 +34,8 @@ export type UiCommand =
   | { type: 'UI_TORRENT_PIN_BOTTOM' }
   | { type: 'UI_TORRENT_UNPIN' }
   | { type: 'UI_MANAGE_TAGS' }
-  | { type: 'UI_MANAGE_CATEGORIES' };
+  | { type: 'UI_MANAGE_CATEGORIES' }
+  | { type: 'UI_MANAGE_SERVERS' };
 
 export type TorrentCommand =
   | { type: 'TORRENT_DELETE_CONFIRM'; removeFiles: boolean }

--- a/packages/app/src/app/pages/main/button-bar/button-bar.scss
+++ b/packages/app/src/app/pages/main/button-bar/button-bar.scss
@@ -65,7 +65,6 @@
   color: var(--bs-body-color);
 
   cursor: pointer;
-  user-select: none;
 
   transition:
     background-color 120ms ease,
@@ -183,7 +182,6 @@
 .bb-search__clear {
   color: var(--bs-secondary-color) !important;
   cursor: pointer;
-  user-select: none;
 
   &--hidden {
     visibility: hidden;

--- a/packages/app/src/app/pages/main/button-bar/button-bar.ts
+++ b/packages/app/src/app/pages/main/button-bar/button-bar.ts
@@ -21,15 +21,19 @@ import {
   faAtom,
   faChevronDown,
   faFile,
+  faLayerGroup,
   faLink,
   faPause,
   faPlay,
   faPlayCircle,
   faPlus,
   faSearch,
+  faServer,
   faSliders,
   faStopCircle,
+  faTags,
   faTrashCan,
+  faUserTie,
   faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import {
@@ -205,6 +209,37 @@ export class ButtonBar implements OnInit {
           },
         ],
       },
+      { kind: 'divider' },
+      {
+        kind: 'group',
+        id: 'manage',
+        label: 'pages.main.button-bar.button.manage-group',
+        icon: faUserTie,
+        variant: 'default',
+        items: [
+          {
+            kind: 'action',
+            id: 'manage.servers',
+            label: 'pages.main.button-bar.button.manage-servers',
+            icon: faServer,
+            variant: 'default',
+          },
+          {
+            kind: 'action',
+            id: 'manage.tags',
+            label: 'pages.main.button-bar.button.manage-tags',
+            icon: faTags,
+            variant: 'default',
+          },
+          {
+            kind: 'action',
+            id: 'manage.categories',
+            label: 'pages.main.button-bar.button.manage-categories',
+            icon: faLayerGroup,
+            variant: 'default',
+          },
+        ],
+      },
     ];
   });
 
@@ -280,6 +315,15 @@ export class ButtonBar implements OnInit {
         break;
       case 'settings.open':
         this.commandBusService.emit({ type: 'UI_OPEN_SETTINGS' });
+        break;
+      case 'manage.servers':
+        this.commandBusService.emit({ type: 'UI_MANAGE_SERVERS' });
+        break;
+      case 'manage.tags':
+        this.commandBusService.emit({ type: 'UI_MANAGE_TAGS' });
+        break;
+      case 'manage.categories':
+        this.commandBusService.emit({ type: 'UI_MANAGE_CATEGORIES' });
         break;
       case 'new.addTorrentFile':
         this.commandBusService.emit({ type: 'UI_ADD_TORRENT' });

--- a/packages/app/src/app/pages/main/grid/context-menu/context-menu.scss
+++ b/packages/app/src/app/pages/main/grid/context-menu/context-menu.scss
@@ -21,7 +21,6 @@
   font-weight: 600;
   opacity: 0.75;
   letter-spacing: 0.02em;
-  user-select: none;
 }
 
 .bb-item {

--- a/packages/app/src/app/pages/main/main.scss
+++ b/packages/app/src/app/pages/main/main.scss
@@ -15,8 +15,6 @@
 }
 
 .bb-brand {
-  user-select: none;
-
   .brand-title {
     font-size: 2rem;
     font-weight: 700;

--- a/packages/app/src/app/pages/main/main.spec.ts
+++ b/packages/app/src/app/pages/main/main.spec.ts
@@ -20,6 +20,7 @@ describe('Main', () => {
   let serverStoreMock: {
     currentServer: ReturnType<typeof signal<any>>;
     currentServerId: ReturnType<typeof signal<string | null>>;
+    refresh: ReturnType<typeof vi.fn>;
   };
 
   beforeAll(() => {
@@ -46,6 +47,7 @@ describe('Main', () => {
     serverStoreMock = {
       currentServer: signal(null),
       currentServerId: signal(null),
+      refresh: vi.fn().mockResolvedValue(undefined),
     };
 
     await TestBed.configureTestingModule({

--- a/packages/app/src/app/pages/main/main.ts
+++ b/packages/app/src/app/pages/main/main.ts
@@ -72,6 +72,7 @@ export class Main implements OnDestroy {
 
   constructor() {
     this.windowService.maximize();
+    this.serverStoreService.refresh();
   }
 
   ngOnDestroy(): void {

--- a/packages/app/src/app/pages/main/server-state/server-state.scss
+++ b/packages/app/src/app/pages/main/server-state/server-state.scss
@@ -6,7 +6,6 @@
   border-top: 1px solid var(--bs-border-color);
   color: var(--bs-body-color);
   font-size: 0.8rem;
-  user-select: none;
   display: flex;
   align-items: center;
 }

--- a/packages/app/src/app/pages/settings/status-bar/status-bar.scss
+++ b/packages/app/src/app/pages/settings/status-bar/status-bar.scss
@@ -37,7 +37,6 @@
   border: 1px solid var(--bs-border-color);
   border-radius: var(--bb-control-radius);
   cursor: grab;
-  user-select: none;
 
   &:active {
     cursor: grabbing;
@@ -69,7 +68,6 @@
   height: 32px;
   padding: 0 1rem;
   cursor: grab;
-  user-select: none;
   font-weight: 500;
   font-size: 0.875rem;
   background-color: var(--bs-card-cap-bg);

--- a/packages/app/src/app/services/menu-bar-command-handler.service.ts
+++ b/packages/app/src/app/services/menu-bar-command-handler.service.ts
@@ -51,8 +51,8 @@ export class MenuBarCommandHandlerService {
           this.disconnect();
           break;
 
-        case 'server.add':
-          this.commandBusService.emit({ type: 'UI_SERVER_EDITOR_OPEN' });
+        case 'server.manage':
+          this.commandBusService.emit({ type: 'UI_MANAGE_SERVERS' });
           break;
 
         case 'server.select':

--- a/packages/app/src/app/services/menu-bar-command-handler.service.ts
+++ b/packages/app/src/app/services/menu-bar-command-handler.service.ts
@@ -46,6 +46,10 @@ export class MenuBarCommandHandlerService {
           this.disconnect();
           break;
 
+        case 'server.add':
+          this.commandBusService.emit({ type: 'UI_SERVER_EDITOR_OPEN' });
+          break;
+
         case 'server.manage':
           this.commandBusService.emit({ type: 'UI_MANAGE_SERVERS' });
           break;

--- a/packages/app/src/app/services/menu-bar-command-handler.service.ts
+++ b/packages/app/src/app/services/menu-bar-command-handler.service.ts
@@ -1,8 +1,5 @@
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateService } from '@ngx-translate/core';
-import { AppLoader } from '../components/app-loader/app-loader';
 import { ToastType } from '../models/toast.model';
 import { CommandBusService } from './command-bus.service';
 import { MenuBarService, MenuClick } from './menu-bar.service';
@@ -23,8 +20,6 @@ export class MenuBarCommandHandlerService {
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly qbService = inject(QbService);
   private readonly router = inject(Router);
-  private readonly modalService = inject(NgbModal);
-  private readonly translateService = inject(TranslateService);
 
   public start(): void {
     this.menuBarService.clicks$.subscribe((payload: MenuClick) => {
@@ -195,54 +190,9 @@ export class MenuBarCommandHandlerService {
     }
   }
 
-  private async handleServerSwitch(serverId: string) {
+  private handleServerSwitch(serverId: string): void {
     if (!serverId) return;
     if (this.serverStoreService.currentServerId() === serverId) return;
-
-    const { name } = this.serverStoreService.servers().find((s) => s.id === serverId) || {
-      name: '',
-    };
-
-    this.toastService.info(
-      this.translateService.instant('services.menu-bar-command-handler.info.switching-server', {
-        name,
-      }),
-    );
-
-    const appLoaderModal = this.modalService.open(AppLoader, { size: 'sm', centered: true });
-    appLoaderModal.componentInstance.title = this.translateService.instant(
-      'services.menu-bar-command-handler.app-loader.title',
-    );
-    appLoaderModal.componentInstance.message = this.translateService.instant(
-      'services.menu-bar-command-handler.app-loader.message',
-      { name },
-    );
-
-    try {
-      const hasSession = await this.qbService.hasCookie(serverId);
-
-      if (!hasSession) {
-        const loginRes = await this.qbService.login(serverId);
-        if (!loginRes.loggedIn) {
-          throw new Error('Login failed');
-        }
-      }
-
-      (this.serverStoreService as any).select(serverId);
-    } catch (err) {
-      console.error(
-        MenuBarCommandHandlerService.name,
-        'handleServerSwitch',
-        '[MenuHandler] Failed to switch servers',
-        err,
-      );
-      this.toastService.danger(
-        this.translateService.instant('services.menu-bar-command-handler.error.failed-to-connect', {
-          name,
-        }),
-      );
-    } finally {
-      appLoaderModal.close();
-    }
+    this.commandBusService.emit({ type: 'UI_SERVER_SWITCH', id: serverId });
   }
 }

--- a/packages/app/src/app/services/server-command-handler.service.spec.ts
+++ b/packages/app/src/app/services/server-command-handler.service.spec.ts
@@ -31,6 +31,7 @@ describe('ServerCommandHandlerService', () => {
           useValue: {
             refresh: serverStoreRefresh,
             servers: signal([{ id: '1', name: 'Test Server' }]),
+            currentServerId: signal(null),
             select: vi.fn(),
           },
         },

--- a/packages/app/src/app/services/server-command-handler.service.ts
+++ b/packages/app/src/app/services/server-command-handler.service.ts
@@ -50,7 +50,9 @@ export class ServerCommandHandlerService {
     await this.serverStoreService.refresh();
     const server = this.serverStoreService.servers().find((s) => s.id === id);
     this.toastService.success(`Server ${server?.name || 'New Host'} added!`);
-    this.serverStoreService.select(id);
+    if (!this.serverStoreService.currentServerId()) {
+      this.serverStoreService.select(id);
+    }
   }
 
   private async handleServerUpdated(id: string): Promise<void> {

--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -30,6 +30,7 @@ import { PathService } from './path.service';
 import { QbService } from './qb.service';
 import { SelectionStoreService } from './selection-store.service';
 import { ServerStoreService } from './server-store.service';
+import { ServerService } from './server.service';
 import { ToastService } from './toast.service';
 
 @Injectable({ providedIn: 'root' })
@@ -40,6 +41,7 @@ export class UiCommandHandlerService {
   private readonly pathService = inject(PathService);
   private readonly toastService = inject(ToastService);
   private readonly translateService = inject(TranslateService);
+  private readonly serverService = inject(ServerService);
   private readonly electronService = inject(ElectronService);
   private readonly qbService = inject(QbService);
   private readonly serverStoreService = inject(ServerStoreService);
@@ -356,6 +358,7 @@ export class UiCommandHandlerService {
           name,
         }),
       );
+      this.serverService.setActive(this.serverStoreService.currentServerId());
     } finally {
       appLoaderModal.close();
     }

--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -1,9 +1,11 @@
 import { DestroyRef, Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateService } from '@ngx-translate/core';
 import { filter } from 'rxjs';
 import { About } from '../components/about/about';
 import { AddTorrent } from '../components/add-torrent/add-torrent';
+import { AppLoader } from '../components/app-loader/app-loader';
 import { DeleteTorrent } from '../components/modals/delete-torrent/delete-torrent';
 import { ManageCategories } from '../components/modals/manage-categories/manage-categories';
 import { ManageServers } from '../components/modals/manage-servers/manage-servers';
@@ -37,6 +39,7 @@ export class UiCommandHandlerService {
   private readonly selectionStoreService = inject(SelectionStoreService);
   private readonly pathService = inject(PathService);
   private readonly toastService = inject(ToastService);
+  private readonly translateService = inject(TranslateService);
   private readonly electronService = inject(ElectronService);
   private readonly qbService = inject(QbService);
   private readonly serverStoreService = inject(ServerStoreService);
@@ -301,10 +304,61 @@ export class UiCommandHandlerService {
             manageServersModalRef.result.then(() => {}).catch(() => {});
             break;
 
+          case 'UI_SERVER_SWITCH':
+            this.handleServerSwitch(command.id);
+            break;
+
           default:
             console.warn(UiCommandHandlerService.name, 'start', 'Unhandled UI command', command);
         }
       });
+  }
+
+  private async handleServerSwitch(serverId: string): Promise<void> {
+    const server = this.serverStoreService.servers().find((s) => s.id === serverId);
+    const name = server?.name || '';
+
+    this.toastService.info(
+      this.translateService.instant('services.menu-bar-command-handler.info.switching-server', {
+        name,
+      }),
+    );
+
+    const appLoaderModal = this.modalService.open(AppLoader, { size: 'sm', centered: true });
+    appLoaderModal.componentInstance.title = this.translateService.instant(
+      'services.menu-bar-command-handler.app-loader.title',
+    );
+    appLoaderModal.componentInstance.message = this.translateService.instant(
+      'services.menu-bar-command-handler.app-loader.message',
+      { name },
+    );
+
+    try {
+      const hasSession = await this.qbService.hasCookie(serverId);
+
+      if (!hasSession) {
+        const loginRes = await this.qbService.login(serverId);
+        if (!loginRes.loggedIn) {
+          throw new Error('Login failed');
+        }
+      }
+
+      (this.serverStoreService as any).select(serverId);
+    } catch (err) {
+      console.error(
+        UiCommandHandlerService.name,
+        'handleServerSwitch',
+        'Failed to switch servers',
+        err,
+      );
+      this.toastService.danger(
+        this.translateService.instant('services.menu-bar-command-handler.error.failed-to-connect', {
+          name,
+        }),
+      );
+    } finally {
+      appLoaderModal.close();
+    }
   }
 
   private uiCommandGuard(cmd: AppCommand): cmd is UiCommand {

--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -6,6 +6,7 @@ import { About } from '../components/about/about';
 import { AddTorrent } from '../components/add-torrent/add-torrent';
 import { DeleteTorrent } from '../components/modals/delete-torrent/delete-torrent';
 import { ManageCategories } from '../components/modals/manage-categories/manage-categories';
+import { ManageServers } from '../components/modals/manage-servers/manage-servers';
 import { ManageTags } from '../components/modals/manage-tags/manage-tags';
 import { RenameTorrent } from '../components/modals/rename-torrent/rename-torrent';
 import { ServerEditor } from '../components/modals/server-editor/server-editor';
@@ -292,6 +293,12 @@ export class UiCommandHandlerService {
               beforeDismiss: () => manageCategoriesModalRef.componentInstance.canDeactivate(),
             });
             manageCategoriesModalRef.result.then(() => {}).catch(() => {});
+            break;
+
+          case 'UI_MANAGE_SERVERS':
+            if (this.isModalOpen(ManageServers)) break;
+            const manageServersModalRef = this.modalService.open(ManageServers);
+            manageServersModalRef.result.then(() => {}).catch(() => {});
             break;
 
           default:

--- a/packages/app/src/styles.scss
+++ b/packages/app/src/styles.scss
@@ -1030,8 +1030,16 @@ html ngb-typeahead-window.dropdown-menu .dropdown-item:active {
   }
 }
 
+body {
+  user-select: none;
+}
+
 .user-select-none {
   user-select: none;
+}
+
+.user-select-text {
+  user-select: text;
 }
 
 .pointer-events-none {

--- a/packages/app/src/styles.scss
+++ b/packages/app/src/styles.scss
@@ -837,7 +837,6 @@ html ngb-typeahead-window.dropdown-menu .dropdown-item:active {
     text-decoration: none;
     vertical-align: middle;
     cursor: pointer;
-    user-select: none;
     transition:
       color 0.15s ease-in-out,
       background-color 0.15s ease-in-out,
@@ -990,7 +989,6 @@ html ngb-typeahead-window.dropdown-menu .dropdown-item:active {
   .form-check-label {
     margin-top: 1px;
     margin-left: 7px;
-    user-select: none;
   }
 }
 

--- a/packages/electron/src/ipc/server.ts
+++ b/packages/electron/src/ipc/server.ts
@@ -21,6 +21,7 @@ export function registerServerIpcHandlers(): void {
   ipcMain.handle('server:getByHost', async (_event, payload: unknown) => serverGetByHost(payload));
 
   ipcMain.on('server:set-active', (_event, id: string | null) => {
+    if (activeServerId === id) return;
     activeServerId = id;
     rebuildMenu();
     rebuildTrayMenu();

--- a/packages/electron/src/ipc/server.ts
+++ b/packages/electron/src/ipc/server.ts
@@ -21,11 +21,9 @@ export function registerServerIpcHandlers(): void {
   ipcMain.handle('server:getByHost', async (_event, payload: unknown) => serverGetByHost(payload));
 
   ipcMain.on('server:set-active', (_event, id: string | null) => {
-    if (activeServerId !== id) {
-      activeServerId = id;
-      rebuildMenu();
-      rebuildTrayMenu();
-    }
+    activeServerId = id;
+    rebuildMenu();
+    rebuildTrayMenu();
   });
 }
 

--- a/packages/electron/src/menu.ts
+++ b/packages/electron/src/menu.ts
@@ -31,7 +31,7 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
   }));
 
   const serverSubmenuItems: Electron.MenuItemConstructorOptions[] =
-    servers.length >= 2 ? [...serverMenuItems, { type: 'separator' }] : [];
+    servers.length > 0 ? [...serverMenuItems, { type: 'separator' }] : [];
 
   const loggedInItems: Electron.MenuItemConstructorOptions[] = loggedIn
     ? [
@@ -40,8 +40,8 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
           submenu: [
             ...serverSubmenuItems,
             {
-              label: t('electron.menu.add-new'),
-              click: () => sendMenuAction(mainWindow, 'server.add'),
+              label: t('electron.menu.manage-servers'),
+              click: () => sendMenuAction(mainWindow, 'server.manage'),
             },
           ],
         },

--- a/packages/electron/src/menu.ts
+++ b/packages/electron/src/menu.ts
@@ -30,27 +30,21 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
     click: () => sendMenuAction(mainWindow, 'server.select', { serverId: server.id }),
   }));
 
-  const serverSubmenuItems: Electron.MenuItemConstructorOptions[] =
-    servers.length > 0 ? [...serverMenuItems, { type: 'separator' }] : [];
-
   const loggedInItems: Electron.MenuItemConstructorOptions[] = loggedIn
     ? [
-        {
-          label: t('electron.menu.servers'),
-          submenu: [
-            ...serverSubmenuItems,
-            {
-              label: t('electron.menu.manage-servers'),
-              click: () => sendMenuAction(mainWindow, 'server.manage'),
-            },
-          ],
-        },
+        ...(servers.length > 0
+          ? [
+              {
+                label: t('electron.menu.servers'),
+                submenu: serverMenuItems,
+              },
+            ]
+          : []),
         {
           label: t('electron.menu.settings-menu'),
           submenu: [
             {
               label: t('electron.menu.app-settings'),
-              accelerator: 'Ctrl+,',
               click: () => sendMenuAction(mainWindow, 'settings.app'),
             },
             {
@@ -58,6 +52,10 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
               click: () => sendMenuAction(mainWindow, 'settings.qb'),
             },
             { type: 'separator' },
+            {
+              label: t('electron.menu.manage-servers'),
+              click: () => sendMenuAction(mainWindow, 'server.manage'),
+            },
             {
               label: t('electron.menu.manage-tags'),
               click: () => sendMenuAction(mainWindow, 'settings.manage-tags'),
@@ -78,7 +76,6 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
           submenu: [
             {
               label: 'Open DevTools',
-              accelerator: 'F12',
               click: () => getMainWindow()?.webContents.openDevTools({ mode: 'detach' }),
             },
             { type: 'separator' },
@@ -128,7 +125,6 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
                 { type: 'separator' },
                 {
                   label: 'Random',
-                  accelerator: 'Ctrl+.',
                   click: () => sendMenuAction(mainWindow, 'debug.toast.random'),
                 },
                 {
@@ -140,7 +136,6 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
             { type: 'separator' },
             {
               label: 'Reload',
-              accelerator: 'Ctrl+R',
               click: () => sendMenuAction(mainWindow, 'debug.reload'),
             },
           ],
@@ -158,7 +153,6 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
           submenu: [
             {
               label: t('electron.menu.add-torrent-from-file'),
-              accelerator: 'Ctrl+O',
               click: () => sendMenuAction(mainWindow, 'file.addTorrent.file'),
             },
             {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -595,7 +595,8 @@
           "hint": "Vesszővel elválasztott lista használatával egyszerre több cimkét is hozzáadhatsz"
         },
         "filter": {
-          "placeholder": "Cimkék szűrése..."
+          "placeholder": "Cimkék szűrése...",
+          "no-match": "Egy cimke sem felel meg a szűrőnek."
         },
         "empty": "Még nincsenek cimkék.",
         "delete-confirm": {
@@ -613,7 +614,8 @@
       "manage-servers": {
         "title": "Szerverek kezelése",
         "filter": {
-          "placeholder": "Szerverek szűrése..."
+          "placeholder": "Szerverek szűrése...",
+          "no-match": "Egy szerver sem felel meg a szűrőnek."
         },
         "empty": "Nincsenek konfigurált szerverek.",
         "button": {
@@ -636,7 +638,8 @@
           "save-path": "Mentési útvonal (opcionális)"
         },
         "filter": {
-          "placeholder": "Kategóriák szűrése..."
+          "placeholder": "Kategóriák szűrése...",
+          "no-match": "Egy kategória sem felel meg a szűrőnek."
         },
         "list": {
           "no-save-path": "Nincs mentési útvonal"

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -616,6 +616,14 @@
           "placeholder": "Szerverek szűrése..."
         },
         "empty": "Nincsenek konfigurált szerverek.",
+        "button": {
+          "connect": "Csatlakozás"
+        },
+        "tooltip": {
+          "active": "Jelenleg aktív szerver",
+          "cannot-edit": "Az aktív szerver nem szerkeszthető",
+          "cannot-delete": "Az aktív szerver nem törölhető"
+        },
         "delete-confirm": {
           "title": "Szerver törlése",
           "message": "Biztosan törölni szeretnéd a \"{{ name }}\" szervert?"

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -610,6 +610,17 @@
           "delete-failed": "Nem sikerült törölni a \"{{ name }}\" cimkét."
         }
       },
+      "manage-servers": {
+        "title": "Szerverek kezelése",
+        "filter": {
+          "placeholder": "Szerverek szűrése..."
+        },
+        "empty": "Nincsenek konfigurált szerverek.",
+        "delete-confirm": {
+          "title": "Szerver törlése",
+          "message": "Biztosan törölni szeretnéd a \"{{ name }}\" szervert?"
+        }
+      },
       "manage-categories": {
         "title": "Kategóriák kezelése",
         "add-form": {
@@ -1358,6 +1369,7 @@
       "qb-settings": "qBittorrent beállítások",
       "manage-tags": "Cimkék kezelése",
       "manage-categories": "Kategóriák kezelése",
+      "manage-servers": "Szerverek kezelése...",
       "help": "Súgó",
       "check-for-updates": "Frissítések keresése",
       "about": "A BitButlerről"

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -622,9 +622,7 @@
           "connect": "Csatlakozás"
         },
         "tooltip": {
-          "active": "Jelenleg aktív szerver",
-          "cannot-edit": "Az aktív szerver nem szerkeszthető",
-          "cannot-delete": "Az aktív szerver nem törölhető"
+          "active": "Jelenleg aktív szerver"
         },
         "delete-confirm": {
           "title": "Szerver törlése",
@@ -752,11 +750,11 @@
           "bottom": "Legalulra",
           "settings-group": "Beállítások",
           "manage-group": "Kezelés",
-          "manage-servers": "Szerverek kezelése",
-          "manage-tags": "Cimkék kezelése",
-          "manage-categories": "Kategóriák kezelése",
-          "settings": "BitButler Beállítások",
-          "qb-settings": "qBittorrent Beállítások"
+          "manage-servers": "Szerverek",
+          "manage-tags": "Cimkék",
+          "manage-categories": "Kategóriák",
+          "settings": "BitButler",
+          "qb-settings": "qBittorrent"
         },
         "search-form": {
           "search": "Keresés..."
@@ -1380,11 +1378,11 @@
       "servers": "Szerverek",
       "add-new": "Új hozzáadása…",
       "settings-menu": "Beállítások",
-      "app-settings": "Alkalmazás beállítások",
+      "app-settings": "BitButler beállítások",
       "qb-settings": "qBittorrent beállítások",
       "manage-tags": "Cimkék kezelése",
       "manage-categories": "Kategóriák kezelése",
-      "manage-servers": "Szerverek kezelése...",
+      "manage-servers": "Szerverek kezelése",
       "help": "Súgó",
       "check-for-updates": "Frissítések keresése",
       "about": "A BitButlerről"

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -751,6 +751,10 @@
           "down": "Le",
           "bottom": "Legalulra",
           "settings-group": "Beállítások",
+          "manage-group": "Kezelés",
+          "manage-servers": "Szerverek kezelése",
+          "manage-tags": "Cimkék kezelése",
+          "manage-categories": "Kategóriák kezelése",
           "settings": "BitButler Beállítások",
           "qb-settings": "qBittorrent Beállítások"
         },

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -616,6 +616,14 @@
           "placeholder": "Filter servers..."
         },
         "empty": "No servers configured.",
+        "button": {
+          "connect": "Connect"
+        },
+        "tooltip": {
+          "active": "Currently active server",
+          "cannot-edit": "Cannot edit the active server",
+          "cannot-delete": "Cannot delete the active server"
+        },
         "delete-confirm": {
           "title": "Delete Server",
           "message": "Are you sure you want to delete the server \"{{ name }}\"?"

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -610,6 +610,17 @@
           "delete-failed": "Failed to delete tag \"{{ name }}\"."
         }
       },
+      "manage-servers": {
+        "title": "Manage Servers",
+        "filter": {
+          "placeholder": "Filter servers..."
+        },
+        "empty": "No servers configured.",
+        "delete-confirm": {
+          "title": "Delete Server",
+          "message": "Are you sure you want to delete the server \"{{ name }}\"?"
+        }
+      },
       "manage-categories": {
         "title": "Manage Categories",
         "add-form": {
@@ -1358,6 +1369,7 @@
       "qb-settings": "qBittorrent Settings",
       "manage-tags": "Manage Tags",
       "manage-categories": "Manage Categories",
+      "manage-servers": "Manage Servers...",
       "help": "Help",
       "check-for-updates": "Check for Updates",
       "about": "About BitButler"

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -595,7 +595,8 @@
           "hint": "Use comma separated list to add multiple tags in one go"
         },
         "filter": {
-          "placeholder": "Filter tags..."
+          "placeholder": "Filter tags...",
+          "no-match": "No tags match your filter."
         },
         "empty": "No tags yet.",
         "delete-confirm": {
@@ -613,7 +614,8 @@
       "manage-servers": {
         "title": "Manage Servers",
         "filter": {
-          "placeholder": "Filter servers..."
+          "placeholder": "Filter servers...",
+          "no-match": "No servers match your filter."
         },
         "empty": "No servers configured.",
         "button": {
@@ -636,7 +638,8 @@
           "save-path": "Save path (optional)"
         },
         "filter": {
-          "placeholder": "Filter categories..."
+          "placeholder": "Filter categories...",
+          "no-match": "No categories match your filter."
         },
         "list": {
           "no-save-path": "No save path"

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -752,7 +752,11 @@
           "bottom": "Bottom",
           "settings-group": "Settings",
           "settings": "BitButler Settings",
-          "qb-settings": "qBittorrent Settings"
+          "qb-settings": "qBittorrent Settings",
+          "manage-group": "Manage",
+          "manage-servers": "Manage Servers",
+          "manage-tags": "Manage Tags",
+          "manage-categories": "Manage Categories"
         },
         "search-form": {
           "search": "Search..."

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -622,9 +622,7 @@
           "connect": "Connect"
         },
         "tooltip": {
-          "active": "Currently active server",
-          "cannot-edit": "Cannot edit the active server",
-          "cannot-delete": "Cannot delete the active server"
+          "active": "Currently active server"
         },
         "delete-confirm": {
           "title": "Delete Server",
@@ -751,12 +749,12 @@
           "down": "Down",
           "bottom": "Bottom",
           "settings-group": "Settings",
-          "settings": "BitButler Settings",
-          "qb-settings": "qBittorrent Settings",
+          "settings": "BitButler",
+          "qb-settings": "qBittorrent",
           "manage-group": "Manage",
-          "manage-servers": "Manage Servers",
-          "manage-tags": "Manage Tags",
-          "manage-categories": "Manage Categories"
+          "manage-servers": "Servers",
+          "manage-tags": "Tags",
+          "manage-categories": "Categories"
         },
         "search-form": {
           "search": "Search..."
@@ -1380,11 +1378,11 @@
       "servers": "Servers",
       "add-new": "Add new…",
       "settings-menu": "Settings",
-      "app-settings": "App Settings",
+      "app-settings": "BitButler Settings",
       "qb-settings": "qBittorrent Settings",
       "manage-tags": "Manage Tags",
       "manage-categories": "Manage Categories",
-      "manage-servers": "Manage Servers...",
+      "manage-servers": "Manage Servers",
       "help": "Help",
       "check-for-updates": "Check for Updates",
       "about": "About BitButler"


### PR DESCRIPTION
## Issue ID

Fixes #102

## Description

- Adds a Manage Servers modal accessible from the button bar and Electron menu
- Active server row hides edit/delete actions instead of showing disabled buttons
- Server editor defaults the set-as-default switch to false if another server already has auto_login, true otherwise
- Adds a Manage group to the button bar with Servers, Tags and Categories
- Reorganizes the Electron menu: Manage Servers, Tags and Categories grouped under Settings; Servers menu hidden when no servers are configured
- Removes all keyboard accelerators from the Electron menu
- Simplifies button bar submenu labels by removing redundant prefixes