### PR TITLE
Make the grid right-click context menu selection-aware

### DIFF
--- a/packages/app/src/app/pages/main/grid/context-menu/grid-context-menu.service.spec.ts
+++ b/packages/app/src/app/pages/main/grid/context-menu/grid-context-menu.service.spec.ts
@@ -1,6 +1,7 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { faSquare, faSquareCheck, faSquareMinus } from '@fortawesome/free-regular-svg-icons';
 import { of } from 'rxjs';
 import type { Torrent } from '../../../../models/torrent.model';
 import { CommandBusService } from '../../../../services/command-bus.service';
@@ -40,10 +41,12 @@ function makeRow(overrides: Partial<Torrent> = {}): Torrent {
 }
 
 function makeData(overrides: Partial<GridContextMenuData> = {}): GridContextMenuData {
+  const row = overrides.row ?? makeRow();
+
   return {
-    row: makeRow(),
+    row,
     cell: { colId: 'name', rowId: 'abc123', value: 'My Torrent' },
-    selected: [],
+    selected: [row],
     rowPinned: null,
     ...overrides,
   };
@@ -289,11 +292,11 @@ describe('GridContextMenuService', () => {
         expect(clipboard.copy).toHaveBeenCalledWith('magnet:?xt=abc123');
       });
 
-      it('torrent.copyJson action copies the row as formatted JSON', async () => {
+      it('torrent.copyJson action copies the selection as formatted JSON', async () => {
         const row = makeRow();
         const entries = await service.buildTorrentMenu(makeData({ row }));
         (findItem(entries, 'torrent.copyJson')!.action as () => void)();
-        expect(clipboard.copy).toHaveBeenCalledWith(JSON.stringify(row, null, 2));
+        expect(clipboard.copy).toHaveBeenCalledWith(JSON.stringify([row], null, 2));
       });
 
       it('row.pinToTop action emits UI_TORRENT_PIN_TOP', async () => {
@@ -332,13 +335,14 @@ describe('GridContextMenuService', () => {
         expect(commandBusService.emit).toHaveBeenCalledWith({ type: 'TORRENT_FORCE_RESUME' });
       });
 
-      it('files.setLocation action emits UI_SET_TORRENT_LOCATION with the torrent', async () => {
+      it('files.setLocation action emits UI_SET_TORRENT_LOCATION with the torrent and selected hashes', async () => {
         const row = makeRow();
         const entries = await service.buildTorrentMenu(makeData({ row }));
         (findItem(entries, 'files.setLocation')!.action as () => void)();
         expect(commandBusService.emit).toHaveBeenCalledWith({
           type: 'UI_SET_TORRENT_LOCATION',
           torrent: row,
+          hashes: [row.hash],
         });
       });
 
@@ -372,23 +376,54 @@ describe('GridContextMenuService', () => {
         });
       });
 
-      it('files.category action emits UI_SET_TORRENT_CATEGORY with the torrent', async () => {
+      it('files.category action emits UI_SET_TORRENT_CATEGORY with the torrent and selected hashes', async () => {
         const row = makeRow();
         const entries = await service.buildTorrentMenu(makeData({ row }));
         (findItem(entries, 'files.category')!.action as () => void)();
         expect(commandBusService.emit).toHaveBeenCalledWith({
           type: 'UI_SET_TORRENT_CATEGORY',
           torrent: row,
+          hashes: [row.hash],
         });
       });
 
-      it('files.tags action emits UI_SET_TORRENT_TAGS with the torrent', async () => {
+      it('files.tags action emits UI_SET_TORRENT_TAGS with the torrent and selected hashes', async () => {
         const row = makeRow();
         const entries = await service.buildTorrentMenu(makeData({ row }));
         (findItem(entries, 'files.tags')!.action as () => void)();
         expect(commandBusService.emit).toHaveBeenCalledWith({
           type: 'UI_SET_TORRENT_TAGS',
           torrent: row,
+          hashes: [row.hash],
+        });
+      });
+
+      it('UI_SET_TORRENT_LOCATION/CATEGORY/TAGS carry the full selection hashes for a multi-selection', async () => {
+        const rowA = makeRow({ hash: 'hash-a' });
+        const rowB = makeRow({ hash: 'hash-b' });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+
+        (findItem(entries, 'files.setLocation')!.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'UI_SET_TORRENT_LOCATION',
+          torrent: rowA,
+          hashes: ['hash-a', 'hash-b'],
+        });
+
+        (findItem(entries, 'files.category')!.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'UI_SET_TORRENT_CATEGORY',
+          torrent: rowA,
+          hashes: ['hash-a', 'hash-b'],
+        });
+
+        (findItem(entries, 'files.tags')!.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'UI_SET_TORRENT_TAGS',
+          torrent: rowA,
+          hashes: ['hash-a', 'hash-b'],
         });
       });
 
@@ -451,6 +486,168 @@ describe('GridContextMenuService', () => {
         const entries = await service.buildTorrentMenu(makeData());
         (findItem(entries, 'queue.moveBottom')!.action as () => void)();
         expect(commandBusService.emit).toHaveBeenCalledWith({ type: 'QUEUE_MOVE_BOTTOM' });
+      });
+    });
+
+    describe('multi-selection behavior', () => {
+      it('hides single-target-only items when multiple torrents are selected', async () => {
+        const rowA = makeRow({ hash: 'hash-a' });
+        const rowB = makeRow({ hash: 'hash-b' });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+
+        expect(findItem(entries, 'torrent.details')).toBeUndefined();
+        expect(findItem(entries, 'files.openDestination')).toBeUndefined();
+        expect(findItem(entries, 'files.renameTorrent')).toBeUndefined();
+        expect(findItem(entries, 'files.renameFiles')).toBeUndefined();
+        expect(findItem(entries, 'cell.copyValue')).toBeUndefined();
+      });
+
+      it('keeps single-target-only items when a single torrent is selected', async () => {
+        const entries = await service.buildTorrentMenu(makeData());
+
+        expect(findItem(entries, 'torrent.details')).toBeDefined();
+        expect(findItem(entries, 'files.openDestination')).toBeDefined();
+        expect(findItem(entries, 'files.renameTorrent')).toBeDefined();
+        expect(findItem(entries, 'files.renameFiles')).toBeDefined();
+        expect(findItem(entries, 'cell.copyValue')).toBeDefined();
+      });
+
+      it('pluralizes copy labels and joins clipboard content with newlines for multi-selection', async () => {
+        const rowA = makeRow({ hash: 'hash-a', magnet_uri: 'magnet:?xt=hash-a' });
+        const rowB = makeRow({ hash: 'hash-b', magnet_uri: 'magnet:?xt=hash-b' });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+
+        expect(findItem(entries, 'torrent.copyInfoHash')?.label).toContain('copy-info-hashes');
+        (findItem(entries, 'torrent.copyInfoHash')!.action as () => void)();
+        expect(clipboard.copy).toHaveBeenCalledWith('hash-a\nhash-b');
+
+        expect(findItem(entries, 'torrent.copyMagnet')?.label).toContain('copy-magnet-links');
+        (findItem(entries, 'torrent.copyMagnet')!.action as () => void)();
+        expect(clipboard.copy).toHaveBeenCalledWith('magnet:?xt=hash-a\nmagnet:?xt=hash-b');
+
+        (findItem(entries, 'torrent.copyJson')!.action as () => void)();
+        expect(clipboard.copy).toHaveBeenCalledWith(JSON.stringify([rowA, rowB], null, 2));
+      });
+
+      it('uses singular copy labels for a single selection', async () => {
+        const entries = await service.buildTorrentMenu(makeData());
+
+        expect(findItem(entries, 'torrent.copyInfoHash')?.label).toBe(
+          'pages.main.grid.context-menu.item.copy-info-hash',
+        );
+        expect(findItem(entries, 'torrent.copyMagnet')?.label).toBe(
+          'pages.main.grid.context-menu.item.copy-magnet-link',
+        );
+      });
+    });
+
+    describe('super seeding tri-state', () => {
+      it('shows the checked icon, "disable" label and forces status true (toggling off) when every selected torrent has it on', async () => {
+        const rowA = makeRow({ hash: 'hash-a', super_seeding: true });
+        const rowB = makeRow({ hash: 'hash-b', super_seeding: true });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+        const item = findItem(entries, 'speed.superSeeding')!;
+
+        expect(item.label).toContain('disable-super-seeding');
+        expect(item.icon).toBe(faSquareCheck);
+        (item.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'TORRENT_SUPER_SEEDING',
+          status: true,
+        });
+      });
+
+      it('shows the empty icon, "enable" label and status false when every selected torrent has it off', async () => {
+        const rowA = makeRow({ hash: 'hash-a', super_seeding: false });
+        const rowB = makeRow({ hash: 'hash-b', super_seeding: false });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+        const item = findItem(entries, 'speed.superSeeding')!;
+
+        expect(item.label).toContain('enable-super-seeding');
+        expect(item.icon).toBe(faSquare);
+        (item.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'TORRENT_SUPER_SEEDING',
+          status: false,
+        });
+      });
+
+      it('shows the indeterminate icon, "enable" label and forces status false (enabling for all) when the selection is mixed', async () => {
+        const rowA = makeRow({ hash: 'hash-a', super_seeding: true });
+        const rowB = makeRow({ hash: 'hash-b', super_seeding: false });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+        const item = findItem(entries, 'speed.superSeeding')!;
+
+        expect(item.label).toContain('enable-super-seeding');
+        expect(item.icon).toBe(faSquareMinus);
+        (item.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'TORRENT_SUPER_SEEDING',
+          status: false,
+        });
+      });
+    });
+
+    describe('auto TMM tri-state', () => {
+      it('shows the checked icon, "disable" label and forces status true (toggling off) when every selected torrent has it on', async () => {
+        const rowA = makeRow({ hash: 'hash-a', auto_tmm: true });
+        const rowB = makeRow({ hash: 'hash-b', auto_tmm: true });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+        const item = findItem(entries, 'maintenance.autoTmm')!;
+
+        expect(item.label).toContain('disable-auto-tmm');
+        expect(item.icon).toBe(faSquareCheck);
+        (item.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'TORRENT_AUTO_TMM',
+          status: true,
+        });
+      });
+
+      it('shows the empty icon, "enable" label and status false when every selected torrent has it off', async () => {
+        const rowA = makeRow({ hash: 'hash-a', auto_tmm: false });
+        const rowB = makeRow({ hash: 'hash-b', auto_tmm: false });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+        const item = findItem(entries, 'maintenance.autoTmm')!;
+
+        expect(item.label).toContain('enable-auto-tmm');
+        expect(item.icon).toBe(faSquare);
+        (item.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'TORRENT_AUTO_TMM',
+          status: false,
+        });
+      });
+
+      it('shows the indeterminate icon, "enable" label and forces status false (enabling for all) when the selection is mixed', async () => {
+        const rowA = makeRow({ hash: 'hash-a', auto_tmm: true });
+        const rowB = makeRow({ hash: 'hash-b', auto_tmm: false });
+        const entries = await service.buildTorrentMenu(
+          makeData({ row: rowA, selected: [rowA, rowB] }),
+        );
+        const item = findItem(entries, 'maintenance.autoTmm')!;
+
+        expect(item.label).toContain('enable-auto-tmm');
+        expect(item.icon).toBe(faSquareMinus);
+        (item.action as () => void)();
+        expect(commandBusService.emit).toHaveBeenCalledWith({
+          type: 'TORRENT_AUTO_TMM',
+          status: false,
+        });
       });
     });
   });

--- a/packages/app/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/packages/app/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -1,6 +1,6 @@
 import { Clipboard } from '@angular/cdk/clipboard';
 import { Injectable, inject } from '@angular/core';
-import { faSquare, faSquareCheck } from '@fortawesome/free-regular-svg-icons';
+import { faSquare, faSquareCheck, faSquareMinus } from '@fortawesome/free-regular-svg-icons';
 import {
   faArrowDown,
   faArrowDownUpAcrossLine,
@@ -62,6 +62,15 @@ export class GridContextMenuService {
   private readonly torrentListGridSettingsService = inject(TorrentListGridSettingsService);
 
   public async buildTorrentMenu(data: GridContextMenuData): Promise<ContextMenuEntry[]> {
+    const isMulti = data.selected.length > 1;
+    const hashes = data.selected.map((torrent) => torrent.hash);
+
+    const allSuperSeeding = data.selected.every((torrent) => torrent.super_seeding);
+    const noneSuperSeeding = data.selected.every((torrent) => !torrent.super_seeding);
+
+    const allAutoTmm = data.selected.every((torrent) => torrent.auto_tmm);
+    const noneAutoTmm = data.selected.every((torrent) => !torrent.auto_tmm);
+
     return [
       {
         kind: 'item',
@@ -87,16 +96,23 @@ export class GridContextMenuService {
         action: () => this.commandBusService.emit({ type: 'TORRENT_FORCE_RESUME' }),
       },
       { kind: 'divider' },
-      {
-        kind: 'item',
-        id: 'torrent.details',
-        label: 'pages.main.grid.context-menu.item.torrent-details',
-        icon: faInfoCircle,
-        variant: 'info',
-        action: () =>
-          this.commandBusService.emit({ type: 'UI_OPEN_TORRENT_DETAILS', hash: data.row.hash }),
-      },
-      { kind: 'divider' },
+      ...(isMulti
+        ? []
+        : [
+            {
+              kind: 'item' as const,
+              id: 'torrent.details',
+              label: 'pages.main.grid.context-menu.item.torrent-details',
+              icon: faInfoCircle,
+              variant: 'info' as const,
+              action: () =>
+                this.commandBusService.emit({
+                  type: 'UI_OPEN_TORRENT_DETAILS',
+                  hash: data.row.hash,
+                }),
+            },
+            { kind: 'divider' as const },
+          ]),
 
       {
         kind: 'submenu',
@@ -104,58 +120,74 @@ export class GridContextMenuService {
         label: 'pages.main.grid.context-menu.submenu.files',
         icon: faFolderOpen,
         children: [
-          {
-            kind: 'item',
-            id: 'files.openDestination',
-            label:
-              (
-                await this.qbService.torrentContents(
-                  this.serverStoreService.currentServerId() as string,
-                  data.row.hash,
-                )
-              ).length === 1
-                ? 'pages.main.grid.context-menu.item.show-in-folder'
-                : 'pages.main.grid.context-menu.item.open-destination',
-            icon: faFolderOpen,
-            disabled: (await this.pathService.resolveLocalPath(data.row.save_path)) === null,
-            action: () =>
-              this.commandBusService.emit({
-                type: 'UI_OPEN_DESTINATION',
-                remotePath: data.row.content_path,
-                hash: data.row.hash,
-              }),
-          },
+          ...(isMulti
+            ? []
+            : [
+                {
+                  kind: 'item' as const,
+                  id: 'files.openDestination',
+                  label:
+                    (
+                      await this.qbService.torrentContents(
+                        this.serverStoreService.currentServerId() as string,
+                        data.row.hash,
+                      )
+                    ).length === 1
+                      ? 'pages.main.grid.context-menu.item.show-in-folder'
+                      : 'pages.main.grid.context-menu.item.open-destination',
+                  icon: faFolderOpen,
+                  disabled: (await this.pathService.resolveLocalPath(data.row.save_path)) === null,
+                  action: () =>
+                    this.commandBusService.emit({
+                      type: 'UI_OPEN_DESTINATION',
+                      remotePath: data.row.content_path,
+                      hash: data.row.hash,
+                    }),
+                },
+              ]),
           {
             kind: 'item',
             id: 'files.setLocation',
             label: 'pages.main.grid.context-menu.item.set-location',
             icon: faFolderOpen,
             action: () =>
-              this.commandBusService.emit({ type: 'UI_SET_TORRENT_LOCATION', torrent: data.row }),
+              this.commandBusService.emit({
+                type: 'UI_SET_TORRENT_LOCATION',
+                torrent: data.row,
+                hashes,
+              }),
           },
-          {
-            kind: 'item',
-            id: 'files.renameTorrent',
-            label: 'pages.main.grid.context-menu.item.rename-torrent',
-            icon: faPen,
-            action: () =>
-              this.commandBusService.emit({ type: 'UI_RENAME_TORRENT', torrent: data.row }),
-          },
-          {
-            kind: 'item',
-            id: 'files.renameFiles',
-            label: 'pages.main.grid.context-menu.item.rename-files',
-            icon: faFilePen,
-            action: () =>
-              this.commandBusService.emit({ type: 'UI_RENAME_FILES', hash: data.row.hash }),
-          },
+          ...(isMulti
+            ? []
+            : [
+                {
+                  kind: 'item' as const,
+                  id: 'files.renameTorrent',
+                  label: 'pages.main.grid.context-menu.item.rename-torrent',
+                  icon: faPen,
+                  action: () =>
+                    this.commandBusService.emit({ type: 'UI_RENAME_TORRENT', torrent: data.row }),
+                },
+                {
+                  kind: 'item' as const,
+                  id: 'files.renameFiles',
+                  label: 'pages.main.grid.context-menu.item.rename-files',
+                  icon: faFilePen,
+                  action: () =>
+                    this.commandBusService.emit({ type: 'UI_RENAME_FILES', hash: data.row.hash }),
+                },
+              ]),
           {
             kind: 'item',
             id: 'files.category',
             label: 'pages.main.grid.context-menu.item.set-category',
             icon: faFolderTree,
             action: () =>
-              this.commandBusService.emit({ type: 'UI_SET_TORRENT_CATEGORY', torrent: data.row }),
+              this.commandBusService.emit({
+                type: 'UI_SET_TORRENT_CATEGORY',
+                torrent: data.row,
+                hashes,
+              }),
           },
           {
             kind: 'item',
@@ -163,7 +195,11 @@ export class GridContextMenuService {
             label: 'pages.main.grid.context-menu.item.set-tags',
             icon: faTags,
             action: () =>
-              this.commandBusService.emit({ type: 'UI_SET_TORRENT_TAGS', torrent: data.row }),
+              this.commandBusService.emit({
+                type: 'UI_SET_TORRENT_TAGS',
+                torrent: data.row,
+                hashes,
+              }),
           },
         ],
       },
@@ -236,14 +272,14 @@ export class GridContextMenuService {
           {
             kind: 'item',
             id: 'speed.superSeeding',
-            label: data.row.super_seeding
+            label: allSuperSeeding
               ? 'pages.main.grid.context-menu.item.disable-super-seeding'
               : 'pages.main.grid.context-menu.item.enable-super-seeding',
-            icon: data.row.super_seeding ? faSquareCheck : faSquare,
+            icon: allSuperSeeding ? faSquareCheck : noneSuperSeeding ? faSquare : faSquareMinus,
             action: () =>
               this.commandBusService.emit({
                 type: 'TORRENT_SUPER_SEEDING',
-                status: data.row.super_seeding,
+                status: allSuperSeeding,
               }),
           },
         ],
@@ -272,12 +308,12 @@ export class GridContextMenuService {
           {
             kind: 'item',
             id: 'maintenance.autoTmm',
-            label: data.row.auto_tmm
+            label: allAutoTmm
               ? 'pages.main.grid.context-menu.item.disable-auto-tmm'
               : 'pages.main.grid.context-menu.item.enable-auto-tmm',
-            icon: data.row.auto_tmm ? faSquareCheck : faSquare,
+            icon: allAutoTmm ? faSquareCheck : noneAutoTmm ? faSquare : faSquareMinus,
             action: () =>
-              this.commandBusService.emit({ type: 'TORRENT_AUTO_TMM', status: data.row.auto_tmm }),
+              this.commandBusService.emit({ type: 'TORRENT_AUTO_TMM', status: allAutoTmm }),
           },
         ],
       },
@@ -288,33 +324,46 @@ export class GridContextMenuService {
         label: 'pages.main.grid.context-menu.submenu.copy',
         icon: faCopy,
         children: [
-          {
-            kind: 'item',
-            id: 'cell.copyValue',
-            label: 'pages.main.grid.context-menu.item.copy-cell-value',
-            icon: faCopy,
-            action: () => this.clipboard.copy(String(data.cell.value)),
-          },
+          ...(isMulti
+            ? []
+            : [
+                {
+                  kind: 'item' as const,
+                  id: 'cell.copyValue',
+                  label: 'pages.main.grid.context-menu.item.copy-cell-value',
+                  icon: faCopy,
+                  action: () => this.clipboard.copy(String(data.cell.value)),
+                },
+              ]),
           {
             kind: 'item',
             id: 'torrent.copyInfoHash',
-            label: 'pages.main.grid.context-menu.item.copy-info-hash',
+            label: isMulti
+              ? 'pages.main.grid.context-menu.item.copy-info-hashes'
+              : 'pages.main.grid.context-menu.item.copy-info-hash',
             icon: faHashtag,
-            action: () => this.clipboard.copy(String(data.row.hash)),
+            action: () => this.clipboard.copy(isMulti ? hashes.join('\n') : String(data.row.hash)),
           },
           {
             kind: 'item',
             id: 'torrent.copyMagnet',
-            label: 'pages.main.grid.context-menu.item.copy-magnet-link',
+            label: isMulti
+              ? 'pages.main.grid.context-menu.item.copy-magnet-links'
+              : 'pages.main.grid.context-menu.item.copy-magnet-link',
             icon: faLink,
-            action: () => this.clipboard.copy(String(data.row.magnet_uri)),
+            action: () =>
+              this.clipboard.copy(
+                isMulti
+                  ? data.selected.map((torrent) => torrent.magnet_uri).join('\n')
+                  : String(data.row.magnet_uri),
+              ),
           },
           {
             kind: 'item',
             id: 'torrent.copyJson',
             label: 'pages.main.grid.context-menu.item.copy-as-json',
             icon: faCode,
-            action: () => this.clipboard.copy(String(JSON.stringify(data.row, null, 2))),
+            action: () => this.clipboard.copy(String(JSON.stringify(data.selected, null, 2))),
           },
         ],
       },

--- a/packages/app/src/app/pages/main/grid/grid.ts
+++ b/packages/app/src/app/pages/main/grid/grid.ts
@@ -283,9 +283,13 @@ export class Grid implements AfterViewInit {
   private handleCellRightClick = async (event: CellContextMenuEvent<Torrent, any>) => {
     if (!event.data) return;
 
-    if (this.selectionStore.selected().length <= 1) {
-      this.selectionStore.setByHashes([event.data.hash]);
-    }
+    const currentSelection = this.selectionStore.selected();
+
+    this.selectionStore.setByHashes(
+      currentSelection.length <= 1
+        ? [event.data.hash]
+        : currentSelection.map((torrent) => torrent.hash),
+    );
 
     this.contextMenuService.open({
       items: await this.gridContextMenuService.buildTorrentMenu({

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -934,7 +934,9 @@
           "item": {
             "copy-cell-value": "Cella értékének másolása",
             "copy-info-hash": "Info hash másolása",
+            "copy-info-hashes": "Info hash-ek másolása",
             "copy-magnet-link": "Magnet link másolása",
+            "copy-magnet-links": "Magnet linkek másolása",
             "copy-as-json": "Másolás JSON-ként",
             "torrent-details": "Torrent részletei",
             "start": "Indítás",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -934,7 +934,9 @@
           "item": {
             "copy-cell-value": "Copy cell value",
             "copy-info-hash": "Copy info hash",
+            "copy-info-hashes": "Copy info hashes",
             "copy-magnet-link": "Copy magnet link",
+            "copy-magnet-links": "Copy magnet links",
             "copy-as-json": "Copy as JSON",
             "torrent-details": "Torrent details",
             "start": "Start",


### PR DESCRIPTION
## Issue ID

Fixes #135

## Description

The torrent grid's right-click context menu built a single, static layout regardless of how many torrents were selected, and several actions only ever targeted the right-clicked row even though the underlying handlers can act on the whole selection.

`buildTorrentMenu` now adapts to the selection:

- Single-target-only items (`Details`, `Open destination`, `Rename torrent`, `Rename files`, `Copy cell value`) are hidden when more than one torrent is selected.
- `Set location` / `Set category` / `Set tags` now act on the full selection (passing explicit `hashes`, building on the fix from #133/#134) while still seeding the form from the right-clicked row.
- `Copy info hash` / `Copy magnet link` pluralize their labels and join clipboard content with newlines for multi-selections; `Copy as JSON` always serializes the full selection array.
- `Super seeding` and `Auto TMM` show tri-state icons (checked / empty / indeterminate) reflecting whether the selection is uniformly on, uniformly off, or mixed - clicking a mixed/indeterminate state enables it for the whole selection.
- Added `copy-info-hashes` / `copy-magnet-links` i18n keys (English and Hungarian).