### PR TITLE
File tree input field fills available space with rename validation

### DIFF
--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -100,14 +100,25 @@
       @if (!editMode()) {
         <span class="bb-name">{{ node.name }}</span>
       } @else {
-        <input
-          class="bb-input"
-          [(ngModel)]="node.name"
-          (click)="$event.stopPropagation()"
-          (change)="onFolderNameChange(node)"
-          (keydown.enter)="onRenameEnter($event, node, 'folder')"
-          (keydown.escape)="onEscapeInInput($event)"
-        />
+        <div class="bb-input-wrapper">
+          <input
+            class="bb-input"
+            [class.bb-input--invalid]="getControl(node).invalid && getControl(node).dirty"
+            [formControl]="getControl(node)"
+            (click)="$event.stopPropagation()"
+            (keydown.enter)="onRenameEnter($event)"
+            (keydown.escape)="onEscapeInInput($event)"
+          />
+          @if (getControl(node).invalid && getControl(node).dirty) {
+            <fa-icon
+              class="bb-input-error-icon"
+              [icon]="icon.faCircleExclamation"
+              [ngbTooltip]="getControlError(getControl(node))"
+              tooltipClass="single-line-tooltip danger"
+              placement="top"
+            />
+          }
+        </div>
 
         <div class="bb-meta">
           <ng-select
@@ -165,14 +176,26 @@
           >{{ node.name }}</span
         >
       } @else {
-        <input
-          class="bb-input"
-          data-testid="file-rename-input"
-          [attr.data-testid-file]="node.name"
-          [(ngModel)]="node.name"
-          (keydown.enter)="onRenameEnter($event, node, 'file')"
-          (keydown.escape)="onEscapeInInput($event)"
-        />
+        <div class="bb-input-wrapper">
+          <input
+            class="bb-input"
+            data-testid="file-rename-input"
+            [attr.data-testid-file]="node.name"
+            [class.bb-input--invalid]="getControl(node).invalid && getControl(node).dirty"
+            [formControl]="getControl(node)"
+            (keydown.enter)="onRenameEnter($event)"
+            (keydown.escape)="onEscapeInInput($event)"
+          />
+          @if (getControl(node).invalid && getControl(node).dirty) {
+            <fa-icon
+              class="bb-input-error-icon"
+              [icon]="icon.faCircleExclamation"
+              [ngbTooltip]="getControlError(getControl(node))"
+              tooltipClass="single-line-tooltip danger"
+              placement="top"
+            />
+          }
+        </div>
       }
 
       @if (showMeta() && node.file; as f) {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
@@ -116,8 +116,17 @@
   padding-left: 0.25rem;
 }
 
+.bb-input-wrapper {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 .bb-input {
   flex: 1;
+  min-width: 0;
   background: var(--bb-control-bg);
   border: 1px solid var(--bb-control-border);
   border-radius: 6px;
@@ -125,12 +134,27 @@
   font-size: 0.85rem;
   padding: 2px 8px;
   outline: none;
-  max-width: 400px;
 
   &:focus {
     border-color: var(--bb-control-focus-border);
     box-shadow: 0 0 0 2px var(--bb-control-focus-ring);
   }
+
+  &--invalid {
+    border-color: var(--bs-danger);
+
+    &:focus {
+      border-color: var(--bs-danger);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--bs-danger) 25%, transparent);
+    }
+  }
+}
+
+.bb-input-error-icon {
+  color: var(--bs-danger);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  cursor: default;
 }
 
 .bb-meta {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -10,10 +10,10 @@ import {
   output,
   signal,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TorrentFileEntry } from '@bitbutler/shared';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faCheck, faEdit, faX } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faCircleExclamation, faEdit, faX } from '@fortawesome/free-solid-svg-icons';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -35,12 +35,15 @@ export type FileTreeSaveEvent = {
   renames: { oldPath: string; newPath: string }[];
 };
 
+const INVALID_FILENAME_CHARS = /^[^<>:"/\\|?*\x00-\x1f]+$/;
+
 @Component({
   selector: 'app-bb-file-tree',
   standalone: true,
   imports: [
     CdkTreeModule,
     FormsModule,
+    ReactiveFormsModule,
     FilesizePipe,
     BbProgress,
     NgbTooltipModule,
@@ -68,6 +71,7 @@ export class BbFileTree {
   @ViewChild(CdkTree) private tree!: CdkTree<BbFileTreeNode>;
 
   public editMode = signal(false);
+  public nameControls = new Map<string, FormControl<string>>();
   private originalFiles: TorrentFileEntry[] = [];
   private autoEditTriggered = false;
   private sessionDirty = false;
@@ -100,7 +104,7 @@ export class BbFileTree {
     },
   ];
 
-  public icon = { faEdit, faCheck, faX };
+  public icon = { faEdit, faCheck, faX, faCircleExclamation };
 
   trackByPath = (_index: number, node: BbFileTreeNode): string => node.fullPath;
 
@@ -182,19 +186,65 @@ export class BbFileTree {
     this.sessionDirty = false;
     this.originalFiles = structuredClone(this.files());
     this.folderPriorityMemory.clear();
+    this.buildFormControls(this.data);
     this.editMode.set(true);
     this.editModeChange.emit(true);
   }
 
+  private buildFormControls(nodes: BbFileTreeNode[]): void {
+    this.nameControls = new Map<string, FormControl<string>>();
+    this.addControlsForNodes(nodes);
+  }
+
+  private addControlsForNodes(nodes: BbFileTreeNode[]): void {
+    for (const node of nodes) {
+      this.nameControls.set(
+        node.fullPath,
+        new FormControl(node.name, {
+          nonNullable: true,
+          validators: [Validators.required, Validators.pattern(INVALID_FILENAME_CHARS)],
+        }),
+      );
+      if (node.children) this.addControlsForNodes(node.children);
+    }
+  }
+
+  private applyControlValues(nodes: BbFileTreeNode[]): void {
+    for (const node of nodes) {
+      const control = this.nameControls.get(node.fullPath);
+      if (control) node.name = control.value;
+      if (node.children) this.applyControlValues(node.children);
+    }
+  }
+
+  private hasInvalidControls(): boolean {
+    return Array.from(this.nameControls.values()).some((c) => c.invalid);
+  }
+
+  public getControl(node: BbFileTreeNode): FormControl<string> {
+    return this.nameControls.get(node.fullPath)!;
+  }
+
+  public getControlError(control: FormControl<string>): string {
+    if (control.hasError('required')) {
+      return this.translateService.instant('components.bb-file-tree.validation.required');
+    }
+    if (control.hasError('pattern')) {
+      return this.translateService.instant('components.bb-file-tree.validation.pattern');
+    }
+    return '';
+  }
+
   public async cancelEdit(): Promise<void> {
-    if (this.sessionDirty) {
+    const isDirty =
+      this.sessionDirty || Array.from(this.nameControls.values()).some((c) => c.dirty);
+    if (isDirty) {
       const confirmed = await this.confirmService.confirm(
         'components.bb-file-tree.confirm.cancel.title',
         'components.bb-file-tree.confirm.cancel.message',
       );
       if (!confirmed) return;
     }
-    // Restore names mutated by ngModel (input events) before CDK re-renders with reused node objects
     this.restoreNodeNames(this.data);
     const files = this.files();
     for (let i = 0; i < this.originalFiles.length && i < files.length; i++) {
@@ -208,6 +258,7 @@ export class BbFileTree {
     this.calculateStats();
     if (this.expandAll()) this.expandAllNodes();
     else this.restoreExpansionState(this.data, expandedPaths);
+    this.nameControls.clear();
     this.originalFiles = [];
     this.folderPriorityMemory.clear();
     this.sessionDirty = false;
@@ -216,11 +267,18 @@ export class BbFileTree {
   }
 
   public saveEdit(): void {
+    if (this.hasInvalidControls()) {
+      this.nameControls.forEach((c) => c.markAsDirty());
+      return;
+    }
+    this.applyControlValues(this.data);
     const files = this.flatten(this.data, '');
     const renames = this.collectRenames(this.data, '');
     this.saved.emit({ files, renames });
+    this.nameControls.clear();
     this.originalFiles = [];
     this.folderPriorityMemory.clear();
+    this.sessionDirty = false;
     this.editMode.set(false);
     this.editModeChange.emit(false);
   }
@@ -296,10 +354,8 @@ export class BbFileTree {
     this.calculateStats();
   }
 
-  onRenameEnter(event: Event, node: BbFileTreeNode, type: 'file' | 'folder'): void {
+  onRenameEnter(event: Event): void {
     event.preventDefault();
-    if (type === 'file') this.onFileNameChange(node);
-    else this.onFolderNameChange(node);
     this.saveEdit();
   }
 
@@ -307,36 +363,6 @@ export class BbFileTree {
     event.stopPropagation();
     event.preventDefault();
     await this.cancelEdit();
-  }
-
-  onFileNameChange(node: BbFileTreeNode): void {
-    const { oldPath, newPath } = this.deriveRenamePayload(node);
-    if (oldPath === newPath) return;
-    node.fullPath = newPath;
-    this.sessionDirty = true;
-  }
-
-  onFolderNameChange(node: BbFileTreeNode): void {
-    const { oldPath, newPath } = this.deriveRenamePayload(node);
-    if (oldPath === newPath) return;
-    node.fullPath = newPath;
-    this.updateChildPaths(node.children ?? [], oldPath, newPath);
-    this.sessionDirty = true;
-  }
-
-  private deriveRenamePayload(node: BbFileTreeNode): { oldPath: string; newPath: string } {
-    const oldPath = node.fullPath;
-    const slashIdx = oldPath.lastIndexOf('/');
-    const parentPath = slashIdx >= 0 ? oldPath.slice(0, slashIdx) : '';
-    const newPath = parentPath ? `${parentPath}/${node.name}` : node.name;
-    return { oldPath, newPath };
-  }
-
-  private updateChildPaths(nodes: BbFileTreeNode[], oldPrefix: string, newPrefix: string): void {
-    for (const child of nodes) {
-      child.fullPath = newPrefix + child.fullPath.slice(oldPrefix.length);
-      if (child.children) this.updateChildPaths(child.children, oldPrefix, newPrefix);
-    }
   }
 
   hasChild = (_: number, node: BbFileTreeNode) => !!node.children?.length;

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -354,6 +354,18 @@ export class BbFileTree {
     this.calculateStats();
   }
 
+  onFileNameChange(node: BbFileTreeNode): void {
+    this.sessionDirty = true;
+    const control = this.nameControls.get(node.fullPath);
+    if (control) control.setValue(node.name);
+  }
+
+  onFolderNameChange(node: BbFileTreeNode): void {
+    this.sessionDirty = true;
+    const control = this.nameControls.get(node.fullPath);
+    if (control) control.setValue(node.name);
+  }
+
   onRenameEnter(event: Event): void {
     event.preventDefault();
     this.saveEdit();

--- a/packages/app/src/styles.scss
+++ b/packages/app/src/styles.scss
@@ -873,44 +873,38 @@ html ngb-typeahead-window.dropdown-menu .dropdown-item:active {
 }
 
 .tooltip {
-  &.danger {
-    --bs-tooltip-bg: var(--bs-danger);
-    --bs-tooltip-color: var(--bb-danger-ink);
-  }
+  @each $variant in danger, success, primary, secondary, warning, info, light, dark {
+    &.#{$variant} {
+      .tooltip-inner {
+        background-color: var(--bs-#{$variant}) !important;
+        color: var(--bb-#{$variant}-ink) !important;
+        border-color: var(--bs-#{$variant}) !important;
+      }
 
-  &.success {
-    --bs-tooltip-bg: var(--bs-success);
-    --bs-tooltip-color: var(--bb-success-ink);
-  }
+      &.bs-tooltip-top .tooltip-arrow::before,
+      &.bs-tooltip-auto[x-placement^='top'] .tooltip-arrow::before {
+        border-top-color: var(--bs-#{$variant}) !important;
+        filter: none;
+      }
 
-  &.primary {
-    --bs-tooltip-bg: var(--bs-primary);
-    --bs-tooltip-color: var(--bb-primary-ink);
-  }
+      &.bs-tooltip-bottom .tooltip-arrow::before,
+      &.bs-tooltip-auto[x-placement^='bottom'] .tooltip-arrow::before {
+        border-bottom-color: var(--bs-#{$variant}) !important;
+        filter: none;
+      }
 
-  &.secondary {
-    --bs-tooltip-bg: var(--bs-secondary);
-    --bs-tooltip-color: var(--bb-secondary-ink);
-  }
+      &.bs-tooltip-start .tooltip-arrow::before,
+      &.bs-tooltip-auto[x-placement^='left'] .tooltip-arrow::before {
+        border-left-color: var(--bs-#{$variant}) !important;
+        filter: none;
+      }
 
-  &.warning {
-    --bs-tooltip-bg: var(--bs-warning);
-    --bs-tooltip-color: var(--bb-warning-ink);
-  }
-
-  &.info {
-    --bs-tooltip-bg: var(--bs-info);
-    --bs-tooltip-color: var(--bb-info-ink);
-  }
-
-  &.light {
-    --bs-tooltip-bg: var(--bs-light);
-    --bs-tooltip-color: var(--bb-light-ink);
-  }
-
-  &.dark {
-    --bs-tooltip-bg: var(--bs-dark);
-    --bs-tooltip-color: var(--bb-dark-ink);
+      &.bs-tooltip-end .tooltip-arrow::before,
+      &.bs-tooltip-auto[x-placement^='right'] .tooltip-arrow::before {
+        border-right-color: var(--bs-#{$variant}) !important;
+        filter: none;
+      }
+    }
   }
 }
 

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -155,6 +155,10 @@
           "title": "Változtatások elvetése",
           "message": "Nem mentett változtatásaid vannak. Biztosan elveted őket?"
         }
+      },
+      "validation": {
+        "required": "A név nem lehet üres",
+        "pattern": "A név érvénytelen karaktereket tartalmaz (< > : \" / \\ | ? *)"
       }
     },
     "bb-popover": {},

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -155,6 +155,10 @@
           "title": "Discard changes",
           "message": "You have unsaved changes. Are you sure you want to discard them?"
         }
+      },
+      "validation": {
+        "required": "Name cannot be empty",
+        "pattern": "Name contains invalid characters (< > : \" / \\ | ? *)"
       }
     },
     "bb-popover": {},


### PR DESCRIPTION
## Issue ID

Fixes #118

## Description

<img width="1442" height="427" alt="image" src="https://github.com/user-attachments/assets/0910981d-6993-4b3f-9bdd-984cb491d375" />

- Remove the `max-width: 400px` cap from `.bb-input` so rename inputs fill all available horizontal space
- Refactor `bb-file-tree` from template-driven (`ngModel`) to reactive forms, building a flat `Map<string, FormControl>` keyed by node path on entering edit mode
- Add `required` and `pattern` validators to every rename input, blocking empty names and Windows-invalid filename characters (`< > : " / \ | ? *`)
- Wrap each rename input in `.bb-input-wrapper` (flex row); show a red border and a `faCircleExclamation` icon to the right when the control is dirty and invalid
- Error icon uses `ngbTooltip` with `tooltipClass="single-line-tooltip danger"` to show the specific validation message on hover
- Fix colored tooltip variants (`danger`, `success`, `warning`, etc.) which were silently broken - CSS variable approach was overridden by `!important` rules; replaced with a SCSS `@each` loop using per-placement `border-color` overrides and proper specificity
- Add `components.bb-file-tree.validation.required` and `.pattern` i18n keys to `us.json` and `hu.json`