### PR TITLE
Fix toast edge gap to match side offset for all corner positions

### DIFF
--- a/packages/app/src/app/components/toast-overlay/toast-overlay.scss
+++ b/packages/app/src/app/components/toast-overlay/toast-overlay.scss
@@ -105,8 +105,7 @@
   align-items: flex-start;
 }
 
-.bb-toast-pos-bottom-left,
-.bb-toast-pos-top-left {
+.bb-toast-pos-bottom-left {
   .bb-toast-wrapper.bb-toast-closing {
     animation: slide-out-left-and-collapse 350ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
   }
@@ -136,6 +135,71 @@
 .bb-toast-pos-top-right,
 .bb-toast-pos-top-left {
   flex-direction: column-reverse;
+
+  .bb-toast-wrapper {
+    animation: wrapper-push-down 250ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  }
+}
+
+.bb-toast-pos-top-right {
+  .bb-toast-wrapper.bb-toast-closing {
+    animation: slide-out-top-and-collapse 350ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  }
+}
+
+.bb-toast-pos-top-left {
+  .bb-toast-wrapper.bb-toast-closing {
+    animation: slide-out-top-left-and-collapse 350ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  }
+}
+
+@keyframes wrapper-push-down {
+  to {
+    grid-template-rows: 1fr;
+    margin-bottom: 8px;
+  }
+}
+
+@keyframes slide-out-top-and-collapse {
+  0% {
+    grid-template-rows: 1fr;
+    margin-bottom: 8px;
+    opacity: 1;
+    transform: translateX(0);
+  }
+  50% {
+    grid-template-rows: 1fr;
+    margin-bottom: 8px;
+    opacity: 0;
+    transform: translateX(50px);
+  }
+  100% {
+    grid-template-rows: 0fr;
+    margin-bottom: 0;
+    opacity: 0;
+    transform: translateX(50px);
+  }
+}
+
+@keyframes slide-out-top-left-and-collapse {
+  0% {
+    grid-template-rows: 1fr;
+    margin-bottom: 8px;
+    opacity: 1;
+    transform: translateX(0);
+  }
+  50% {
+    grid-template-rows: 1fr;
+    margin-bottom: 8px;
+    opacity: 0;
+    transform: translateX(-50px);
+  }
+  100% {
+    grid-template-rows: 0fr;
+    margin-bottom: 0;
+    opacity: 0;
+    transform: translateX(-50px);
+  }
 }
 
 .bb-toast-pos-top-right,

--- a/packages/app/src/styles/themes/_theme-utils.scss
+++ b/packages/app/src/styles/themes/_theme-utils.scss
@@ -72,7 +72,6 @@
     border-radius: var(--bb-control-radius);
     color: var(--bs-body-color);
     box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
-    margin-bottom: 1rem;
     overflow: hidden;
 
     .bb-toast-header {


### PR DESCRIPTION
## Issue ID

Fixes #116

## Description

The toast overlay was positioned farther from the bottom/top window edge than from the side edge. Two root causes were identified and fixed:

**Bottom positions (`bottom-right`, `bottom-left`):**
The `.bb-toast` element had `margin-bottom: 1rem` (16px) applied via the `bb-install-toast-variants` mixin. Since the toast is a grid item inside `.bb-toast-wrapper`, this margin inflated the wrapper's height, pushing the toast's visible bottom 16px above the CDK overlay anchor point. The effective bottom gap was 25px + 16px = 41px vs the expected 25px side gap.

**Top positions (`top-right`, `top-left`):**
The `wrapper-push-up` animation ends with `margin-top: 8px`. In `flex-direction: column-reverse`, this margin sits between the topmost toast and the container's top edge, adding 8px to the effective top gap (33px vs 25px).

**Fix:**
- Removed `margin-bottom: 1rem` from `.bb-toast` in `_theme-utils.scss` - inter-toast spacing is already handled by `margin-top: 8px` on the wrapper.
- Added a `wrapper-push-down` animation for top positions that uses `margin-bottom: 8px` instead of `margin-top: 8px`. In `column-reverse`, `margin-bottom` creates spacing between stacked toasts while leaving the topmost toast's top edge flush with the container's anchor point.
- Added matching close animations (`slide-out-top-and-collapse`, `slide-out-top-left-and-collapse`) for top positions that collapse `margin-bottom` instead of `margin-top`.
- Separated the `bottom-left` and `top-left` close animation overrides since they now use different animations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)