### PR TITLE
Update deprecated GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
           disable-autolabeler: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
     name: '[1/6] Lint & Tests'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -46,8 +46,8 @@ jobs:
       version: ${{ steps.bump.outputs.version }}
       raw_version: ${{ steps.bump.outputs.raw_version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -66,7 +66,7 @@ jobs:
           echo "raw_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload versioned package files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: versioned-packages
           # electron-builder reads root package.json for the app version
@@ -81,8 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [bump-version]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -92,14 +92,14 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
 
       - name: Apply bumped package versions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: versioned-packages
 
       - run: npm run build:ui
 
       - name: Upload Angular build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: angular-dist
           path: dist/
@@ -121,8 +121,8 @@ jobs:
             target: --win
             job_name: 'Windows'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -136,12 +136,12 @@ jobs:
           sudo apt-get install -y rpm
 
       - name: Apply bumped package versions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: versioned-packages
 
       - name: Download Angular build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: angular-dist
           path: dist/
@@ -153,7 +153,7 @@ jobs:
         run: npx electron-builder ${{ matrix.target }}
 
       - name: Upload packaged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: electron-dist-${{ matrix.os }}
           path: dist-electron/
@@ -168,7 +168,7 @@ jobs:
     outputs:
       commit_sha: ${{ steps.commit.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Apply bumped package versions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: versioned-packages
 
@@ -201,22 +201,22 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: electron-dist-ubuntu-latest
           path: dist-electron/
 
       - name: Download Windows artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: electron-dist-windows-latest
           path: dist-electron/
 
       - name: Draft release notes
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v7
         with:
           tag: ${{ needs.bump-version.outputs.raw_version }}
           name: BitButler ${{ needs.bump-version.outputs.raw_version }}
@@ -228,7 +228,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.bump-version.outputs.raw_version }}
           files: |


### PR DESCRIPTION
## Issue ID

Fixes #108

## Description

Updates all deprecated GitHub Actions in the release workflow that were running on Node.js 20. These actions will be forced to Node.js 24 by default starting June 2, 2026, and Node.js 20 will be removed from runners on September 16, 2026.

### Changes in \`.github/workflows/release.yml\`
- \`actions/checkout@v4\` → \`@v6\`
- \`actions/setup-node@v4\` → \`@v6\`
- \`actions/upload-artifact@v4\` → \`@v7\`
- \`actions/download-artifact@v4\` → \`@v8\`
- \`release-drafter/release-drafter@v5\` → \`@v7\`
- \`softprops/action-gh-release@v2\` → \`@v3\`

### Changes in \`.github/workflows/release-drafter.yml\`
- \`release-drafter/release-drafter@v6\` → \`@v7\`