### PR TITLE
Refactor save-path component to support dropdown and typeahead modes

### DIFF
--- a/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
@@ -2,6 +2,8 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { TorrentDraft } from '@bitbutler/shared';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { of } from 'rxjs';
+import { DEFAULT_GENERAL_SETTINGS } from '../../models/general-settings.model';
 import { AddTorrentSettingsService } from '../../services/add-torrent-settings.service';
 import { GeneralSettingsService } from '../../services/general-settings.service';
 import { OpenFilesService } from '../../services/open-files.service';
@@ -40,7 +42,10 @@ describe('AddTorrent', () => {
         },
         {
           provide: GeneralSettingsService,
-          useValue: { load: vi.fn().mockResolvedValue({ behavior: { deleteTorrentFile: false } }) },
+          useValue: {
+            load: vi.fn().mockResolvedValue({ behavior: { deleteTorrentFile: false } }),
+            asObservable: vi.fn().mockReturnValue(of(DEFAULT_GENERAL_SETTINGS)),
+          },
         },
         {
           provide: QbService,

--- a/packages/app/src/app/components/save-path-select/save-path-select.html
+++ b/packages/app/src/app/components/save-path-select/save-path-select.html
@@ -1,31 +1,56 @@
 @let resolvedLabel = label() ?? ('components.save-path-select.label' | translate);
+
 @if (showPopover()) {
   <div class="container-fluid px-0">
     <div class="row">
       <div class="col-11">
-        <div class="form-floating">
-          <ng-select
-            data-testid="save-path-select-input"
-            [items]="paths()"
-            [addTag]="addTag"
-            [searchable]="true"
-            [clearable]="clearable()"
-            [clearOnBackspace]="false"
-            [editableSearchTerm]="true"
-            [formControl]="selectControl"
-            [keyDownFn]="keyDownFn"
-            [markFirst]="true"
-            [openOnEnter]="false"
-            [appendTo]="appendTo()"
-            [placeholder]="placeholder() ?? defaultPath()"
-            [fixedPlaceholder]="false"
-            (search)="resetHighlight()"
-            (open)="resetHighlight()"
-            #ngselect
-          >
-          </ng-select>
-          <label>{{ resolvedLabel }}</label>
-        </div>
+        @if (resolvedInputType() === 'typeahead') {
+          <div class="form-floating bb-filter-input">
+            <input
+              type="text"
+              class="form-control"
+              [placeholder]="placeholder() || defaultPath() || ' '"
+              [formControl]="selectControl"
+              [ngbTypeahead]="typeaheadService.searchSavePaths"
+              [editable]="true"
+              [focusFirst]="false"
+              autocomplete="off"
+              #typeaheadInput
+            />
+            <label>{{ resolvedLabel }}</label>
+            @if (controlValue()) {
+              <button
+                type="button"
+                class="bb-filter-clear"
+                (click)="clearValue()"
+                aria-label="Clear"
+              >
+                <fa-icon [icon]="icons.faXmark"></fa-icon>
+              </button>
+            }
+          </div>
+        } @else {
+          <div class="form-floating">
+            <ng-select
+              data-testid="save-path-select-input"
+              [items]="paths()"
+              [addTag]="addTag"
+              [searchable]="true"
+              [clearable]="clearable()"
+              [clearOnBackspace]="false"
+              [editableSearchTerm]="true"
+              [formControl]="selectControl"
+              [keyDownFn]="keyDownFn"
+              [openOnEnter]="false"
+              [appendTo]="appendTo()"
+              [placeholder]="placeholder() ?? defaultPath()"
+              [fixedPlaceholder]="false"
+              #ngselect
+            >
+            </ng-select>
+            <label>{{ resolvedLabel }}</label>
+          </div>
+        }
       </div>
 
       <div class="col-1 d-flex align-items-center">
@@ -38,29 +63,48 @@
     </div>
   </div>
 } @else {
-  <div class="form-floating">
-    <ng-select
-      data-testid="save-path-select-input"
-      [items]="paths()"
-      [addTag]="addTag"
-      [searchable]="true"
-      [clearable]="clearable()"
-      [clearOnBackspace]="false"
-      [editableSearchTerm]="true"
-      [formControl]="selectControl"
-      [keyDownFn]="keyDownFn"
-      [markFirst]="true"
-      [openOnEnter]="false"
-      [appendTo]="appendTo()"
-      [placeholder]="placeholder() ?? defaultPath()"
-      [fixedPlaceholder]="false"
-      (search)="resetHighlight()"
-      (open)="resetHighlight()"
-      #ngselect
-    >
-    </ng-select>
-    <label>{{ resolvedLabel }}</label>
-  </div>
+  @if (resolvedInputType() === 'typeahead') {
+    <div class="form-floating bb-filter-input">
+      <input
+        type="text"
+        class="form-control"
+        [placeholder]="placeholder() || defaultPath() || ' '"
+        [formControl]="selectControl"
+        [ngbTypeahead]="typeaheadService.searchSavePaths"
+        [editable]="true"
+        [focusFirst]="false"
+        autocomplete="off"
+        #typeaheadInput
+      />
+      <label>{{ resolvedLabel }}</label>
+      @if (controlValue()) {
+        <button type="button" class="bb-filter-clear" (click)="clearValue()" aria-label="Clear">
+          <fa-icon [icon]="icons.faXmark"></fa-icon>
+        </button>
+      }
+    </div>
+  } @else {
+    <div class="form-floating">
+      <ng-select
+        data-testid="save-path-select-input"
+        [items]="paths()"
+        [addTag]="addTag"
+        [searchable]="true"
+        [clearable]="clearable()"
+        [clearOnBackspace]="false"
+        [editableSearchTerm]="true"
+        [formControl]="selectControl"
+        [keyDownFn]="keyDownFn"
+        [openOnEnter]="false"
+        [appendTo]="appendTo()"
+        [placeholder]="placeholder() ?? defaultPath()"
+        [fixedPlaceholder]="false"
+        #ngselect
+      >
+      </ng-select>
+      <label>{{ resolvedLabel }}</label>
+    </div>
+  }
 }
 
 <ng-template #savePathPopover>

--- a/packages/app/src/app/components/save-path-select/save-path-select.ts
+++ b/packages/app/src/app/components/save-path-select/save-path-select.ts
@@ -2,32 +2,47 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  ViewChild,
+  ElementRef,
   afterNextRender,
   computed,
   forwardRef,
   inject,
   input,
   signal,
+  viewChild,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import {
   ControlValueAccessor,
   FormControl,
   NG_VALUE_ACCESSOR,
   ReactiveFormsModule,
 } from '@angular/forms';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe } from '@ngx-translate/core';
+import { DEFAULT_GENERAL_SETTINGS, SavePathInputType } from '../../models/general-settings.model';
+import { GeneralSettingsService } from '../../services/general-settings.service';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
 import { TorrentStoreService } from '../../services/torrent-store.service';
 import { BbPopover } from '../bb-popover/bb-popover';
+import { SavePathTypeaheadService } from './save-path-typeahead.service';
 
 @Component({
   selector: 'app-save-path-select',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, NgSelectComponent, TranslatePipe, BbPopover],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    NgSelectComponent,
+    NgbTypeahead,
+    FontAwesomeModule,
+    TranslatePipe,
+    BbPopover,
+  ],
   templateUrl: './save-path-select.html',
   styleUrls: ['./save-path-select.scss'],
   providers: [
@@ -36,6 +51,7 @@ import { BbPopover } from '../bb-popover/bb-popover';
       useExisting: forwardRef(() => SavePathSelect),
       multi: true,
     },
+    SavePathTypeaheadService,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -46,11 +62,26 @@ export class SavePathSelect implements ControlValueAccessor {
   readonly label = input<string | null>(null);
   readonly placeholder = input<string | null>(null);
   readonly appendTo = input('');
-  @ViewChild('ngselect') ngselect!: NgSelectComponent;
+  readonly inputType = input<SavePathInputType | null>(null);
+
+  private readonly ngselect = viewChild<NgSelectComponent>('ngselect');
+  private readonly typeaheadInput = viewChild<ElementRef<HTMLInputElement>>('typeaheadInput');
 
   private readonly torrentStoreService = inject(TorrentStoreService);
   private readonly qbService = inject(QbService);
   private readonly serverStoreService = inject(ServerStoreService);
+  private readonly generalSettingsService = inject(GeneralSettingsService);
+  public readonly typeaheadService = inject(SavePathTypeaheadService);
+
+  public readonly icons = { faXmark };
+
+  private readonly generalSettings = toSignal(this.generalSettingsService.asObservable(), {
+    initialValue: DEFAULT_GENERAL_SETTINGS,
+  });
+
+  public readonly resolvedInputType = computed(
+    () => this.inputType() ?? this.generalSettings().savePath.inputType,
+  );
 
   public paths = computed(
     () => {
@@ -66,6 +97,10 @@ export class SavePathSelect implements ControlValueAccessor {
 
   public defaultPath = signal<string>('');
   public selectControl = new FormControl<string | null>(null);
+
+  public readonly controlValue = toSignal(this.selectControl.valueChanges, {
+    initialValue: this.selectControl.value,
+  });
 
   private onChange: (value: string | null) => void = () => {};
   private onTouched: () => void = () => {};
@@ -90,7 +125,8 @@ export class SavePathSelect implements ControlValueAccessor {
 
     afterNextRender(() => {
       if (this.autofocus()) {
-        this.ngselect.focus();
+        this.ngselect()?.focus();
+        this.typeaheadInput()?.nativeElement.focus();
       }
     });
   }
@@ -117,8 +153,8 @@ export class SavePathSelect implements ControlValueAccessor {
 
   addTag = (term: string): string => term;
 
-  public resetHighlight(): void {
-    this.ngselect.itemsList.unmarkItem();
+  public clearValue(): void {
+    this.selectControl.setValue(null);
   }
 
   keyDownFn(event: KeyboardEvent): boolean {

--- a/packages/app/src/app/components/save-path-select/save-path-typeahead.service.spec.ts
+++ b/packages/app/src/app/components/save-path-select/save-path-typeahead.service.spec.ts
@@ -1,0 +1,68 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, of } from 'rxjs';
+import { Torrent } from '../../models/torrent.model';
+import { TorrentStoreService } from '../../services/torrent-store.service';
+import { SavePathTypeaheadService } from './save-path-typeahead.service';
+
+const makeTorrents = (savePaths: string[]): Torrent[] =>
+  savePaths.map((p, i) => ({ hash: String(i), save_path: p }) as Torrent);
+
+describe('SavePathTypeaheadService', () => {
+  let service: SavePathTypeaheadService;
+  let torrentsSignal: ReturnType<typeof signal<Torrent[]>>;
+
+  beforeEach(() => {
+    torrentsSignal = signal<Torrent[]>([]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        SavePathTypeaheadService,
+        {
+          provide: TorrentStoreService,
+          useValue: { torrentsArray: torrentsSignal },
+        },
+      ],
+    });
+
+    service = TestBed.inject(SavePathTypeaheadService);
+  });
+
+  it('should return an empty array for empty search term', async () => {
+    torrentsSignal.set(makeTorrents(['/downloads', '/media']));
+    const results = await firstValueFrom(service.searchSavePaths(of('')));
+    expect(results).toEqual([]);
+  });
+
+  it('should filter save paths by search term', async () => {
+    torrentsSignal.set(makeTorrents(['/downloads/movies', '/downloads/music', '/media']));
+    const results = await firstValueFrom(service.searchSavePaths(of('downloads')));
+    expect(results).toHaveLength(2);
+    expect(results.every((p) => p.includes('downloads'))).toBe(true);
+  });
+
+  it('should be case-insensitive', async () => {
+    torrentsSignal.set(makeTorrents(['/Downloads/Movies']));
+    const results = await firstValueFrom(service.searchSavePaths(of('downloads')));
+    expect(results).toHaveLength(1);
+  });
+
+  it('should limit results to 5 entries', async () => {
+    torrentsSignal.set(makeTorrents(['/a/1', '/a/2', '/a/3', '/a/4', '/a/5', '/a/6', '/a/7']));
+    const results = await firstValueFrom(service.searchSavePaths(of('/a/')));
+    expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  it('should exclude paths that exactly match the search term', async () => {
+    torrentsSignal.set(makeTorrents(['/downloads', '/downloads/movies']));
+    const results = await firstValueFrom(service.searchSavePaths(of('/downloads')));
+    expect(results).not.toContain('/downloads');
+  });
+
+  it('should deduplicate save paths from multiple torrents', async () => {
+    torrentsSignal.set(makeTorrents(['/downloads', '/downloads', '/downloads/movies']));
+    const results = await firstValueFrom(service.searchSavePaths(of('down')));
+    const unique = new Set(results);
+    expect(unique.size).toBe(results.length);
+  });
+});

--- a/packages/app/src/app/components/save-path-select/save-path-typeahead.service.ts
+++ b/packages/app/src/app/components/save-path-select/save-path-typeahead.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { TorrentStoreService } from '../../services/torrent-store.service';
+
+@Injectable()
+export class SavePathTypeaheadService {
+  private readonly torrentStoreService = inject(TorrentStoreService);
+  private readonly resultSetSize = 5;
+
+  private readonly paths = computed(() => {
+    const uniquePaths = new Set<string>();
+    for (const t of this.torrentStoreService.torrentsArray()) {
+      const path = t.save_path?.trim();
+      if (path) uniquePaths.add(path);
+    }
+    return Array.from(uniquePaths);
+  });
+
+  public searchSavePaths = (text$: Observable<string>): Observable<string[]> =>
+    text$.pipe(
+      map((term) => {
+        const t = (term ?? '').trim().toLowerCase();
+        if (!t) return [];
+        return this.paths()
+          .sort()
+          .filter((p) => p.toLowerCase().includes(t) && p.toLowerCase() !== t)
+          .slice(0, this.resultSetSize);
+      }),
+    );
+}

--- a/packages/app/src/app/models/general-settings.model.ts
+++ b/packages/app/src/app/models/general-settings.model.ts
@@ -1,6 +1,7 @@
 import { ThemeFamily, ThemeMode } from '../services/theme.service';
 
 export type ToastPosition = 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left';
+export type SavePathInputType = 'select' | 'typeahead';
 
 export interface GeneralSettings {
   behavior: {
@@ -18,6 +19,9 @@ export interface GeneralSettings {
   startup: {
     openAtLogin: boolean;
     startMinimized: boolean;
+  };
+  savePath: {
+    inputType: SavePathInputType;
   };
 }
 
@@ -37,5 +41,8 @@ export const DEFAULT_GENERAL_SETTINGS: GeneralSettings = {
   startup: {
     openAtLogin: false,
     startMinimized: false,
+  },
+  savePath: {
+    inputType: 'select',
   },
 };

--- a/packages/app/src/app/pages/settings/general/general.html
+++ b/packages/app/src/app/pages/settings/general/general.html
@@ -333,7 +333,11 @@
               </div>
             </div>
             <div class="col-10">
-              <app-save-path-select [inputType]="'select'" [showPopover]="false" />
+              <app-save-path-select
+                [inputType]="'select'"
+                [showPopover]="false"
+                [clearable]="true"
+              />
             </div>
           </div>
           <div class="row mb-3">

--- a/packages/app/src/app/pages/settings/general/general.html
+++ b/packages/app/src/app/pages/settings/general/general.html
@@ -316,7 +316,7 @@
             </div>
           </div>
           <div class="row mb-3">
-            <div class="col-2 d-flex align-items-center">
+            <div class="col-6 d-flex align-items-center">
               <div class="form-check">
                 <input
                   class="form-check-input"
@@ -332,7 +332,7 @@
                 </label>
               </div>
             </div>
-            <div class="col-10">
+            <div class="col-6">
               <app-save-path-select
                 [inputType]="'select'"
                 [showPopover]="false"
@@ -341,7 +341,7 @@
             </div>
           </div>
           <div class="row mb-3">
-            <div class="col-2 d-flex align-items-center">
+            <div class="col-6 d-flex align-items-center">
               <div class="form-check">
                 <input
                   class="form-check-input"
@@ -358,7 +358,7 @@
                 </label>
               </div>
             </div>
-            <div class="col-10">
+            <div class="col-6">
               <app-save-path-select [inputType]="'typeahead'" [showPopover]="false" />
             </div>
           </div>

--- a/packages/app/src/app/pages/settings/general/general.html
+++ b/packages/app/src/app/pages/settings/general/general.html
@@ -5,6 +5,64 @@
         <div class="col-12">{{ 'pages.settings.tab.general.description' | translate }}</div>
       </div>
 
+      <fieldset class="bb-fieldset" formGroupName="startup">
+        <legend>{{ 'pages.settings.tab.general.label.startup' | translate }}</legend>
+
+        <div class="container">
+          <div class="row mb-3">
+            <div class="col-12">
+              <div class="form-check form-switch">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="open-at-login"
+                  formControlName="openAtLogin"
+                />
+                <label class="form-check-label" for="open-at-login">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.startup.open-at-login'
+                      | translate
+                  }}
+                  <bb-popover
+                    [subject]="'pages.settings.tab.general.popover.open-at-login.title' | translate"
+                    [description]="
+                      'pages.settings.tab.general.popover.open-at-login.description' | translate
+                    "
+                  ></bb-popover>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-12">
+              <div class="form-check form-switch">
+                <input
+                  class="form-check-input"
+                  type="checkbox"
+                  role="switch"
+                  id="start-minimized"
+                  formControlName="startMinimized"
+                />
+                <label class="form-check-label" for="start-minimized">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.startup.start-minimized'
+                      | translate
+                  }}
+                  <bb-popover
+                    [subject]="
+                      'pages.settings.tab.general.popover.start-minimized.title' | translate
+                    "
+                    [description]="
+                      'pages.settings.tab.general.popover.start-minimized.description' | translate
+                    "
+                  ></bb-popover>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
       <fieldset class="bb-fieldset" formGroupName="behavior">
         <legend>{{ 'pages.settings.tab.general.label.behavior' | translate }}</legend>
 
@@ -246,64 +304,6 @@
         </div>
       </fieldset>
 
-      <fieldset class="bb-fieldset" formGroupName="startup">
-        <legend>{{ 'pages.settings.tab.general.label.startup' | translate }}</legend>
-
-        <div class="container">
-          <div class="row mb-3">
-            <div class="col-12">
-              <div class="form-check form-switch">
-                <input
-                  class="form-check-input"
-                  type="checkbox"
-                  role="switch"
-                  id="open-at-login"
-                  formControlName="openAtLogin"
-                />
-                <label class="form-check-label" for="open-at-login">
-                  {{
-                    'pages.settings.tab.general.general-settings-form.startup.open-at-login'
-                      | translate
-                  }}
-                  <bb-popover
-                    [subject]="'pages.settings.tab.general.popover.open-at-login.title' | translate"
-                    [description]="
-                      'pages.settings.tab.general.popover.open-at-login.description' | translate
-                    "
-                  ></bb-popover>
-                </label>
-              </div>
-            </div>
-          </div>
-          <div class="row mb-3">
-            <div class="col-12">
-              <div class="form-check form-switch">
-                <input
-                  class="form-check-input"
-                  type="checkbox"
-                  role="switch"
-                  id="start-minimized"
-                  formControlName="startMinimized"
-                />
-                <label class="form-check-label" for="start-minimized">
-                  {{
-                    'pages.settings.tab.general.general-settings-form.startup.start-minimized'
-                      | translate
-                  }}
-                  <bb-popover
-                    [subject]="
-                      'pages.settings.tab.general.popover.start-minimized.title' | translate
-                    "
-                    [description]="
-                      'pages.settings.tab.general.popover.start-minimized.description' | translate
-                    "
-                  ></bb-popover>
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      </fieldset>
       <fieldset class="bb-fieldset" formGroupName="savePath">
         <legend>{{ 'pages.settings.tab.general.label.save-path-input' | translate }}</legend>
 

--- a/packages/app/src/app/pages/settings/general/general.html
+++ b/packages/app/src/app/pages/settings/general/general.html
@@ -304,6 +304,62 @@
           </div>
         </div>
       </fieldset>
+      <fieldset class="bb-fieldset" formGroupName="savePath">
+        <legend>{{ 'pages.settings.tab.general.label.save-path-input' | translate }}</legend>
+
+        <div class="container">
+          <div class="row mb-3">
+            <div class="col-12">
+              {{
+                'pages.settings.tab.general.general-settings-form.save-path.description' | translate
+              }}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-2 d-flex align-items-center">
+              <div class="form-check">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  id="save-path-select-radio"
+                  value="select"
+                  formControlName="inputType"
+                />
+                <label class="form-check-label" for="save-path-select-radio">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.save-path.select' | translate
+                  }}
+                </label>
+              </div>
+            </div>
+            <div class="col-10">
+              <app-save-path-select [inputType]="'select'" [showPopover]="false" />
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-2 d-flex align-items-center">
+              <div class="form-check">
+                <input
+                  class="form-check-input"
+                  type="radio"
+                  id="save-path-typeahead-radio"
+                  value="typeahead"
+                  formControlName="inputType"
+                />
+                <label class="form-check-label" for="save-path-typeahead-radio">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.save-path.typeahead'
+                      | translate
+                  }}
+                </label>
+              </div>
+            </div>
+            <div class="col-10">
+              <app-save-path-select [inputType]="'typeahead'" [showPopover]="false" />
+            </div>
+          </div>
+        </div>
+      </fieldset>
     </div>
   </form>
 } @else {

--- a/packages/app/src/app/pages/settings/general/general.ts
+++ b/packages/app/src/app/pages/settings/general/general.ts
@@ -24,7 +24,12 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { firstValueFrom, from, tap } from 'rxjs';
 import { BbPopover } from '../../../components/bb-popover/bb-popover';
 import { BbSpinner } from '../../../components/bb-spinner/bb-spinner';
-import { GeneralSettings, ToastPosition } from '../../../models/general-settings.model';
+import { SavePathSelect } from '../../../components/save-path-select/save-path-select';
+import {
+  GeneralSettings,
+  SavePathInputType,
+  ToastPosition,
+} from '../../../models/general-settings.model';
 import { CommandBusService } from '../../../services/command-bus.service';
 import { GeneralSettingsService } from '../../../services/general-settings.service';
 import { ServerStoreService } from '../../../services/server-store.service';
@@ -50,6 +55,7 @@ interface NgSelectItem {
     BbSpinner,
     BbPopover,
     TranslatePipe,
+    SavePathSelect,
   ],
   templateUrl: './general.html',
   styleUrl: './general.scss',
@@ -163,6 +169,9 @@ export class General implements SettingsTabComponent {
     startup: new FormGroup({
       openAtLogin: new FormControl({ value: false, disabled: true }, { nonNullable: true }),
       startMinimized: new FormControl({ value: false, disabled: true }, { nonNullable: true }),
+    }),
+    savePath: new FormGroup({
+      inputType: new FormControl<SavePathInputType>('select', { nonNullable: true }),
     }),
   });
 

--- a/packages/app/src/styles.scss
+++ b/packages/app/src/styles.scss
@@ -750,6 +750,10 @@ html ngb-typeahead-window.dropdown-menu .dropdown-item:active {
   border-color: color-mix(in srgb, var(--bb-check-color) 35%, var(--bs-border-color)) !important;
 }
 
+.form-check-input[type='radio'] {
+  background-color: var(--bb-control-bg) !important;
+}
+
 .form-check-input:checked,
 .form-check-input:indeterminate {
   background-color: var(--bb-check-color) !important;

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -981,13 +981,19 @@
             "startup": {
               "open-at-login": "Alkalmazás indítása a rendszerrel",
               "start-minimized": "Indítás minimalizálva"
+            },
+            "save-path": {
+              "description": "Válaszd ki, hogyan viselkedjenek a mentési útvonal mezők torrentek hozzáadásakor vagy áthelyezésekor.",
+              "select": "Legördülő",
+              "typeahead": "Szövegkiegészítős"
             }
           },
           "label": {
             "behavior": "Viselkedés",
             "language": "Nyelv",
             "appearance": "Megjelenés",
-            "startup": "Indítás"
+            "startup": "Indítás",
+            "save-path-input": "Mentési útvonal bevitel"
           },
           "position": {
             "top-left": "Bal felül",

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -984,8 +984,8 @@
             },
             "save-path": {
               "description": "Válaszd ki, hogyan viselkedjenek a mentési útvonal mezők torrentek hozzáadásakor vagy áthelyezésekor.",
-              "select": "Legördülő",
-              "typeahead": "Szövegkiegészítős"
+              "select": "ng-select",
+              "typeahead": "ngb-typeahead"
             }
           },
           "label": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -981,13 +981,19 @@
             "startup": {
               "open-at-login": "Start app with the system",
               "start-minimized": "Start minimized"
+            },
+            "save-path": {
+              "description": "Choose how save path fields behave when adding or moving torrents.",
+              "select": "Dropdown",
+              "typeahead": "Typeahead"
             }
           },
           "label": {
             "behavior": "Behavior",
             "language": "Language",
             "appearance": "Appearance",
-            "startup": "Startup"
+            "startup": "Startup",
+            "save-path-input": "Save Path Input"
           },
           "position": {
             "top-left": "Top Left",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -984,8 +984,8 @@
             },
             "save-path": {
               "description": "Choose how save path fields behave when adding or moving torrents.",
-              "select": "Dropdown",
-              "typeahead": "Typeahead"
+              "select": "ng-select",
+              "typeahead": "ngb-typeahead"
             }
           },
           "label": {


### PR DESCRIPTION
## Issue ID

Fixes #119

## Description

<img width="1471" height="347" alt="image" src="https://github.com/user-attachments/assets/4b7bd5e0-d467-49ce-a5cb-054554abae8b" />

Refactors the `SavePathSelect` component to support two input modes - `ng-select` (dropdown) and `ngb-typeahead` - selectable by the user in General Settings.

**`SavePathTypeaheadService`** (new, component-scoped):
- Provides `searchSavePaths` observable used by `ngbTypeahead`
- Filters existing torrent save paths against the typed term, limited to 5 results
- Not `providedIn: 'root'` - scoped to `SavePathSelect` via its `providers` array

**`SavePathSelect` component:**
- New `inputType` input (`'select' | 'typeahead' | null`) - when `null` (default), reads the preference from `GeneralSettingsService` so all instances automatically reflect the user's choice
- `resolvedInputType` computed signal: respects an explicit `inputType` binding first, falls back to the saved setting
- Typeahead mode renders a plain `<input>` with `ngbTypeahead` and a clear button using the existing `bb-filter-input` / `bb-filter-clear` pattern (FontAwesome `faXmark`, shown only when the field has a value)
- ng-select mode reverts the typeahead-like overrides from a previous PR (`[markFirst]`, `resetHighlight`) - restoring it to pure dropdown behaviour
- Autofocus works for both modes via `viewChild` signals

**`GeneralSettings` model:**
- Added `SavePathInputType = 'select' | 'typeahead'` type
- Added `savePath.inputType` field (default `'select'`)
- Existing saved settings without this field automatically receive the default on next load

**General Settings page:**
- New "Save Path Input" fieldset with two `col-6 / col-6` rows - each row has a radio button on the left and a live, non-wired preview of that mode on the right
- ng-select preview has `[clearable]="true"` to show off the clear button feature
- Radio buttons use `formControlName` and are persisted with the rest of general settings

**Global styles:**
- Added `.form-check-input[type='radio'] { background-color: var(--bb-control-bg) !important; }` (placed before the `:checked` rule) to fix radio button white background on dark themes