### PR TITLE
Reset start minimized toggle when open at login is disabled

### DIFF
--- a/packages/app/src/app/pages/settings/general/general.ts
+++ b/packages/app/src/app/pages/settings/general/general.ts
@@ -191,6 +191,7 @@ export class General implements SettingsTabComponent {
         if (value && this.hasDefaultServer()) {
           ctrl.enable({ emitEvent: false });
         } else {
+          ctrl.setValue(false, { emitEvent: false });
           ctrl.disable({ emitEvent: false });
         }
       });


### PR DESCRIPTION
## Issue ID

Fixes #113

## Description

When the user disables the "Start with the system" toggle while "Start minimized" is enabled, the `startMinimized` form control was only being disabled but not reset to `false`. This caused the UI to show the toggle as visually checked (even though it was grayed out), which was misleading.

The fix adds a `setValue(false)` call before disabling the control, so the toggle correctly reflects its effective value in the UI immediately when the user flips "Start with the system" off.