### PR TITLE
Fix share limit defaults and show inactive seeding time limit when adding torrents

### DIFF
--- a/packages/app/src/app/components/add-torrent/add-torrent.html
+++ b/packages/app/src/app/components/add-torrent/add-torrent.html
@@ -302,7 +302,7 @@
           </div>
 
           <div class="col-12">
-            <app-share-limit formControlName="shareLimits" [hideInactive]="true"></app-share-limit>
+            <app-share-limit formControlName="shareLimits"></app-share-limit>
           </div>
         </div>
       </div>

--- a/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
@@ -1,6 +1,7 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import type { TorrentDraft } from '../../models/torrent-draft.model';
 import { AddTorrentSettingsService } from '../../services/add-torrent-settings.service';
 import { GeneralSettingsService } from '../../services/general-settings.service';
 import { OpenFilesService } from '../../services/open-files.service';
@@ -50,6 +51,7 @@ describe('AddTorrent', () => {
             renameTorrentFile: vi.fn(),
             renameTorrentFolder: vi.fn(),
             setFilePriority: vi.fn(),
+            setShareLimits: vi.fn().mockResolvedValue(undefined),
             getAllCategories: vi.fn().mockResolvedValue({}),
             getAllTags: vi.fn().mockResolvedValue([]),
             createTags: vi.fn().mockResolvedValue(undefined),
@@ -114,6 +116,50 @@ describe('AddTorrent', () => {
       mockOpenFilesService.pendingDrafts.set([{ draft: {}, selected: {} } as any]);
       component.handleCancel();
       expect(mockOpenFilesService.consumeCurrentDraft).toHaveBeenCalled();
+    });
+  });
+
+  describe('tryRenameContentAfterAdd', () => {
+    let mockQbService: any;
+    const hash = 'abcdef1234567890';
+    const draft: Partial<TorrentDraft> = { torrent: { infoHashV1: hash } as any };
+
+    beforeEach(() => {
+      mockQbService = TestBed.inject(QbService) as any;
+      component.manualDraft.set(draft as TorrentDraft);
+      mockQbService.torrentContents.mockResolvedValue([{ name: 'file.mkv', index: 0 }]);
+    });
+
+    it('should call setShareLimits when inactiveSeedingTimeLimit is no-limit (-1)', async () => {
+      await (component as any).tryRenameContentAfterAdd('server-1', {
+        ratioLimit: -2,
+        seedingTimeLimit: -2,
+        inactiveSeedingTimeLimit: -1,
+      });
+      expect(mockQbService.setShareLimits).toHaveBeenCalledWith('server-1', [hash], -2, -2, -1);
+    });
+
+    it('should call setShareLimits when inactiveSeedingTimeLimit is a custom value', async () => {
+      await (component as any).tryRenameContentAfterAdd('server-1', {
+        ratioLimit: 2,
+        seedingTimeLimit: 120,
+        inactiveSeedingTimeLimit: 60,
+      });
+      expect(mockQbService.setShareLimits).toHaveBeenCalledWith('server-1', [hash], 2, 120, 60);
+    });
+
+    it('should not call setShareLimits when inactiveSeedingTimeLimit is global (-2)', async () => {
+      await (component as any).tryRenameContentAfterAdd('server-1', {
+        ratioLimit: -2,
+        seedingTimeLimit: -2,
+        inactiveSeedingTimeLimit: -2,
+      });
+      expect(mockQbService.setShareLimits).not.toHaveBeenCalled();
+    });
+
+    it('should not call setShareLimits when shareLimits is null', async () => {
+      await (component as any).tryRenameContentAfterAdd('server-1', null);
+      expect(mockQbService.setShareLimits).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/app/src/app/components/add-torrent/add-torrent.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.ts
@@ -269,8 +269,10 @@ export class AddTorrent implements OnInit {
         const hasTreeCustomizations =
           state != null &&
           (state.renames.length > 0 || state.files.some((f) => (f.priority ?? 1) !== 1));
-        if (hasTreeCustomizations) {
-          await this.tryRenameContentAfterAdd(serverId);
+        const inactiveLimit = raw.shareLimits?.inactiveSeedingTimeLimit ?? null;
+        const needsInactivePost = inactiveLimit !== null && inactiveLimit !== -2;
+        if (hasTreeCustomizations || needsInactivePost) {
+          await this.tryRenameContentAfterAdd(serverId, raw.shareLimits);
         }
       }
 
@@ -438,7 +440,10 @@ export class AddTorrent implements OnInit {
     this.showTree.set(!!draft.torrent?.files?.length);
   }
 
-  private async tryRenameContentAfterAdd(serverId: string): Promise<void> {
+  private async tryRenameContentAfterAdd(
+    serverId: string,
+    shareLimits?: ShareLimitValue | null,
+  ): Promise<void> {
     const hash = this.effectiveDraft()?.torrent?.infoHashV1?.trim();
     if (!hash) return;
 
@@ -478,6 +483,19 @@ export class AddTorrent implements OnInit {
               await this.qbService.setFilePriority(serverId, hash, [index], f.priority ?? 0);
             }
           }
+        }
+      }
+
+      if (shareLimits != null) {
+        const inactiveLimit = shareLimits.inactiveSeedingTimeLimit;
+        if (inactiveLimit !== null && inactiveLimit !== -2) {
+          await this.qbService.setShareLimits(
+            serverId,
+            [hash],
+            shareLimits.ratioLimit ?? -2,
+            shareLimits.seedingTimeLimit ?? -2,
+            inactiveLimit,
+          );
         }
       }
     } catch (error) {

--- a/packages/app/src/app/components/share-limit/share-limit.html
+++ b/packages/app/src/app/components/share-limit/share-limit.html
@@ -1,4 +1,4 @@
-<div [formGroup]="form" class="d-flex flex-column gap-2">
+<div [formGroup]="form" class="d-flex flex-column gap-2 pb-3">
   <div class="limit-row">
     <div class="form-check mb-0 text-nowrap">
       <input
@@ -136,76 +136,74 @@
     }
   </div>
 
-  @if (!hideInactive) {
-    <div class="limit-row">
+  <div class="limit-row">
+    <div class="form-check mb-0 text-nowrap">
+      <input
+        class="form-check-input"
+        type="radio"
+        name="inactiveMode"
+        id="inactiveModeCustom"
+        [checked]="inactiveMode() === 'custom'"
+        (change)="setInactiveMode('custom')"
+      />
+    </div>
+
+    <div class="form-floating">
+      <input
+        type="number"
+        class="form-control"
+        id="inactiveSeedingTimeLimit"
+        placeholder="0"
+        formControlName="inactiveSeedingTimeLimit"
+        min="0"
+      />
+      <label for="inactiveSeedingTimeLimit">
+        {{ 'components.share-limit.inactive-seeding-time-limit' | translate }}
+      </label>
+    </div>
+
+    <div class="d-flex flex-column gap-1">
       <div class="form-check mb-0 text-nowrap">
         <input
           class="form-check-input"
           type="radio"
           name="inactiveMode"
-          id="inactiveModeCustom"
-          [checked]="inactiveMode() === 'custom'"
-          (change)="setInactiveMode('custom')"
+          id="inactiveModeGlobal"
+          [checked]="inactiveMode() === 'global'"
+          (change)="setInactiveMode('global')"
         />
-      </div>
-
-      <div class="form-floating">
-        <input
-          type="number"
-          class="form-control"
-          id="inactiveSeedingTimeLimit"
-          placeholder="0"
-          formControlName="inactiveSeedingTimeLimit"
-          min="0"
-        />
-        <label for="inactiveSeedingTimeLimit">
-          {{ 'components.share-limit.inactive-seeding-time-limit' | translate }}
+        <label class="form-check-label" for="inactiveModeGlobal">
+          {{ 'general.limit.global' | translate }}
         </label>
       </div>
 
-      <div class="d-flex flex-column gap-1">
-        <div class="form-check mb-0 text-nowrap">
-          <input
-            class="form-check-input"
-            type="radio"
-            name="inactiveMode"
-            id="inactiveModeGlobal"
-            [checked]="inactiveMode() === 'global'"
-            (change)="setInactiveMode('global')"
-          />
-          <label class="form-check-label" for="inactiveModeGlobal">
-            {{ 'general.limit.global' | translate }}
-          </label>
-        </div>
-
-        <div class="form-check mb-0 text-nowrap">
-          <input
-            class="form-check-input"
-            type="radio"
-            name="inactiveMode"
-            id="inactiveModeNoLimit"
-            [checked]="inactiveMode() === 'no-limit'"
-            (change)="setInactiveMode('no-limit')"
-          />
-          <label class="form-check-label" for="inactiveModeNoLimit">
-            {{ 'general.limit.no-limit' | translate }}
-          </label>
-        </div>
+      <div class="form-check mb-0 text-nowrap">
+        <input
+          class="form-check-input"
+          type="radio"
+          name="inactiveMode"
+          id="inactiveModeNoLimit"
+          [checked]="inactiveMode() === 'no-limit'"
+          (change)="setInactiveMode('no-limit')"
+        />
+        <label class="form-check-label" for="inactiveModeNoLimit">
+          {{ 'general.limit.no-limit' | translate }}
+        </label>
       </div>
-
-      <bb-popover
-        [subject]="'components.share-limit.popover.inactive-seeding-time-limit.title' | translate"
-        [description]="
-          'components.share-limit.popover.inactive-seeding-time-limit.description' | translate
-        "
-        placement="top"
-      ></bb-popover>
-
-      @if (inactiveMode() === 'custom' && form.controls.inactiveSeedingTimeLimit.value !== null) {
-        <div class="form-text ms-1 limit-row__helper">
-          {{ form.controls.inactiveSeedingTimeLimit.value | timeLimit }}
-        </div>
-      }
     </div>
-  }
+
+    <bb-popover
+      [subject]="'components.share-limit.popover.inactive-seeding-time-limit.title' | translate"
+      [description]="
+        'components.share-limit.popover.inactive-seeding-time-limit.description' | translate
+      "
+      placement="top"
+    ></bb-popover>
+
+    @if (inactiveMode() === 'custom' && form.controls.inactiveSeedingTimeLimit.value !== null) {
+      <div class="form-text ms-1 limit-row__helper">
+        {{ form.controls.inactiveSeedingTimeLimit.value | timeLimit }}
+      </div>
+    }
+  </div>
 </div>

--- a/packages/app/src/app/components/share-limit/share-limit.ts
+++ b/packages/app/src/app/components/share-limit/share-limit.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectorRef,
   Component,
-  Input,
   OnInit,
   WritableSignal,
   forwardRef,
@@ -42,8 +41,6 @@ export type ShareLimitValue = {
   ],
 })
 export class ShareLimit implements ControlValueAccessor, OnInit {
-  @Input() public hideInactive = false;
-
   private readonly cdr = inject(ChangeDetectorRef);
 
   public form = new FormGroup({

--- a/packages/app/src/app/models/add-torrent.model.ts
+++ b/packages/app/src/app/models/add-torrent.model.ts
@@ -28,5 +28,5 @@ export const DEFAULT_ADD_TORRENT_SETTINGS: AddTorrentSettings = {
   firstLastPiecePrio: false,
   autoTMM: false,
   transferRateLimits: null,
-  shareLimits: null,
+  shareLimits: { ratioLimit: -2, seedingTimeLimit: -2, inactiveSeedingTimeLimit: -2 },
 };


### PR DESCRIPTION
## Issue ID

Fixes #106

## Description

The share limit component in the add-torrent dialog previously defaulted to **no-limit** for all three limit fields, which was misleading - qBittorrent's actual default when adding a torrent without explicit limits is to apply the global limits. Additionally, the inactive seeding time limit field was hidden in the add-torrent context because the qBittorrent add API does not support it in a single step.

**Changes:**

- Changed the default `shareLimits` in `DEFAULT_ADD_TORRENT_SETTINGS` from `null` (no-limit) to `{ ratioLimit: -2, seedingTimeLimit: -2, inactiveSeedingTimeLimit: -2 }` (global) so the add-torrent form correctly reflects qBittorrent's behavior out of the box
- Removed the `hideInactive` input from the `ShareLimit` component entirely - the inactive seeding time limit row is now always visible
- The post-add wait (polling for the torrent to appear in the queue) now also triggers when `inactiveSeedingTimeLimit` is set to anything other than global (`-2`), and calls `setShareLimits` once the torrent is confirmed present
- Added `pb-3` bottom padding to the share-limit component to prevent the last row from sitting flush against the fieldset border
- Added `setShareLimits` to the `QbService` mock in `add-torrent.spec.ts` and added 4 new tests covering the post-add `inactiveSeedingTimeLimit` behavior