### PR TITLE
Skip maximize on login when window is hidden by start minimized

### DIFF
--- a/packages/app/src/app/pages/main/main.spec.ts
+++ b/packages/app/src/app/pages/main/main.spec.ts
@@ -22,6 +22,10 @@ describe('Main', () => {
     currentServerId: ReturnType<typeof signal<string | null>>;
     refresh: ReturnType<typeof vi.fn>;
   };
+  let windowMock: {
+    maximize: ReturnType<typeof vi.fn>;
+    state: ReturnType<typeof signal<{ isMinimized: boolean }>>;
+  };
 
   beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
@@ -39,17 +43,7 @@ describe('Main', () => {
     });
   });
 
-  beforeEach(async () => {
-    themeMock = {
-      family: signal('bitbutler'),
-      effectiveMode: signal<'dark' | 'light'>('dark'),
-    };
-    serverStoreMock = {
-      currentServer: signal(null),
-      currentServerId: signal(null),
-      refresh: vi.fn().mockResolvedValue(undefined),
-    };
-
+  async function createComponent(): Promise<void> {
     await TestBed.configureTestingModule({
       imports: [Main],
       providers: [
@@ -60,7 +54,7 @@ describe('Main', () => {
           useValue: { startMaindataPolling: vi.fn().mockReturnValue(new Subject()) },
         },
         { provide: TorrentStoreService, useValue: { applyMaindata: vi.fn() } },
-        { provide: WindowService, useValue: { maximize: vi.fn() } },
+        { provide: WindowService, useValue: windowMock },
         {
           provide: TorrentListGridSettingsService,
           useValue: { asObservable: vi.fn().mockReturnValue(new Subject().asObservable()) },
@@ -74,33 +68,68 @@ describe('Main', () => {
     fixture = TestBed.createComponent(Main);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    themeMock = {
+      family: signal('bitbutler'),
+      effectiveMode: signal<'dark' | 'light'>('dark'),
+    };
+    serverStoreMock = {
+      currentServer: signal(null),
+      currentServerId: signal(null),
+      refresh: vi.fn().mockResolvedValue(undefined),
+    };
+    windowMock = {
+      maximize: vi.fn(),
+      state: signal({ isMinimized: false }),
+    };
   });
 
-  it('should create', () => {
+  it('should create', async () => {
+    await createComponent();
     expect(component).toBeTruthy();
   });
 
+  describe('maximize on login', () => {
+    it('should call maximize when window is not minimized', async () => {
+      windowMock.state.set({ isMinimized: false });
+      await createComponent();
+      expect(windowMock.maximize).toHaveBeenCalled();
+    });
+
+    it('should skip maximize when window is minimized (startMinimized mode)', async () => {
+      windowMock.state.set({ isMinimized: true });
+      await createComponent();
+      expect(windowMock.maximize).not.toHaveBeenCalled();
+    });
+  });
+
   describe('logoUrl', () => {
-    it('should build the URL from the current theme family', () => {
+    it('should build the URL from the current theme family', async () => {
+      await createComponent();
       themeMock.family.set('aurora');
       expect(component.logoUrl()).toBe('assets/images/bitbutler-logo-aurora.png');
     });
   });
 
   describe('theme', () => {
-    it('should be the effectiveMode signal from ThemeService', () => {
+    it('should be the effectiveMode signal from ThemeService', async () => {
+      await createComponent();
       expect(component.theme).toBe(themeMock.effectiveMode);
     });
   });
 
   describe('currentServer', () => {
-    it('should be the currentServer signal from ServerStoreService', () => {
+    it('should be the currentServer signal from ServerStoreService', async () => {
+      await createComponent();
       expect(component.currentServer).toBe(serverStoreMock.currentServer);
     });
   });
 
   describe('serverState', () => {
-    it('should be null initially', () => {
+    it('should be null initially', async () => {
+      await createComponent();
       expect(component.serverState()).toBeNull();
     });
   });

--- a/packages/app/src/app/pages/main/main.ts
+++ b/packages/app/src/app/pages/main/main.ts
@@ -80,7 +80,9 @@ export class Main implements OnDestroy {
   });
 
   constructor() {
-    this.windowService.maximize();
+    if (!this.windowService.state().isMinimized) {
+      this.windowService.maximize();
+    }
     this.serverStoreService.refresh();
   }
 

--- a/packages/electron/src/main-window.ts
+++ b/packages/electron/src/main-window.ts
@@ -100,5 +100,7 @@ export function createMainWindow(startMinimized = false): BrowserWindow {
     sendWindowState();
   });
 
+  mainWindow.webContents.once('did-finish-load', sendWindowState);
+
   return mainWindow;
 }

--- a/packages/electron/src/preload.ts
+++ b/packages/electron/src/preload.ts
@@ -7,6 +7,11 @@ import type {
 } from '@bitbutler/shared';
 import { contextBridge, ipcRenderer } from 'electron';
 
+let cachedWindowState: WindowState | null = null;
+ipcRenderer.on('window:state-change', (_event, state) => {
+  cachedWindowState = state as WindowState;
+});
+
 function makeIpcSubscription<T>(
   channel: string,
   mapPayload: (payload: unknown) => T,
@@ -92,8 +97,19 @@ const api: BitButlerAPI = {
         callback,
       ),
 
-    onStateChange: (callback) =>
-      makeIpcSubscription('window:state-change', (state) => state as WindowState, callback),
+    onStateChange: (callback) => {
+      const unsubscribe = makeIpcSubscription(
+        'window:state-change',
+        (state) => state as WindowState,
+        callback,
+      );
+      if (cachedWindowState) {
+        try {
+          callback(cachedWindowState);
+        } catch {}
+      }
+      return unsubscribe;
+    },
 
     drainOpenFiles: () => ipcRenderer.invoke('window:open-files:drain'),
     drainOpenTorrents: () => ipcRenderer.invoke('window:open-torrents:drain'),


### PR DESCRIPTION
## Issue ID

Fixes #112

## Description

When "start minimized" is enabled, Electron creates the main window with `show: false` (hidden). Previously, the `Main` component always called `windowService.maximize()` in its constructor, which caused the hidden window to become visible and maximized immediately after login.

The fix uses the existing `WindowState.isMinimized` signal, which already maps hidden windows to `isMinimized: true` (`mainWindow.isMinimized() || !mainWindow.isVisible()`). `Main` now skips `maximize()` when the window is minimized/hidden.

To make the state signal reliable at the time `Main` constructs, two small Electron-side changes ensure the actual window state reaches Angular before login completes:

- `main-window.ts`: sends the window state once on `did-finish-load`, so Angular receives it before the user can log in.
- `preload.ts`: caches the last received `window:state-change` message at module level (before Angular bootstraps) and replays it synchronously to late subscribers, eliminating the timing gap between the IPC push and `WindowService` registering its listener.

Subsequent logins after logout work correctly because the window is already visible by then, so `isMinimized` is `false` and `maximize()` is called as before.