### PR TITLE
Fix set-location/category/tags to target the correct torrent hashes

### DIFF
--- a/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.html
+++ b/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.html
@@ -7,12 +7,16 @@
     <div
       #element
       class="small text-body-secondary mt-1 bb-hash-clamp"
-      [ngbTooltip]="torrent().name"
+      [ngbTooltip]="selected() === 1 ? torrent().name : null"
       bbTooltipOverflow
       placement="top"
       tooltipClass="single-line-tooltip"
     >
-      {{ torrent().name }}
+      @if (selected() > 1) {
+        {{ 'general.label.torrent-selected' | translate: { count: selected() } }}
+      } @else {
+        {{ torrent().name }}
+      }
     </div>
   </div>
 

--- a/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts
+++ b/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Torrent } from '../../../models/torrent.model';
 import { QbService } from '../../../services/qb.service';
-import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { SetTorrentCategory } from './set-torrent-category';
 
@@ -21,10 +20,6 @@ describe('SetTorrentCategory', () => {
         { provide: NgbActiveModal, useValue: mockActiveModal },
         { provide: ServerStoreService, useValue: { currentServerId: signal('server-1') } },
         {
-          provide: SelectionStoreService,
-          useValue: { selected: signal([]), selectedHashes: vi.fn().mockReturnValue([]) },
-        },
-        {
           provide: QbService,
           useValue: {
             getAllCategories: vi.fn().mockResolvedValue({}),
@@ -37,6 +32,7 @@ describe('SetTorrentCategory', () => {
     fixture = TestBed.createComponent(SetTorrentCategory);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('torrent', { category: 'movies' } as Torrent);
+    fixture.componentRef.setInput('hashes', ['hash-1']);
     fixture.detectChanges();
   });
 
@@ -64,6 +60,17 @@ describe('SetTorrentCategory', () => {
       component.setTorrentCategoryForm.markAsDirty();
       component.saving = true;
       expect(component.canSave()).toBe(false);
+    });
+  });
+
+  describe('handleSubmit', () => {
+    it('should apply the category to the hashes provided via the input, not the selection store', async () => {
+      const mockQbService = TestBed.inject(QbService) as unknown as {
+        setTorrentCategory: ReturnType<typeof vi.fn>;
+      };
+      component.setTorrentCategoryForm.get('category')?.setValue('tv');
+      await component.handleSubmit();
+      expect(mockQbService.setTorrentCategory).toHaveBeenCalledWith('server-1', ['hash-1'], 'tv');
     });
   });
 });

--- a/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts
+++ b/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts
@@ -1,12 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject, input } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { Torrent } from '../../../models/torrent.model';
 import { QbService } from '../../../services/qb.service';
-import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { CategorySelect } from '../../category-select/category-select';
 
@@ -27,12 +26,13 @@ import { CategorySelect } from '../../category-select/category-select';
 })
 export class SetTorrentCategory implements OnInit {
   readonly torrent = input.required<Torrent>();
+  readonly hashes = input<string[]>([]);
 
   private readonly serverStoreService = inject(ServerStoreService);
-  private readonly selectionStoreService = inject(SelectionStoreService);
   public readonly activeModal = inject(NgbActiveModal);
   public readonly qbService = inject(QbService);
 
+  public readonly selected = computed(() => this.hashes().length);
   public saving = false;
   public setTorrentCategoryForm = new FormGroup({
     category: new FormControl(''),
@@ -47,10 +47,9 @@ export class SetTorrentCategory implements OnInit {
 
     const category = this.setTorrentCategoryForm.get('category')?.value || '';
     const serverId = this.serverStoreService.currentServerId() ?? '';
-    const hashes = this.selectionStoreService.selectedHashes();
 
     try {
-      await this.qbService.setTorrentCategory(serverId, hashes, category);
+      await this.qbService.setTorrentCategory(serverId, this.hashes(), category);
       this.activeModal.close();
     } catch (error) {
       console.error(

--- a/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.html
+++ b/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.html
@@ -7,13 +7,13 @@
     <div
       #element
       class="small text-body-secondary mt-1 bb-hash-clamp"
-      [ngbTooltip]="selected === 1 ? torrent().name : null"
+      [ngbTooltip]="selected() === 1 ? torrent().name : null"
       bbTooltipOverflow
       tooltipClass="single-line-tooltip"
       placement="bottom"
     >
-      @if (selected > 1) {
-        {{ 'general.label.torrent-selected' | translate: { count: selected } }}
+      @if (selected() > 1) {
+        {{ 'general.label.torrent-selected' | translate: { count: selected() } }}
       } @else {
         {{ torrent().name }}
       }

--- a/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.spec.ts
+++ b/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Torrent } from '../../../models/torrent.model';
 import { QbService } from '../../../services/qb.service';
-import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { ToastService } from '../../../services/toast.service';
 import { TorrentStoreService } from '../../../services/torrent-store.service';
@@ -23,13 +22,6 @@ describe('SetTorrentLocation', () => {
         { provide: NgbActiveModal, useValue: mockActiveModal },
         { provide: ServerStoreService, useValue: { currentServerId: signal('server-1') } },
         {
-          provide: SelectionStoreService,
-          useValue: {
-            selected: signal([{ save_path: '/downloads' }]),
-            selectedHashes: vi.fn().mockReturnValue([]),
-          },
-        },
-        {
           provide: QbService,
           useValue: {
             setTorrentLocation: vi.fn().mockResolvedValue(undefined),
@@ -44,6 +36,7 @@ describe('SetTorrentLocation', () => {
     fixture = TestBed.createComponent(SetTorrentLocation);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('torrent', { save_path: '/downloads' } as Torrent);
+    fixture.componentRef.setInput('hashes', ['hash-1']);
     fixture.detectChanges();
   });
 
@@ -81,7 +74,7 @@ describe('SetTorrentLocation', () => {
       await component.handleSubmit();
       expect(mockQbService.setTorrentLocation).toHaveBeenCalledWith(
         'server-1',
-        expect.any(Array),
+        ['hash-1'],
         '/custom/path',
       );
     });
@@ -91,7 +84,7 @@ describe('SetTorrentLocation', () => {
       await component.handleSubmit();
       expect(mockQbService.setTorrentLocation).toHaveBeenCalledWith(
         'server-1',
-        expect.any(Array),
+        ['hash-1'],
         '/downloads',
       );
     });

--- a/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.ts
+++ b/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.ts
@@ -1,11 +1,18 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, input, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { Torrent } from '../../../models/torrent.model';
 import { QbService } from '../../../services/qb.service';
-import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { ToastService } from '../../../services/toast.service';
 import { SavePathSelect } from '../../save-path-select/save-path-select';
@@ -19,9 +26,9 @@ import { SavePathSelect } from '../../save-path-select/save-path-select';
 })
 export class SetTorrentLocation implements OnInit {
   readonly torrent = input.required<Torrent>();
+  readonly hashes = input<string[]>([]);
 
   private readonly serverStoreService = inject(ServerStoreService);
-  private readonly selectionStoreService = inject(SelectionStoreService);
   private readonly toastService = inject(ToastService);
   private readonly qbService = inject(QbService);
   public readonly activeModal = inject(NgbActiveModal);
@@ -30,7 +37,7 @@ export class SetTorrentLocation implements OnInit {
     path: new FormControl<string | null>(null),
   });
 
-  public selected = this.selectionStoreService.selected().length;
+  public readonly selected = computed(() => this.hashes().length);
   private defaultPath = signal<string>('');
 
   public async ngOnInit(): Promise<void> {
@@ -61,11 +68,7 @@ export class SetTorrentLocation implements OnInit {
     }
 
     try {
-      await this.qbService.setTorrentLocation(
-        serverId,
-        this.selectionStoreService.selectedHashes(),
-        newPath,
-      );
+      await this.qbService.setTorrentLocation(serverId, this.hashes(), newPath);
       this.activeModal.close();
     } catch (error: any) {
       console.error(

--- a/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.html
+++ b/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.html
@@ -7,13 +7,13 @@
     <div
       #element
       class="small text-body-secondary mt-1 bb-hash-clamp"
-      [ngbTooltip]="selected === 1 ? torrent().name : null"
+      [ngbTooltip]="selected() === 1 ? torrent().name : null"
       bbTooltipOverflow
       placement="bottom"
       tooltipClass="single-line-tooltip"
     >
-      @if (selected > 1) {
-        {{ 'general.label.torrent-selected' | translate: { count: selected } }}
+      @if (selected() > 1) {
+        {{ 'general.label.torrent-selected' | translate: { count: selected() } }}
       } @else {
         {{ torrent().name }}
       }

--- a/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.spec.ts
+++ b/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Torrent } from '../../../models/torrent.model';
 import { QbService } from '../../../services/qb.service';
-import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { SetTorrentTags } from './set-torrent-tags';
 
@@ -21,10 +20,6 @@ describe('SetTorrentTags', () => {
         { provide: NgbActiveModal, useValue: mockActiveModal },
         { provide: ServerStoreService, useValue: { currentServerId: signal('server-1') } },
         {
-          provide: SelectionStoreService,
-          useValue: { selected: signal([]), selectedHashes: vi.fn().mockReturnValue([]) },
-        },
-        {
           provide: QbService,
           useValue: {
             getAllTags: vi.fn().mockResolvedValue([]),
@@ -38,6 +33,7 @@ describe('SetTorrentTags', () => {
     fixture = TestBed.createComponent(SetTorrentTags);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('torrent', { tags: 'action,comedy' } as Torrent);
+    fixture.componentRef.setInput('hashes', ['hash-1']);
     fixture.detectChanges();
   });
 
@@ -69,6 +65,24 @@ describe('SetTorrentTags', () => {
       component.setTorrentTagsForm.updateValueAndValidity();
       component.setTorrentTagsForm.get('tags')?.setValue(['action']);
       expect(component.canSave()).toBe(true);
+    });
+  });
+
+  describe('handleSubmit', () => {
+    it('should apply tag changes to the hashes provided via the input, not the selection store', async () => {
+      const mockQbService = TestBed.inject(QbService) as unknown as {
+        addTorrentTags: ReturnType<typeof vi.fn>;
+        removeTorrentTags: ReturnType<typeof vi.fn>;
+      };
+      await component.ngOnInit();
+      component.setTorrentTagsForm.get('tags')?.setValue(['action', 'drama']);
+      await component.handleSubmit();
+      expect(mockQbService.addTorrentTags).toHaveBeenCalledWith('server-1', ['hash-1'], ['drama']);
+      expect(mockQbService.removeTorrentTags).toHaveBeenCalledWith(
+        'server-1',
+        ['hash-1'],
+        ['comedy'],
+      );
     });
   });
 });

--- a/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.ts
+++ b/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.ts
@@ -14,7 +14,6 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { TooltipOverflow } from '../../../directives/tooltip-overflow';
 import { Torrent } from '../../../models/torrent.model';
 import { QbService } from '../../../services/qb.service';
-import { SelectionStoreService } from '../../../services/selection-store.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 import { TagSelect } from '../../tag-select/tag-select';
 
@@ -27,13 +26,13 @@ import { TagSelect } from '../../tag-select/tag-select';
 })
 export class SetTorrentTags implements OnInit {
   readonly torrent = input.required<Torrent>();
+  readonly hashes = input<string[]>([]);
 
   private readonly serverStoreService = inject(ServerStoreService);
-  private readonly selectionStoreService = inject(SelectionStoreService);
   private readonly qbService = inject(QbService);
   public readonly activeModal = inject(NgbActiveModal);
 
-  public selected = this.selectionStoreService.selected().length;
+  public readonly selected = computed(() => this.hashes().length);
   public saving = signal(false);
   public setTorrentTagsForm = new FormGroup({
     tags: new FormControl([] as string[]),
@@ -73,7 +72,7 @@ export class SetTorrentTags implements OnInit {
 
     const newTagsValue = this.setTorrentTagsForm.get('tags')?.value || [];
     const serverId = this.serverStoreService.currentServerId() ?? '';
-    const hashes = this.selectionStoreService.selectedHashes();
+    const hashes = this.hashes();
 
     const initialTags = (this.torrent().tags || '')
       .split(',')

--- a/packages/app/src/app/components/modals/torrent-details/general/general.ts
+++ b/packages/app/src/app/components/modals/torrent-details/general/general.ts
@@ -290,6 +290,7 @@ export class General implements TorrentDetailTabComponent, OnInit {
     this.commandBusService.emit({
       type: 'UI_SET_TORRENT_CATEGORY',
       torrent: this.torrent()!.data,
+      hashes: [this.hash()],
     });
   }
 
@@ -301,7 +302,11 @@ export class General implements TorrentDetailTabComponent, OnInit {
   }
 
   public changeTags(): void {
-    this.commandBusService.emit({ type: 'UI_SET_TORRENT_TAGS', torrent: this.torrent()!.data });
+    this.commandBusService.emit({
+      type: 'UI_SET_TORRENT_TAGS',
+      torrent: this.torrent()!.data,
+      hashes: [this.hash()],
+    });
   }
 
   public removeAllTags(): void {
@@ -319,6 +324,7 @@ export class General implements TorrentDetailTabComponent, OnInit {
     this.commandBusService.emit({
       type: 'UI_SET_TORRENT_LOCATION',
       torrent: this.torrent()!.data,
+      hashes: [this.hash()],
     });
   }
 

--- a/packages/app/src/app/models/command.model.ts
+++ b/packages/app/src/app/models/command.model.ts
@@ -19,12 +19,12 @@ export type UiCommand =
       mode?: 'file' | 'link';
     }
   | { type: 'UI_OPEN_ABOUT' }
-  | { type: 'UI_SET_TORRENT_LOCATION'; torrent: Torrent }
+  | { type: 'UI_SET_TORRENT_LOCATION'; torrent: Torrent; hashes?: string[] }
   | { type: 'UI_RENAME_TORRENT'; torrent: Torrent }
   | { type: 'UI_LIMIT_TRANSFER'; target: LimitTargetType; hashes?: string[] }
   | { type: 'UI_LIMIT_SHARE'; target?: LimitTargetType; hashes?: string[] }
-  | { type: 'UI_SET_TORRENT_TAGS'; torrent: Torrent }
-  | { type: 'UI_SET_TORRENT_CATEGORY'; torrent: Torrent }
+  | { type: 'UI_SET_TORRENT_TAGS'; torrent: Torrent; hashes?: string[] }
+  | { type: 'UI_SET_TORRENT_CATEGORY'; torrent: Torrent; hashes?: string[] }
   | { type: 'UI_OPEN_DESTINATION'; remotePath: string | null; hash: string }
   | { type: 'UI_UPDATE_AVAILABLE'; update: UpdateCheckResponse }
   | { type: 'UI_RENAME_FILES'; hash: string }

--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -177,6 +177,11 @@ export class UiCommandHandlerService {
             });
 
             setModalInput(setLocationModalRef, 'torrent', command.torrent);
+            setModalInput(
+              setLocationModalRef,
+              'hashes',
+              command.hashes ?? this.selectionStoreService.selectedHashes(),
+            );
             setLocationModalRef.result.catch(() => {});
             break;
           }
@@ -213,6 +218,11 @@ export class UiCommandHandlerService {
             if (this.isModalOpen(SetTorrentTags)) break;
             const setTagsModalRef = this.modalService.open(SetTorrentTags, { size: 'lg' });
             setModalInput(setTagsModalRef, 'torrent', command.torrent);
+            setModalInput(
+              setTagsModalRef,
+              'hashes',
+              command.hashes ?? this.selectionStoreService.selectedHashes(),
+            );
             setTagsModalRef.result.catch(() => {});
             break;
           }
@@ -221,6 +231,11 @@ export class UiCommandHandlerService {
             if (this.isModalOpen(SetTorrentCategory)) break;
             const setCategoryModalRef = this.modalService.open(SetTorrentCategory, { size: 'lg' });
             setModalInput(setCategoryModalRef, 'torrent', command.torrent);
+            setModalInput(
+              setCategoryModalRef,
+              'hashes',
+              command.hashes ?? this.selectionStoreService.selectedHashes(),
+            );
             setCategoryModalRef.result.catch(() => {});
             break;
           }


### PR DESCRIPTION
## Issue ID

Fixes #133

## Description

`SetTorrentLocation`, `SetTorrentCategory` and `SetTorrentTags` read their target hashes from `SelectionStoreService.selectedHashes()` instead of an explicit payload. Opening any of these from the torrent details modal for a torrent that wasn't part of the current grid selection silently applied the change to the wrong torrents.

This mirrors the existing `UI_LIMIT_TRANSFER`/`UI_LIMIT_SHARE` pattern: the commands now carry an optional `hashes` payload that `UiCommandHandlerService` resolves against the selection store only as a fallback (for grid-initiated bulk actions), and the modals consume that resolved input directly instead of reaching into the selection store themselves.

Also added the missing "N torrents selected" header to `SetTorrentCategory` so its multi-selection treatment matches `SetTorrentLocation`/`SetTorrentTags`.