### PR TITLE
Save path: show default as placeholder in add-torrent; clearable remote path in server settings

### DIFF
--- a/docs/superpowers/plans/2026-06-04-save-path-placeholder-and-server-settings.md
+++ b/docs/superpowers/plans/2026-06-04-save-path-placeholder-and-server-settings.md
@@ -1,0 +1,439 @@
+# Save Path Placeholder & Server Settings Remote Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop pre-filling the add-torrent save path with the qBittorrent default; make the server settings remote path clearable and resolve empty remote to the default on save.
+
+**Architecture:** Two isolated changes. Task 1 is a single deletion in `add-torrent.ts ngOnInit()`. Task 2 injects `QbService` into the `Server` component, fetches the default path alongside the existing settings reload, and maps empty remote values to that default inside `save()`. No changes to `save-path-select` itself.
+
+**Tech Stack:** Angular 20 (zoneless, signals), Reactive Forms, Vitest
+
+---
+
+### Task 1: Add Torrent - remove default path pre-fill
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/add-torrent/add-torrent.spec.ts`
+- Modify: `packages/app/src/app/components/add-torrent/add-torrent.ts:181-207`
+
+---
+
+- [ ] **Step 1: Write the failing test**
+
+  Open `packages/app/src/app/components/add-torrent/add-torrent.spec.ts`.
+
+  Add this `describe` block after the existing `describe('tryRenameContentAfterAdd', ...)` block (before the closing `}` of the outer `describe`):
+
+  ```typescript
+  describe('ngOnInit savepath behaviour', () => {
+    it('should leave savepath null when AddTorrentSettings returns no savepath', async () => {
+      const addTorrentSettings = TestBed.inject(AddTorrentSettingsService) as any;
+      addTorrentSettings.load.mockResolvedValue({});
+
+      await component.ngOnInit();
+
+      expect(component.addForm.controls.savepath.value).toBeNull();
+    });
+  });
+  ```
+
+  The existing mock for `QbService.getAppPreferences` returns `{ save_path: '/downloads' }`. With the current code, `ngOnInit` will pre-fill `savepath` with `'/downloads'`, so this test will **fail**.
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+  ```
+  npm test
+  ```
+
+  Expected: the new test fails with something like `expected '/downloads' to be null`.
+
+- [ ] **Step 3: Remove the pre-fill block**
+
+  In `packages/app/src/app/components/add-torrent/add-torrent.ts`, find `ngOnInit()` (around line 181) and delete the entire block that fetches the default when `savepath` is missing. After the edit the method should look like this:
+
+  ```typescript
+  public async ngOnInit(): Promise<void> {
+    const settings = (await this.addTorrentSettings.load()) as any;
+
+    for (const [k, v] of Object.entries(settings)) {
+      const ctrl = this.addForm.get(k);
+      if (ctrl && !ctrl.dirty) {
+        if (k === 'tags' && typeof v === 'string') {
+          ctrl.patchValue(
+            v.split(',').map((t) => t.trim()),
+            { emitEvent: false },
+          );
+        } else {
+          ctrl.patchValue(v as any, { emitEvent: false });
+        }
+      }
+    }
+  }
+  ```
+
+  The deleted lines were:
+
+  ```typescript
+  const serverId = this.serverStoreService.currentServerId();
+
+  if (!settings.savepath && serverId) {
+    try {
+      const prefs = await this.qbService.getAppPreferences(serverId);
+      settings.savepath = prefs.save_path;
+    } catch (err) {
+      console.error(AddTorrent.name, `ngOnInit`, `Failed to get app preferences`, err);
+    }
+  }
+  ```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+  ```
+  npm test
+  ```
+
+  Expected: all tests pass, including the new `should leave savepath null...` test.
+
+- [ ] **Step 5: Commit**
+
+  ```
+  git add packages/app/src/app/components/add-torrent/add-torrent.ts packages/app/src/app/components/add-torrent/add-torrent.spec.ts
+  git commit -m "#125: remove default savepath pre-fill in add-torrent ngOnInit"
+  ```
+
+---
+
+### Task 2: Server Settings - clearable remote path with default fallback
+
+**Files:**
+
+- Modify: `packages/app/src/app/pages/settings/server/server.spec.ts`
+- Modify: `packages/app/src/app/pages/settings/server/server.ts`
+- Modify: `packages/app/src/app/pages/settings/server/server.html:153-161`
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+  Open `packages/app/src/app/pages/settings/server/server.spec.ts`.
+
+  **Update the `beforeEach` providers** to add `QbService` and a `save` method on `ServerSettingsService`:
+
+  ```typescript
+  import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
+  import { ComponentFixture, TestBed } from '@angular/core/testing';
+  import { ElectronService } from '../../../services/electron.service';
+  import { QbService } from '../../../services/qb.service';
+  import { ServerSettingsService } from '../../../services/server-settings.service';
+  import { ServerStoreService } from '../../../services/server-store.service';
+  import { SettingsStateService } from '../settings-state.service';
+  import { Server } from './server';
+
+  describe('Server', () => {
+    let component: Server;
+    let fixture: ComponentFixture<Server>;
+
+    let electronMock: {
+      openPath: ReturnType<typeof vi.fn>;
+      showOpenDialog: ReturnType<typeof vi.fn>;
+    };
+    let stateServiceMock: {
+      registerSave: ReturnType<typeof vi.fn>;
+      markDirty: ReturnType<typeof vi.fn>;
+    };
+    let serverSettingsMock: {
+      reload: ReturnType<typeof vi.fn>;
+      save: ReturnType<typeof vi.fn>;
+    };
+    let qbMock: {
+      getAppPreferences: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(async () => {
+      electronMock = {
+        openPath: vi.fn(),
+        showOpenDialog: vi.fn().mockResolvedValue(null),
+      };
+      stateServiceMock = { registerSave: vi.fn(), markDirty: vi.fn() };
+      serverSettingsMock = {
+        reload: vi.fn().mockResolvedValue({
+          pathMappings: [],
+          polling: { foreground: 2000, background: 5000 },
+        }),
+        save: vi.fn().mockResolvedValue(undefined),
+      };
+      qbMock = {
+        getAppPreferences: vi.fn().mockResolvedValue({ save_path: '/default/downloads' }),
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [Server],
+        providers: [
+          { provide: ElectronService, useValue: electronMock },
+          { provide: SettingsStateService, useValue: stateServiceMock },
+          { provide: ServerStoreService, useValue: { currentServerId: signal(null) } },
+          { provide: ServerSettingsService, useValue: serverSettingsMock },
+          { provide: QbService, useValue: qbMock },
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(Server);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+  ```
+
+  Then **add a new `describe` block** for the `save()` behaviour after the existing `describe('testMapping', ...)` block (before the final closing `}`):
+
+  ```typescript
+    describe('save', () => {
+      it('should replace empty remote with defaultRemotePath', async () => {
+        (component as any).defaultRemotePath = '/default/downloads';
+        component.pathMappings.at(0).patchValue({ remote: '', local: '/local/path' });
+
+        await (component as any).save();
+
+        expect(serverSettingsMock.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pathMappings: [{ remote: '/default/downloads', local: '/local/path' }],
+          }),
+        );
+      });
+
+      it('should keep a non-empty remote unchanged', async () => {
+        (component as any).defaultRemotePath = '/default/downloads';
+        component.pathMappings.at(0).patchValue({ remote: '/custom/remote', local: '/local/path' });
+
+        await (component as any).save();
+
+        expect(serverSettingsMock.save).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pathMappings: [{ remote: '/custom/remote', local: '/local/path' }],
+          }),
+        );
+      });
+    });
+  });
+  ```
+
+  These tests access the private `defaultRemotePath` property directly via `(component as any)`. They will **fail** because:
+  - `QbService` is not yet injected into `Server`
+  - `defaultRemotePath` does not exist
+  - `save()` does not resolve empty remotes
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+  ```
+  npm test
+  ```
+
+  Expected: the two new `save` tests fail (likely with a DI error about `QbService` or property-not-found errors).
+
+- [ ] **Step 3: Update server.ts - inject QbService, store defaultRemotePath, resolve on save**
+
+  Replace the full contents of `packages/app/src/app/pages/settings/server/server.ts` with:
+
+  ```typescript
+  import { CommonModule } from '@angular/common';
+  import { ChangeDetectionStrategy, Component, DestroyRef, NgZone, inject } from '@angular/core';
+  import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+  import { FormArray, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+  import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+  import {
+    IconDefinition,
+    faFolderOpen,
+    faMinus,
+    faPlus,
+    faTriangleExclamation,
+  } from '@fortawesome/free-solid-svg-icons';
+  import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+  import { TranslatePipe } from '@ngx-translate/core';
+  import { from, switchMap, tap } from 'rxjs';
+  import { BbPopover } from '../../../components/bb-popover/bb-popover';
+  import { BbSpinner } from '../../../components/bb-spinner/bb-spinner';
+  import { SavePathSelect } from '../../../components/save-path-select/save-path-select';
+  import { ServerSettings } from '../../../models/server-settings.model';
+  import { ElectronService } from '../../../services/electron.service';
+  import { QbService } from '../../../services/qb.service';
+  import { ServerSettingsService } from '../../../services/server-settings.service';
+  import { ServerStoreService } from '../../../services/server-store.service';
+  import { SettingsStateService } from '../settings-state.service';
+  import { SettingsTabComponent } from '../settings.interface';
+
+  @Component({
+    selector: 'app-server',
+    imports: [
+      CommonModule,
+      ReactiveFormsModule,
+      FontAwesomeModule,
+      NgbTooltip,
+      BbSpinner,
+      BbPopover,
+      TranslatePipe,
+      SavePathSelect,
+    ],
+    templateUrl: './server.html',
+    styleUrl: './server.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+  })
+  export class Server implements SettingsTabComponent {
+    private readonly electronService = inject(ElectronService);
+    private readonly zone = inject(NgZone);
+    private readonly serverSettingsService = inject(ServerSettingsService);
+    private readonly destoryRef = inject(DestroyRef);
+    private readonly serverStoreService = inject(ServerStoreService);
+    private readonly stateService = inject(SettingsStateService);
+    private readonly qbService = inject(QbService);
+
+    private defaultRemotePath = '';
+
+    public icons: Record<string, IconDefinition> = {
+      faPlus,
+      faMinus,
+      faTriangleExclamation,
+      faFolderOpen,
+    };
+
+    private settings$ = toObservable(this.serverStoreService.currentServerId).pipe(
+      switchMap(() => from(this.serverSettingsService.reload() as Promise<ServerSettings>)),
+
+      tap((settings: ServerSettings) => {
+        const { pathMappings, ...rest } = settings;
+
+        this.serverSettingsForm.patchValue(rest, { emitEvent: false });
+
+        this.pathMappings.clear({ emitEvent: false });
+
+        const mappings = pathMappings?.length ? pathMappings : [{ remote: '', local: '' }];
+
+        mappings.forEach((m) => {
+          this.pathMappings.push(
+            new FormGroup({
+              remote: new FormControl(m.remote, { nonNullable: true }),
+              local: new FormControl(m.local, { nonNullable: true }),
+            }),
+            { emitEvent: false },
+          );
+        });
+
+        const serverId = this.serverStoreService.currentServerId();
+        if (serverId) {
+          this.qbService
+            .getAppPreferences(serverId)
+            .then((prefs) => {
+              if (prefs.save_path) this.defaultRemotePath = prefs.save_path;
+            })
+            .catch(() => {});
+        }
+      }),
+    );
+
+    public readonly settingsLoaded = toSignal(this.settings$, { initialValue: null });
+
+    public serverSettingsForm = new FormGroup({
+      polling: new FormGroup({
+        foreground: new FormControl(2000, { nonNullable: true }),
+        background: new FormControl(5000, { nonNullable: true }),
+      }),
+      pathMappings: new FormArray([
+        new FormGroup({
+          remote: new FormControl('', { nonNullable: true }),
+          local: new FormControl('', { nonNullable: true }),
+        }),
+      ]),
+    });
+
+    constructor() {
+      this.stateService.registerSave('server', () => this.save());
+
+      this.serverSettingsForm.valueChanges
+        .pipe(takeUntilDestroyed(this.destoryRef))
+        .subscribe(() => this.stateService.markDirty('server', true));
+    }
+
+    private async save(): Promise<void> {
+      const raw = this.serverSettingsForm.getRawValue() as ServerSettings;
+      const settings: ServerSettings = {
+        ...raw,
+        pathMappings: raw.pathMappings.map((m) => ({
+          remote: m.remote || this.defaultRemotePath,
+          local: m.local,
+        })),
+      };
+      await this.serverSettingsService.save(settings);
+    }
+
+    get pathMappings(): FormArray {
+      return this.serverSettingsForm.controls.pathMappings;
+    }
+
+    public addPathMapping(): void {
+      this.pathMappings.push(
+        new FormGroup({
+          remote: new FormControl('', { nonNullable: true }),
+          local: new FormControl('', { nonNullable: true }),
+        }),
+        { emitEvent: false },
+      );
+    }
+
+    public testMapping(path: string): void {
+      this.electronService.openPath(path);
+    }
+
+    public removePathMapping(index: number): void {
+      if (this.pathMappings.length === 1) {
+        this.pathMappings.at(index).reset({ remote: '', local: '' });
+      } else {
+        this.pathMappings.removeAt(index);
+      }
+    }
+
+    public async onBrowse(index: number): Promise<void> {
+      const path = await this.electronService.showOpenDialog();
+      if (path) {
+        this.zone.run(() => {
+          const localControl = this.pathMappings.at(index).get('local');
+          if (localControl) {
+            localControl.setValue(path);
+            localControl.markAsDirty();
+          }
+        });
+      }
+    }
+  }
+  ```
+
+- [ ] **Step 4: Add `[clearable]="true"` to the remote path in server.html**
+
+  In `packages/app/src/app/pages/settings/server/server.html`, find the `app-save-path-select` for the remote field (around line 153) and add `[clearable]="true"`:
+
+  ```html
+  <app-save-path-select
+    [showPopover]="false"
+    [clearable]="true"
+    [label]="
+      'pages.settings.tab.server.server-settings-form.path-mapping.remote-path'
+        | translate
+    "
+    appendTo="ngb-modal-window"
+    formControlName="remote"
+  ></app-save-path-select>
+  ```
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+  ```
+  npm test
+  ```
+
+  Expected: all tests pass, including the three new `save` describe tests.
+
+- [ ] **Step 6: Commit**
+
+  ```
+  git add packages/app/src/app/pages/settings/server/server.ts packages/app/src/app/pages/settings/server/server.html packages/app/src/app/pages/settings/server/server.spec.ts
+  git commit -m "#125: clearable remote path in server settings with default fallback on save"
+  ```

--- a/docs/superpowers/specs/2026-06-04-save-path-placeholder-and-server-settings-design.md
+++ b/docs/superpowers/specs/2026-06-04-save-path-placeholder-and-server-settings-design.md
@@ -1,0 +1,67 @@
+---
+name: save-path-placeholder-and-server-settings
+description: Show qBittorrent default path as placeholder (not value) in add-torrent; make server settings remote path clearable with default fallback on save.
+metadata:
+  type: project
+---
+
+# Save Path Placeholder & Server Settings Remote Path Design
+
+## Scope
+
+Two focused changes to how `save-path-select` is used in add-torrent and server settings.
+
+## Change 1 - Add Torrent: default path as placeholder only
+
+### Problem
+
+In `add-torrent.ts ngOnInit()` (lines 185-192), when `settings.savepath` is null or empty the
+component fetches the qBittorrent default path and sets it as the form value. This pre-fills the
+field with the default, giving the appearance that the user must supply a path.
+
+### Desired behavior
+
+- The `savepath` form control stays `null` when the user has no saved preference.
+- `save-path-select` already fetches and shows `defaultPath` as placeholder text - no pre-fill needed.
+- On submit, `raw.savepath?.trim() || undefined` already converts `null` to `undefined`, so
+  qBittorrent uses its own configured default. No submit-side change required.
+
+### Implementation
+
+Remove the block in `add-torrent.ts ngOnInit()` that fetches `getAppPreferences` and assigns
+`settings.savepath = prefs.save_path`. Everything else is unchanged.
+
+## Change 2 - Server Settings: clearable remote path with default fallback
+
+### Problem
+
+The `save-path-select` bound to `formControlName="remote"` in `server.html`:
+
+- Has no `[clearable]` binding, so the user cannot clear a previously saved path.
+- When the user leaves the field empty and saves, an empty string is persisted. On next load the
+  field shows empty with no placeholder context, which is confusing.
+
+### Desired behavior
+
+- The remote path field is clearable (built-in X button via ng-select when a value is selected).
+- `save-path-select` already fetches `defaultPath` from `getAppPreferences` and shows it as
+  placeholder text - so a cleared/empty field communicates what will be used.
+- When saving, if `remote` is empty/null, resolve it to the qBittorrent default path before
+  persisting. On next load, `writeValue(defaultPath)` shows the path as a selected value (not
+  placeholder), keeping the X button visible and the state unambiguous.
+
+### Implementation
+
+**`server.html`** - add `[clearable]="true"` to the `app-save-path-select` for the remote field.
+
+**`server.ts`** - inject `QbService`. In the `settings$` pipe (where the server ID already drives
+a reload), fetch `getAppPreferences` and store the result in a `defaultRemotePath` signal/property.
+In the `save()` method, iterate `pathMappings` and for each entry where `remote` is falsy, replace
+it with `defaultRemotePath` before passing to `serverSettingsService.save()`.
+
+## Out of scope
+
+- General settings save-path previews - the built-in ng-select X button behaves correctly
+  (visible when a value is selected, hidden when empty). No changes needed.
+- Set-torrent-location (context menu modal) - already works correctly, no changes.
+- The `save-path-select` component itself requires no new inputs or internal changes.

--- a/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
@@ -124,6 +124,17 @@ describe('AddTorrent', () => {
     });
   });
 
+  describe('ngOnInit savepath behaviour', () => {
+    it('should leave savepath null when AddTorrentSettings returns no savepath', async () => {
+      const addTorrentSettings = TestBed.inject(AddTorrentSettingsService) as any;
+      addTorrentSettings.load.mockResolvedValue({});
+
+      await component.ngOnInit();
+
+      expect(component.addForm.controls.savepath.value).toBeNull();
+    });
+  });
+
   describe('tryRenameContentAfterAdd', () => {
     let mockQbService: any;
     const hash = 'abcdef1234567890';

--- a/packages/app/src/app/components/add-torrent/add-torrent.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.ts
@@ -180,16 +180,6 @@ export class AddTorrent implements OnInit {
 
   public async ngOnInit(): Promise<void> {
     const settings = (await this.addTorrentSettings.load()) as any;
-    const serverId = this.serverStoreService.currentServerId();
-
-    if (!settings.savepath && serverId) {
-      try {
-        const prefs = await this.qbService.getAppPreferences(serverId);
-        settings.savepath = prefs.save_path;
-      } catch (err) {
-        console.error(AddTorrent.name, `ngOnInit`, `Failed to get app preferences`, err);
-      }
-    }
 
     for (const [k, v] of Object.entries(settings)) {
       const ctrl = this.addForm.get(k);

--- a/packages/app/src/app/pages/settings/server/server.html
+++ b/packages/app/src/app/pages/settings/server/server.html
@@ -152,6 +152,7 @@
               <div class="col-5">
                 <app-save-path-select
                   [showPopover]="false"
+                  [clearable]="true"
                   [label]="
                     'pages.settings.tab.server.server-settings-form.path-mapping.remote-path'
                       | translate

--- a/packages/app/src/app/pages/settings/server/server.spec.ts
+++ b/packages/app/src/app/pages/settings/server/server.spec.ts
@@ -1,6 +1,7 @@
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ElectronService } from '../../../services/electron.service';
+import { QbService } from '../../../services/qb.service';
 import { ServerSettingsService } from '../../../services/server-settings.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { SettingsStateService } from '../settings-state.service';
@@ -18,6 +19,13 @@ describe('Server', () => {
     registerSave: ReturnType<typeof vi.fn>;
     markDirty: ReturnType<typeof vi.fn>;
   };
+  let serverSettingsMock: {
+    reload: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+  };
+  let qbMock: {
+    getAppPreferences: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
     electronMock = {
@@ -25,6 +33,16 @@ describe('Server', () => {
       showOpenDialog: vi.fn().mockResolvedValue(null),
     };
     stateServiceMock = { registerSave: vi.fn(), markDirty: vi.fn() };
+    serverSettingsMock = {
+      reload: vi.fn().mockResolvedValue({
+        pathMappings: [],
+        polling: { foreground: 2000, background: 5000 },
+      }),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    qbMock = {
+      getAppPreferences: vi.fn().mockResolvedValue({ save_path: '/default/downloads' }),
+    };
 
     await TestBed.configureTestingModule({
       imports: [Server],
@@ -32,15 +50,8 @@ describe('Server', () => {
         { provide: ElectronService, useValue: electronMock },
         { provide: SettingsStateService, useValue: stateServiceMock },
         { provide: ServerStoreService, useValue: { currentServerId: signal(null) } },
-        {
-          provide: ServerSettingsService,
-          useValue: {
-            reload: vi.fn().mockResolvedValue({
-              pathMappings: [],
-              polling: { foreground: 2000, background: 5000 },
-            }),
-          },
-        },
+        { provide: ServerSettingsService, useValue: serverSettingsMock },
+        { provide: QbService, useValue: qbMock },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -99,6 +110,34 @@ describe('Server', () => {
     it('should call electronService.openPath with the given path', () => {
       component.testMapping('/some/local/path');
       expect(electronMock.openPath).toHaveBeenCalledWith('/some/local/path');
+    });
+  });
+
+  describe('save', () => {
+    it('should replace empty remote with defaultRemotePath', async () => {
+      (component as any).defaultRemotePath = '/default/downloads';
+      component.pathMappings.at(0).patchValue({ remote: '', local: '/local/path' });
+
+      await (component as any).save();
+
+      expect(serverSettingsMock.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathMappings: [{ remote: '/default/downloads', local: '/local/path' }],
+        }),
+      );
+    });
+
+    it('should keep a non-empty remote unchanged', async () => {
+      (component as any).defaultRemotePath = '/default/downloads';
+      component.pathMappings.at(0).patchValue({ remote: '/custom/remote', local: '/local/path' });
+
+      await (component as any).save();
+
+      expect(serverSettingsMock.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathMappings: [{ remote: '/custom/remote', local: '/local/path' }],
+        }),
+      );
     });
   });
 });

--- a/packages/app/src/app/pages/settings/server/server.spec.ts
+++ b/packages/app/src/app/pages/settings/server/server.spec.ts
@@ -78,10 +78,10 @@ describe('Server', () => {
       expect(component.pathMappings.length).toBe(before + 1);
     });
 
-    it('new mapping should have empty remote and local controls', () => {
+    it('new mapping should have null remote and empty local controls', () => {
       component.addPathMapping();
       const last = component.pathMappings.at(component.pathMappings.length - 1);
-      expect(last.get('remote')?.value).toBe('');
+      expect(last.get('remote')?.value).toBeNull();
       expect(last.get('local')?.value).toBe('');
     });
   });
@@ -94,14 +94,14 @@ describe('Server', () => {
       expect(component.pathMappings.length).toBe(before - 1);
     });
 
-    it('should reset the mapping to empty strings instead of removing when only one remains', () => {
+    it('should reset remote to null and local to empty string instead of removing when only one remains', () => {
       while (component.pathMappings.length > 1) {
         component.removePathMapping(0);
       }
       component.pathMappings.at(0).patchValue({ remote: 'r', local: 'l' });
       component.removePathMapping(0);
       expect(component.pathMappings.length).toBe(1);
-      expect(component.pathMappings.at(0).get('remote')?.value).toBe('');
+      expect(component.pathMappings.at(0).get('remote')?.value).toBeNull();
       expect(component.pathMappings.at(0).get('local')?.value).toBe('');
     });
   });

--- a/packages/app/src/app/pages/settings/server/server.ts
+++ b/packages/app/src/app/pages/settings/server/server.ts
@@ -73,7 +73,7 @@ export class Server implements SettingsTabComponent {
       mappings.forEach((m) => {
         this.pathMappings.push(
           new FormGroup({
-            remote: new FormControl(m.remote, { nonNullable: true }),
+            remote: new FormControl<string | null>(m.remote || null),
             local: new FormControl(m.local, { nonNullable: true }),
           }),
           { emitEvent: false },
@@ -101,7 +101,7 @@ export class Server implements SettingsTabComponent {
     }),
     pathMappings: new FormArray([
       new FormGroup({
-        remote: new FormControl('', { nonNullable: true }),
+        remote: new FormControl<string | null>(null),
         local: new FormControl('', { nonNullable: true }),
       }),
     ]),
@@ -134,7 +134,7 @@ export class Server implements SettingsTabComponent {
   public addPathMapping(): void {
     this.pathMappings.push(
       new FormGroup({
-        remote: new FormControl('', { nonNullable: true }),
+        remote: new FormControl<string | null>(null),
         local: new FormControl('', { nonNullable: true }),
       }),
       { emitEvent: false },
@@ -147,7 +147,7 @@ export class Server implements SettingsTabComponent {
 
   public removePathMapping(index: number): void {
     if (this.pathMappings.length === 1) {
-      this.pathMappings.at(index).reset({ remote: '', local: '' });
+      this.pathMappings.at(index).reset({ remote: null, local: '' });
     } else {
       this.pathMappings.removeAt(index);
     }

--- a/packages/app/src/app/pages/settings/server/server.ts
+++ b/packages/app/src/app/pages/settings/server/server.ts
@@ -18,6 +18,7 @@ import { BbSpinner } from '../../../components/bb-spinner/bb-spinner';
 import { SavePathSelect } from '../../../components/save-path-select/save-path-select';
 import { ServerSettings } from '../../../models/server-settings.model';
 import { ElectronService } from '../../../services/electron.service';
+import { QbService } from '../../../services/qb.service';
 import { ServerSettingsService } from '../../../services/server-settings.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { SettingsStateService } from '../settings-state.service';
@@ -46,6 +47,9 @@ export class Server implements SettingsTabComponent {
   private readonly destoryRef = inject(DestroyRef);
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly stateService = inject(SettingsStateService);
+  private readonly qbService = inject(QbService);
+
+  private defaultRemotePath = '';
 
   public icons: Record<string, IconDefinition> = {
     faPlus,
@@ -75,6 +79,16 @@ export class Server implements SettingsTabComponent {
           { emitEvent: false },
         );
       });
+
+      const serverId = this.serverStoreService.currentServerId();
+      if (serverId) {
+        this.qbService
+          .getAppPreferences(serverId)
+          .then((prefs) => {
+            if (prefs.save_path) this.defaultRemotePath = prefs.save_path;
+          })
+          .catch(() => {});
+      }
     }),
   );
 
@@ -102,7 +116,14 @@ export class Server implements SettingsTabComponent {
   }
 
   private async save(): Promise<void> {
-    const settings: ServerSettings = this.serverSettingsForm.getRawValue();
+    const raw = this.serverSettingsForm.getRawValue() as ServerSettings;
+    const settings: ServerSettings = {
+      ...raw,
+      pathMappings: raw.pathMappings.map((m) => ({
+        remote: m.remote || this.defaultRemotePath,
+        local: m.local,
+      })),
+    };
     await this.serverSettingsService.save(settings);
   }
 


### PR DESCRIPTION
## Issue ID

Fixes #125

## Description

Two focused improvements to how `save-path-select` is used across the app.

**Add Torrent:** Removed the block in `ngOnInit()` that fetched the qBittorrent default path and pre-filled `savepath` when no saved preference existed. The `save-path-select` component already shows the default as placeholder text - the field should stay null, and a null savepath sends `undefined` to the API which tells qBittorrent to use its own configured default.

**Server Settings - Remote Path:** Injected `QbService` into the `Server` component to fetch the qBittorrent default path when settings load. Added `[clearable]="true"` to the remote path `save-path-select`. Updated `save()` to resolve empty remote values to the default path so a cleared field persists correctly and loads back with a visible value on next visit.