### PR TITLE
Create tags and categories inline from the tag/category selectors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -104,7 +104,9 @@
       "mcp__plugin_playwright_playwright__browser_take_screenshot",
       "mcp__plugin_playwright_playwright__browser_press_key",
       "mcp__plugin_playwright_playwright__browser_resize",
-      "Bash(Select-String -Pattern \"Server\")"
+      "Bash(Select-String -Pattern \"Server\")",
+      "Bash(gh release *)",
+      "Bash(gh label *)"
     ]
   }
 }

--- a/docs/superpowers/plans/2026-06-10-tag-category-addtag-create.md
+++ b/docs/superpowers/plans/2026-06-10-tag-category-addtag-create.md
@@ -1,0 +1,617 @@
+# Tag/Category Select - addTag Create Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users type a tag or category that doesn't exist yet directly into `TagSelect` / `CategorySelect`, creating it on submit (not on type) for categories.
+
+**Architecture:** Enable ng-select's `addTag` (identity function, mirroring `SavePathSelect`) on both selects. `CategorySelect` gains a public `ensureCategoryExists()` method that lazily creates a missing category via `QbService.addCategory(serverId, value, '')` when called. `SetTorrentCategory` and `AddTorrent` call it at the start of their submit handlers, aborting the submit if it returns `false`. Tags need no extra wiring - `addTorrentTags` auto-creates them server-side. The category-select popover gets a third, warning-styled paragraph explaining the empty-save-path implication.
+
+**Tech Stack:** Angular 20 (standalone components, signals), `@ng-select/ng-select`, `@ngx-translate/core`, `@fortawesome/angular-fontawesome`, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-tag-category-addtag-create.md`
+
+---
+
+### Task 1: TagSelect - enable `addTag`
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/tag-select/tag-select.ts`
+- Modify: `packages/app/src/app/components/tag-select/tag-select.html`
+- Test: `packages/app/src/app/components/tag-select/tag-select.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/app/src/app/components/tag-select/tag-select.spec.ts`, add a new `describe` block after the `keyDownFn` block (after line 68):
+
+```ts
+describe('addTag', () => {
+  it('should return the trimmed term', () => {
+    expect(component.addTag('  new-tag  ')).toBe('new-tag');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/tag-select/tag-select.spec.ts`
+Expected: FAIL with `component.addTag is not a function`
+
+- [ ] **Step 3: Implement `addTag`**
+
+In `packages/app/src/app/components/tag-select/tag-select.ts`, insert a new method between the closing brace of `setDisabledState` (line 89) and `keyDownFn` (line 91):
+
+```ts
+  setDisabledState?(isDisabled: boolean): void {
+    if (isDisabled) {
+      this.selectControl.disable();
+    } else {
+      this.selectControl.enable();
+    }
+  }
+
+  addTag = (term: string): string => term.trim();
+
+  keyDownFn(event: KeyboardEvent): boolean {
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/tag-select/tag-select.spec.ts`
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: Wire `addTag` into the template**
+
+In `packages/app/src/app/components/tag-select/tag-select.html`, add `[addTag]="addTag"` to the `<ng-select>` right after `[clearSearchOnAdd]="true"`:
+
+```html
+<ng-select
+  data-testid="tag-select-input"
+  [items]="tags()"
+  [multiple]="true"
+  [hideSelected]="true"
+  [searchable]="true"
+  [clearable]="true"
+  [clearSearchOnAdd]="true"
+  [addTag]="addTag"
+  [formControl]="selectControl"
+  [keyDownFn]="keyDownFn"
+  [openOnEnter]="false"
+  #ngselect
+></ng-select>
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/app/components/tag-select/tag-select.ts packages/app/src/app/components/tag-select/tag-select.html packages/app/src/app/components/tag-select/tag-select.spec.ts
+git commit -m "#143: enable addTag on TagSelect"
+```
+
+---
+
+### Task 2: CategorySelect - `addTag` + `ensureCategoryExists()`
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/category-select/category-select.ts`
+- Modify: `packages/app/src/app/components/category-select/category-select.html`
+- Test: `packages/app/src/app/components/category-select/category-select.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/app/src/app/components/category-select/category-select.spec.ts`:
+
+1. Add `addCategory` to the `mockQbService` object (lines 14-16):
+
+```ts
+mockQbService = {
+  getAllCategories: vi.fn().mockResolvedValue({ movies: {}, tv: {} }),
+  addCategory: vi.fn().mockResolvedValue(undefined),
+};
+```
+
+2. Add new `describe` blocks after the `keyDownFn` block (after line 76):
+
+```ts
+describe('addTag', () => {
+  it('should return the trimmed term', () => {
+    expect(component.addTag('  New Category  ')).toBe('New Category');
+  });
+});
+
+describe('ensureCategoryExists', () => {
+  beforeEach(async () => {
+    await vi.waitUntil(() => component.categories().length > 0);
+  });
+
+  it('should return true and not call addCategory for an empty value', async () => {
+    component.selectControl.setValue('');
+    expect(await component.ensureCategoryExists()).toBe(true);
+    expect(mockQbService.addCategory).not.toHaveBeenCalled();
+  });
+
+  it('should return true and not call addCategory for an existing category', async () => {
+    component.selectControl.setValue('movies');
+    expect(await component.ensureCategoryExists()).toBe(true);
+    expect(mockQbService.addCategory).not.toHaveBeenCalled();
+  });
+
+  it('should create a new category and add it to the known list', async () => {
+    component.selectControl.setValue('new-category');
+    expect(await component.ensureCategoryExists()).toBe(true);
+    expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'new-category', '');
+    expect(component.categories()).toContain('new-category');
+  });
+
+  it('should return false when addCategory fails', async () => {
+    mockQbService.addCategory.mockRejectedValueOnce(new Error('failed'));
+    component.selectControl.setValue('bad-category');
+    expect(await component.ensureCategoryExists()).toBe(false);
+    expect(component.categories()).not.toContain('bad-category');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/category-select/category-select.spec.ts`
+Expected: FAIL - `component.addTag is not a function` and `component.ensureCategoryExists is not a function`
+
+- [ ] **Step 3: Implement `addTag` and `ensureCategoryExists`**
+
+In `packages/app/src/app/components/category-select/category-select.ts`, insert `addTag` between the closing brace of `setDisabledState` (line 98) and `keyDownFn` (line 100):
+
+```ts
+  setDisabledState?(isDisabled: boolean): void {
+    if (isDisabled) {
+      this.selectControl.disable();
+    } else {
+      this.selectControl.enable();
+    }
+  }
+
+  addTag = (term: string): string => term.trim();
+
+  keyDownFn(event: KeyboardEvent): boolean {
+    if (event.key === 'Escape') {
+      return false;
+    }
+
+    return true;
+  }
+
+  public async ensureCategoryExists(): Promise<boolean> {
+    const value = (this.selectControl.value ?? '').trim();
+    if (!value || this.categories().includes(value)) {
+      return true;
+    }
+
+    try {
+      await this.qbService.addCategory(
+        this.serverStoreService.currentServerId() as string,
+        value,
+        '',
+      );
+      this.categories.update((cats) => [...cats, value]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  public openManageCategories(): void {
+```
+
+(`ensureCategoryExists` replaces the line break between the existing `keyDownFn` and `openManageCategories` methods - `keyDownFn`'s body is unchanged, only the new method is inserted before `openManageCategories`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/category-select/category-select.spec.ts`
+Expected: PASS (15 tests)
+
+- [ ] **Step 5: Wire `addTag` into the template**
+
+In `packages/app/src/app/components/category-select/category-select.html`, add `[addTag]="addTag"` to the `<ng-select>` right after `[clearable]="true"`:
+
+```html
+<ng-select
+  data-testid="category-select-input"
+  [items]="categories()"
+  [searchable]="true"
+  [clearable]="true"
+  [addTag]="addTag"
+  [formControl]="selectControl"
+  [keyDownFn]="keyDownFn"
+  [openOnEnter]="false"
+  #ngselect
+></ng-select>
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/app/components/category-select/category-select.ts packages/app/src/app/components/category-select/category-select.html packages/app/src/app/components/category-select/category-select.spec.ts
+git commit -m "#143: add addTag and ensureCategoryExists to CategorySelect"
+```
+
+---
+
+### Task 3: CategorySelect - popover warning (empty save path)
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/category-select/category-select.ts`
+- Modify: `packages/app/src/app/components/category-select/category-select.html`
+- Modify: `public/i18n/us.json`
+- Modify: `public/i18n/hu.json`
+
+- [ ] **Step 1: Add the i18n strings**
+
+In `public/i18n/us.json`, update the `category-select.popover.description` block (around line 171-174):
+
+```json
+        "description": {
+          "line1": "Assigns the torrent to a category. Categories are useful for organizing your downloads and can also define a default save path.",
+          "line2": "If Auto TMM is enabled, changing the category may automatically move the files.",
+          "line3": "Adding a new category here creates it with an empty save path. Whether this affects where your torrents are stored depends on the qBittorrent 'Default torrent management mode' and 'When category save path changes' settings."
+        }
+```
+
+In `public/i18n/hu.json`, update the same block (around line 171-174):
+
+```json
+        "description": {
+          "line1": "Kategóriát rendel a torrenthez. A kategóriák hasznosak a letöltések rendszerezéséhez, és alapértelmezett mentési útvonalat is meghatározhatnak.",
+          "line2": "Ha az automatikus torrentkezelés (TMM) engedélyezve van, a kategória megváltoztatása automatikusan áthelyezheti a fájlokat.",
+          "line3": "Az itt hozzáadott új kategória üres mentési útvonallal jön létre. Hogy ez hogyan befolyásolja a torrentek tárolási helyét, az a qBittorrent 'Alapértelmezett torrent kezelési mód' és 'Amikor a kategória mentési útvonala megváltozik' beállításaitól függ."
+        }
+```
+
+- [ ] **Step 2: Add the icon import and `icons` property**
+
+In `packages/app/src/app/components/category-select/category-select.ts`:
+
+1. Add two new imports between the `@angular/forms` import (line 18) and the `@ng-bootstrap/ng-bootstrap` import (line 19):
+
+```ts
+import {
+  ControlValueAccessor,
+  FormControl,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+```
+
+2. Add `FaIconComponent` to the component's `imports` array (line 30):
+
+```ts
+  imports: [CommonModule, ReactiveFormsModule, NgSelectComponent, FaIconComponent, TranslatePipe, BbPopover],
+```
+
+3. Add an `icons` property right after the injected services (after line 48, before `public categories = signal<string[]>([]);`):
+
+```ts
+  private readonly modalService = inject(NgbModal);
+
+  public readonly icons = { faTriangleExclamation };
+
+  public categories = signal<string[]>([]);
+```
+
+- [ ] **Step 3: Add the warning paragraph to the popover template**
+
+In `packages/app/src/app/components/category-select/category-select.html`, update the `#categoryPopover` template (lines 40-43):
+
+```html
+<ng-template #categoryPopover>
+  <p>{{ 'components.category-select.popover.description.line1' | translate }}</p>
+  <p>{{ 'components.category-select.popover.description.line2' | translate }}</p>
+  <p class="text-warning mb-0">
+    <fa-icon [icon]="icons.faTriangleExclamation" class="me-1"></fa-icon>
+    {{ 'components.category-select.popover.description.line3' | translate }}
+  </p>
+</ng-template>
+```
+
+- [ ] **Step 4: Run lint and the existing component tests**
+
+Run: `npm run lint --workspace=packages/app`
+Expected: PASS, zero warnings
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/category-select/category-select.spec.ts`
+Expected: PASS (15 tests, unchanged from Task 2)
+
+- [ ] **Step 5: Manual verification**
+
+Run `npm start` from the repo root, open the Add Torrent modal (or Set Category modal), hover the info icon next to the Category field, and confirm the popover shows three lines, with the third line in a yellow/warning color and a leading triangle-exclamation icon.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/app/components/category-select/category-select.ts packages/app/src/app/components/category-select/category-select.html public/i18n/us.json public/i18n/hu.json
+git commit -m "#143: add empty-save-path warning to category-select popover"
+```
+
+---
+
+### Task 4: SetTorrentCategory - create category on submit
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts`
+- Test: `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts`:
+
+1. Add `addCategory` to the `QbService` mock (lines 22-28):
+
+```ts
+        {
+          provide: QbService,
+          useValue: {
+            getAllCategories: vi.fn().mockResolvedValue({}),
+            addCategory: vi.fn().mockResolvedValue(undefined),
+            setTorrentCategory: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+```
+
+2. Add two new tests inside the `describe('handleSubmit', ...)` block (after line 74):
+
+```ts
+it('should create the category via ensureCategoryExists before setting it', async () => {
+  const mockQbService = TestBed.inject(QbService) as unknown as {
+    addCategory: ReturnType<typeof vi.fn>;
+    setTorrentCategory: ReturnType<typeof vi.fn>;
+  };
+  component.setTorrentCategoryForm.get('category')?.setValue('new-category');
+  await component.handleSubmit();
+  expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'new-category', '');
+  expect(mockQbService.setTorrentCategory).toHaveBeenCalledWith(
+    'server-1',
+    ['hash-1'],
+    'new-category',
+  );
+});
+
+it('should not set the category and reset saving when ensureCategoryExists fails', async () => {
+  const mockQbService = TestBed.inject(QbService) as unknown as {
+    addCategory: ReturnType<typeof vi.fn>;
+    setTorrentCategory: ReturnType<typeof vi.fn>;
+  };
+  mockQbService.addCategory.mockRejectedValueOnce(new Error('failed'));
+  component.setTorrentCategoryForm.get('category')?.setValue('bad-category');
+  await component.handleSubmit();
+  expect(mockQbService.setTorrentCategory).not.toHaveBeenCalled();
+  expect(component.saving).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts`
+Expected: The new "create the category" and "ensureCategoryExists fails" tests FAIL because `setTorrentCategory` is currently called unconditionally with no prior `addCategory` call, and `categorySelect` doesn't exist yet.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts`:
+
+1. Add `viewChild` to the `@angular/core` import (line 2):
+
+```ts
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
+```
+
+2. Add a `viewChild` reference to `CategorySelect` after `public readonly qbService = inject(QbService);` (line 33):
+
+```ts
+  public readonly qbService = inject(QbService);
+
+  private readonly categorySelect = viewChild(CategorySelect);
+
+  public readonly selected = computed(() => this.hashes().length);
+```
+
+3. Update `handleSubmit` (lines 45-64) to call `ensureCategoryExists()` first:
+
+```ts
+  public async handleSubmit(): Promise<void> {
+    this.saving = true;
+
+    if (!(await this.categorySelect()?.ensureCategoryExists())) {
+      this.saving = false;
+      return;
+    }
+
+    const category = this.setTorrentCategoryForm.get('category')?.value || '';
+    const serverId = this.serverStoreService.currentServerId() ?? '';
+
+    try {
+      await this.qbService.setTorrentCategory(serverId, this.hashes(), category);
+      this.activeModal.close();
+    } catch (error) {
+      console.error(
+        SetTorrentCategory.name,
+        'handleSubmit',
+        'Failed to set torrent category!',
+        error,
+      );
+    } finally {
+      this.saving = false;
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts
+git commit -m "#143: create category on submit in SetTorrentCategory"
+```
+
+---
+
+### Task 5: AddTorrent - create category on submit
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/add-torrent/add-torrent.ts`
+- Test: `packages/app/src/app/components/add-torrent/add-torrent.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/app/src/app/components/add-torrent/add-torrent.spec.ts`:
+
+1. Add `addCategory` to the `QbService` mock (after `getAllCategories`, around line 60):
+
+```ts
+            getAllCategories: vi.fn().mockResolvedValue({}),
+            addCategory: vi.fn().mockResolvedValue(undefined),
+            getAllTags: vi.fn().mockResolvedValue([]),
+```
+
+2. Add a new `describe` block at the end of the file, before the final closing `});` (after line 180):
+
+```ts
+describe('handleSubmit category creation', () => {
+  let mockQbService: any;
+  let torrentsAddSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockQbService = TestBed.inject(QbService) as any;
+    torrentsAddSpy = vi.spyOn(window.bitbutler.qb, 'torrentsAdd').mockClear();
+    (component as any).selectedTorrentFile.set({ name: 'test.torrent', path: '/tmp/test.torrent' });
+    component.addForm.controls.rename.setValue('test-torrent');
+  });
+
+  it('should create a typed category before adding the torrent', async () => {
+    component.addForm.controls.category.setValue('new-category');
+
+    await component.handleSubmit({ preventDefault: () => {} } as unknown as SubmitEvent);
+
+    expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'new-category', '');
+    expect(torrentsAddSpy).toHaveBeenCalled();
+  });
+
+  it('should abort without adding the torrent when category creation fails', async () => {
+    mockQbService.addCategory.mockRejectedValueOnce(new Error('failed'));
+    component.addForm.controls.category.setValue('bad-category');
+
+    await component.handleSubmit({ preventDefault: () => {} } as unknown as SubmitEvent);
+
+    expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'bad-category', '');
+    expect(torrentsAddSpy).not.toHaveBeenCalled();
+    expect(component.isSubmitting()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/add-torrent/add-torrent.spec.ts`
+Expected: The new tests FAIL - `torrentsAdd` is called regardless of `addCategory`, since `handleSubmit` doesn't yet call `ensureCategoryExists()`.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `packages/app/src/app/components/add-torrent/add-torrent.ts`:
+
+1. Add `viewChild` to the `@angular/core` import (lines 2-10):
+
+```ts
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostListener,
+  OnInit,
+  computed,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+```
+
+2. Add a `viewChild` reference to `CategorySelect` after the injected services block, right after `private readonly translateService = inject(TranslateService);` (line 97):
+
+```ts
+  private readonly translateService = inject(TranslateService);
+
+  private readonly categorySelect = viewChild(CategorySelect);
+
+  public pending = this.openFilesService.pendingDrafts;
+```
+
+3. In `handleSubmit`, insert the `ensureCategoryExists()` check right after the `serverId` guard (lines 218-221), before `const raw = this.addForm.getRawValue() as AddTorrentFormValue;`:
+
+```ts
+if (!serverId) {
+  this.addForm.setErrors({ noServerSelected: true });
+  return;
+}
+
+if (!(await this.categorySelect()?.ensureCategoryExists())) {
+  return;
+}
+
+const raw = this.addForm.getRawValue() as AddTorrentFormValue;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test --workspace=packages/app -- --watch=false --include=src/app/components/add-torrent/add-torrent.spec.ts`
+Expected: PASS (all tests, including the 2 new ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app/src/app/components/add-torrent/add-torrent.ts packages/app/src/app/components/add-torrent/add-torrent.spec.ts
+git commit -m "#143: create category on submit in AddTorrent"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full app test suite**
+
+Run: `npm run test --workspace=packages/app -- --watch=false`
+Expected: All test files pass (119+ files, 1234+ tests)
+
+- [ ] **Step 2: Run lint across the workspace**
+
+Run: `npm run lint`
+Expected: PASS, zero warnings
+
+- [ ] **Step 3: Manual end-to-end check**
+
+Run `npm start`. In the running app:
+
+- Open "Add Torrent", type a brand-new category name into the category field and press Enter, fill in the rest of the form, and submit. Confirm the torrent is added and the new category now appears in "Manage categories" with an empty save path.
+- Open "Set Category" on an existing torrent, type a different brand-new category name, then click Cancel. Confirm via "Manage categories" that the category was NOT created.
+- Repeat the "Set Category" flow but click Save. Confirm the category is created and applied to the torrent.
+- Type a brand-new tag into the tag field on either modal, submit, and confirm the tag is created and applied (via "Manage tags").
+
+- [ ] **Step 4: Push the branch (only if requested by the user)**
+
+Do not push or open a PR unless the user asks.

--- a/docs/superpowers/plans/2026-06-10-tag-category-manage-hint.md
+++ b/docs/superpowers/plans/2026-06-10-tag-category-manage-hint.md
@@ -1,0 +1,301 @@
+# Tag/Category Select Manage Hint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dropdown-footer "Manage tags"/"Manage categories" button in `TagSelect` and `CategorySelect` with a persistent link-style hint below the input that opens the same manage modal.
+
+**Architecture:** Both components currently render an `ng-select` with an `ng-footer-tmp` template containing a "Manage" button only visible while the dropdown is open. Remove that template (and the now-unused `NgFooterTemplateDirective` import) and add a `form-text` hint - a `btn btn-link btn-sm` styled button - as a sibling of the existing two-column `.row`, so the popover icon's vertical alignment in `.col-1` is unaffected. The button reuses the existing `openManageTags()`/`openManageCategories()` methods and the existing `components.tag-select.manage`/`components.category-select.manage` translation keys (no new i18n strings).
+
+**Tech Stack:** Angular 20 (standalone components, signals), `@ng-select/ng-select`, `@ngx-translate/core`, Bootstrap 5, Vitest.
+
+---
+
+## Reference: spec
+
+See `docs/superpowers/specs/2026-06-10-tag-category-manage-hint.md` for the approved design. One refinement made during planning: the hint is placed as a sibling of `.row` (full width of `.container-fluid`) rather than inside `.col-11`, so it doesn't change the row's height and the `bb-popover` icon in `.col-1` stays aligned exactly as before - no alignment verification/adjustment needed.
+
+---
+
+### Task 1: TagSelect - replace footer manage button with hint link
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/tag-select/tag-select.html`
+- Modify: `packages/app/src/app/components/tag-select/tag-select.ts`
+- Test: `packages/app/src/app/components/tag-select/tag-select.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/app/src/app/components/tag-select/tag-select.spec.ts`, add a new `describe` block right after the existing `describe('openManageTags', ...)` block (i.e. just before the final closing `});` of the outer `describe('TagSelect', ...)`):
+
+```typescript
+describe('manage hint link', () => {
+  it('should open the ManageTags modal when clicked', () => {
+    const button = fixture.nativeElement.querySelector(
+      '[data-testid="tag-select-manage"]',
+    ) as HTMLButtonElement;
+
+    button.click();
+
+    expect(mockModalService.open).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace=@bitbutler/app -- --include=src/app/components/tag-select/tag-select.spec.ts`
+
+Expected: FAIL - the new "manage hint link > should open the ManageTags modal when clicked" test throws `TypeError: Cannot read properties of null (reading 'click')` because no element matches `[data-testid="tag-select-manage"]` yet.
+
+- [ ] **Step 3: Replace `tag-select.html`**
+
+Replace the entire file contents with:
+
+```html
+<div class="container-fluid px-0">
+  <div class="row">
+    <div class="col-11">
+      <div class="form-floating">
+        <ng-select
+          data-testid="tag-select-input"
+          [items]="tags()"
+          [multiple]="true"
+          [hideSelected]="true"
+          [searchable]="true"
+          [clearable]="true"
+          [clearSearchOnAdd]="true"
+          [formControl]="selectControl"
+          [keyDownFn]="keyDownFn"
+          [openOnEnter]="false"
+          #ngselect
+        ></ng-select>
+        <label>{{ 'components.tag-select.label' | translate }}</label>
+      </div>
+    </div>
+
+    <div class="col-1 d-flex align-items-center">
+      <bb-popover
+        [subject]="'components.tag-select.popover.title' | translate"
+        [description]="tagPopover"
+        placement="left"
+      ></bb-popover>
+    </div>
+  </div>
+
+  <div class="form-text">
+    <button
+      type="button"
+      class="btn btn-link btn-sm p-0 align-baseline"
+      data-testid="tag-select-manage"
+      (click)="openManageTags()"
+    >
+      {{ 'components.tag-select.manage' | translate }}
+    </button>
+  </div>
+</div>
+
+<ng-template #tagPopover>
+  <p>{{ 'components.tag-select.popover.description.line1' | translate }}</p>
+  <p>{{ 'components.tag-select.popover.description.line2' | translate }}</p>
+</ng-template>
+```
+
+This removes the `<ng-template ng-footer-tmp>` block and adds the hint link below the row.
+
+- [ ] **Step 4: Update `tag-select.ts` imports**
+
+In `packages/app/src/app/components/tag-select/tag-select.ts`, change the `@ng-select/ng-select` import (currently):
+
+```typescript
+import { NgFooterTemplateDirective, NgSelectComponent } from '@ng-select/ng-select';
+```
+
+to:
+
+```typescript
+import { NgSelectComponent } from '@ng-select/ng-select';
+```
+
+Then in the `@Component` decorator's `imports` array, remove the `NgFooterTemplateDirective` entry:
+
+```typescript
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    NgSelectComponent,
+    TranslatePipe,
+    BbPopover,
+  ],
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test --workspace=@bitbutler/app -- --include=src/app/components/tag-select/tag-select.spec.ts`
+
+Expected: PASS - all 10 tests pass (9 existing + the new "manage hint link" test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/app/components/tag-select/tag-select.html packages/app/src/app/components/tag-select/tag-select.ts packages/app/src/app/components/tag-select/tag-select.spec.ts
+git commit -m "#143: replace tag select footer manage button with hint link"
+```
+
+---
+
+### Task 2: CategorySelect - replace footer manage button with hint link
+
+**Files:**
+
+- Modify: `packages/app/src/app/components/category-select/category-select.html`
+- Modify: `packages/app/src/app/components/category-select/category-select.ts`
+- Test: `packages/app/src/app/components/category-select/category-select.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/app/src/app/components/category-select/category-select.spec.ts`, add a new `describe` block right after the existing `describe('openManageCategories', ...)` block (i.e. just before the final closing `});` of the outer `describe('CategorySelect', ...)`):
+
+```typescript
+describe('manage hint link', () => {
+  it('should open the ManageCategories modal when clicked', () => {
+    const modalService = TestBed.inject(NgbModal);
+    const button = fixture.nativeElement.querySelector(
+      '[data-testid="category-select-manage"]',
+    ) as HTMLButtonElement;
+
+    button.click();
+
+    expect(modalService.open).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace=@bitbutler/app -- --include=src/app/components/category-select/category-select.spec.ts`
+
+Expected: FAIL - the new "manage hint link > should open the ManageCategories modal when clicked" test throws `TypeError: Cannot read properties of null (reading 'click')` because no element matches `[data-testid="category-select-manage"]` yet.
+
+- [ ] **Step 3: Replace `category-select.html`**
+
+Replace the entire file contents with:
+
+```html
+<div class="container-fluid px-0">
+  <div class="row">
+    <div class="col-11">
+      <div class="form-floating">
+        <ng-select
+          data-testid="category-select-input"
+          [items]="categories()"
+          [searchable]="true"
+          [clearable]="true"
+          [formControl]="selectControl"
+          [keyDownFn]="keyDownFn"
+          [openOnEnter]="false"
+          #ngselect
+        ></ng-select>
+        <label>{{ 'components.category-select.label' | translate }}</label>
+      </div>
+    </div>
+
+    <div class="col-1 d-flex align-items-center">
+      <bb-popover
+        [subject]="'components.category-select.popover.title' | translate"
+        [description]="categoryPopover"
+        placement="left"
+      ></bb-popover>
+    </div>
+  </div>
+
+  <div class="form-text">
+    <button
+      type="button"
+      class="btn btn-link btn-sm p-0 align-baseline"
+      data-testid="category-select-manage"
+      (click)="openManageCategories()"
+    >
+      {{ 'components.category-select.manage' | translate }}
+    </button>
+  </div>
+</div>
+
+<ng-template #categoryPopover>
+  <p>{{ 'components.category-select.popover.description.line1' | translate }}</p>
+  <p>{{ 'components.category-select.popover.description.line2' | translate }}</p>
+</ng-template>
+```
+
+This removes the `<ng-template ng-footer-tmp>` block and adds the hint link below the row.
+
+- [ ] **Step 4: Update `category-select.ts` imports**
+
+In `packages/app/src/app/components/category-select/category-select.ts`, change the `@ng-select/ng-select` import (currently):
+
+```typescript
+import { NgFooterTemplateDirective, NgSelectComponent } from '@ng-select/ng-select';
+```
+
+to:
+
+```typescript
+import { NgSelectComponent } from '@ng-select/ng-select';
+```
+
+Then in the `@Component` decorator's `imports` array, remove the `NgFooterTemplateDirective` entry:
+
+```typescript
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    NgSelectComponent,
+    TranslatePipe,
+    BbPopover,
+  ],
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test --workspace=@bitbutler/app -- --include=src/app/components/category-select/category-select.spec.ts`
+
+Expected: PASS - all 9 tests pass (8 existing + the new "manage hint link" test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/app/src/app/components/category-select/category-select.html packages/app/src/app/components/category-select/category-select.ts packages/app/src/app/components/category-select/category-select.spec.ts
+git commit -m "#143: replace category select footer manage button with hint link"
+```
+
+---
+
+### Task 3: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run lint across the repo**
+
+Run: `npm run lint`
+
+Expected: PASS with zero warnings/errors (the removed `NgFooterTemplateDirective` import must not leave an unused-import lint error).
+
+- [ ] **Step 2: Run the full app test suite**
+
+Run: `npm run test --workspace=@bitbutler/app`
+
+Expected: PASS - all tests in `packages/app` pass, including the two new "manage hint link" tests.
+
+- [ ] **Step 3: Manual verification in the running app**
+
+Run: `npm start`
+
+In the app:
+
+1. Open the "Add Torrent" dialog (it renders both `app-tag-select` and `app-category-select`).
+2. Confirm the dropdown no longer shows a "Manage tags"/"Manage categories" button when opened.
+3. Confirm a "Manage tags"/"Manage categories" link is visible below each input at all times.
+4. Click each link and confirm the corresponding `ManageTags`/`ManageCategories` modal opens.
+5. Confirm the popover (`i`) icon next to each input is still vertically aligned with the input as before.
+
+Close the app when done (no code changes expected from this step; if something looks wrong, fix it in the relevant component file from Task 1/2 and re-run Steps 1-2).

--- a/docs/superpowers/specs/2026-06-10-tag-category-addtag-create.md
+++ b/docs/superpowers/specs/2026-06-10-tag-category-addtag-create.md
@@ -1,0 +1,227 @@
+# Tag/Category Select - Create Non-Existing Items via addTag
+
+**Date:** 2026-06-10
+
+## Summary
+
+Let users type a tag or category name that doesn't exist yet directly into `TagSelect` / `CategorySelect` (via ng-select's `addTag`), and create it on submit rather than immediately on typing.
+
+- Tags: no extra work needed beyond enabling `addTag` - qBittorrent's `addTags` endpoint auto-creates tags that don't exist yet.
+- Categories: qBittorrent's `setCategory` fails for categories that don't exist, so `CategorySelect` gains an `ensureCategoryExists()` method that consumers call right before the actual save/add API call. If the typed category isn't in the known list, it's created (with an empty save path) at that point.
+
+---
+
+## Goals
+
+- `TagSelect` and `CategorySelect` accept freeform typed values via ng-select's `addTag`, mirroring the existing `SavePathSelect` pattern (`addTag = (term: string): string => term;`).
+- Typing a new category and cancelling the modal/dialog must NOT create the category - creation only happens when the user actually submits.
+- `SetTorrentCategory` and `AddTorrent` both ensure a typed-but-not-yet-existing category is created before the underlying `setCategory` / `addTorrent` call.
+- Extend the category-select popover with a warning about the empty save path of categories created this way, using the same color and icon treatment (`text-warning` + triangle-exclamation icon) as the warning in `import-torrents`, scaled down for the popover context.
+
+## Out of scope
+
+- Changes to `ManageTags` / `ManageCategories` modals.
+- Centralizing category creation in the command bus / `TorrentCommandHandlerService`.
+- Any UI for editing the save path of a category created via `addTag` - users can do this afterwards via "Manage categories".
+- Adding an interactive "open settings" link/button inside `bb-popover` (it's hover-triggered via `mouseenter:mouseleave`, which makes interactive elements inside it unreliable).
+
+---
+
+## Changes
+
+### `packages/app/src/app/components/tag-select/`
+
+**`tag-select.html`**
+
+Add `[addTag]="addTag"` to the `<ng-select>`:
+
+```html
+<ng-select
+  data-testid="tag-select-input"
+  [items]="tags()"
+  [multiple]="true"
+  [hideSelected]="true"
+  [searchable]="true"
+  [clearable]="true"
+  [clearSearchOnAdd]="true"
+  [addTag]="addTag"
+  [formControl]="selectControl"
+  [keyDownFn]="keyDownFn"
+  [openOnEnter]="false"
+  #ngselect
+></ng-select>
+```
+
+**`tag-select.ts`**
+
+Add an identity `addTag` function (mirrors `SavePathSelect`):
+
+```ts
+addTag = (term: string): string => term.trim();
+```
+
+No other changes. `QbService.addTorrentTags` (used by `SetTorrentTags`) already creates tags server-side that don't exist yet, so newly-typed tags work without further wiring.
+
+---
+
+### `packages/app/src/app/components/category-select/`
+
+**`category-select.ts`**
+
+1. Add the same identity `addTag` function:
+
+```ts
+addTag = (term: string): string => term.trim();
+```
+
+2. Add `ensureCategoryExists()`. Called by consumers right before they use the category value. Returns `true` if the category already existed or was created successfully, `false` if creation failed (in which case the consumer aborts the submit). `QbService.request()` already shows a danger toast on failure, so this method does not need to surface its own error UI.
+
+```ts
+public async ensureCategoryExists(): Promise<boolean> {
+  const value = (this.selectControl.value ?? '').trim();
+  if (!value || this.categories().includes(value)) {
+    return true;
+  }
+
+  try {
+    await this.qbService.addCategory(
+      this.serverStoreService.currentServerId() as string,
+      value,
+      '',
+    );
+    this.categories.update((cats) => [...cats, value]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+3. Add the warning icon. Import `FaIconComponent` from `@fortawesome/angular-fontawesome` and add it to the component's `imports` array. Import `faTriangleExclamation` from `@fortawesome/free-solid-svg-icons` and expose it to the template:
+
+```ts
+protected readonly icons = { faTriangleExclamation };
+```
+
+**`category-select.html`**
+
+1. Add `[addTag]="addTag"` to the `<ng-select>` (same placement as `TagSelect`).
+
+2. Add a third paragraph to the `#categoryPopover` template, styled with Bootstrap's `text-warning` color and a leading triangle-exclamation icon:
+
+```html
+<ng-template #categoryPopover>
+  <p>{{ 'components.category-select.popover.description.line1' | translate }}</p>
+  <p>{{ 'components.category-select.popover.description.line2' | translate }}</p>
+  <p class="text-warning mb-0">
+    <fa-icon [icon]="icons.faTriangleExclamation" class="me-1"></fa-icon>
+    {{ 'components.category-select.popover.description.line3' | translate }}
+  </p>
+</ng-template>
+```
+
+This is a lighter treatment than the `alert alert-warning` box used in `import-torrents` - a full alert box would nest a second bordered/background block inside the `bb-popover`'s own bordered box, which is too heavy for a small hover popover. `text-warning` + icon gives the same "pay attention" signal while staying compact.
+
+---
+
+### `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts`
+
+Add a `viewChild` reference to the `CategorySelect` and call `ensureCategoryExists()` at the start of `handleSubmit()`, aborting if it fails:
+
+```ts
+private readonly categorySelect = viewChild(CategorySelect);
+```
+
+```ts
+public async handleSubmit(): Promise<void> {
+  this.saving = true;
+
+  if (!(await this.categorySelect()?.ensureCategoryExists())) {
+    this.saving = false;
+    return;
+  }
+
+  const category = this.setTorrentCategoryForm.get('category')?.value || '';
+  const serverId = this.serverStoreService.currentServerId() ?? '';
+  try {
+    await this.qbService.setTorrentCategory(serverId, this.hashes(), category);
+    this.activeModal.close();
+  } catch (error) {
+    console.error(SetTorrentCategory.name, 'handleSubmit', 'Failed to set torrent category!', error);
+  } finally {
+    this.saving = false;
+  }
+}
+```
+
+### `packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.ts`
+
+No changes - `TagSelect`'s new `[addTag]` is enough, since `addTorrentTags` auto-creates tags.
+
+### `packages/app/src/app/components/add-torrent/add-torrent.ts`
+
+`<app-category-select formControlName="category">` is always rendered (not behind an `@if`), so a `viewChild(CategorySelect)` reference resolves reliably.
+
+Add the same `viewChild` reference and call `ensureCategoryExists()` at the start of `handleSubmit()`, aborting (resetting `isSubmitting` and returning) if it fails - same pattern as `SetTorrentCategory`.
+
+---
+
+### i18n (`public/i18n/us.json`, `public/i18n/hu.json`)
+
+Add `components.category-select.popover.description.line3`:
+
+- `us.json`:
+
+  ```json
+  "line3": "Adding a new category here creates it with an empty save path. Whether this affects where your torrents are stored depends on the qBittorrent 'Default torrent management mode' and 'When category save path changes' settings."
+  ```
+
+- `hu.json`:
+
+  ```json
+  "line3": "Az itt hozzáadott új kategória üres mentési útvonallal jön létre. Hogy ez hogyan befolyásolja a torrentek tárolási helyét, az a qBittorrent 'Alapértelmezett torrent kezelési mód' és 'Amikor a kategória mentési útvonala megváltozik' beállításaitól függ."
+  ```
+
+These reuse the exact setting names from `pages.qb-settings.tab.storage.field.auto-tmm-enabled` / `category-changed-tmm-enabled`, kept as plain quoted text (matching line1/line2's plain interpolation - no `[innerHTML]` needed).
+
+---
+
+## Testing
+
+- `tag-select.spec.ts`: test that `addTag` trims and returns the typed term.
+- `category-select.spec.ts`:
+  - test that `addTag` trims and returns the typed term.
+  - `ensureCategoryExists()`:
+    - returns `true` immediately for an empty value, without calling `addCategory`.
+    - returns `true` immediately for a value already in `categories()`, without calling `addCategory`.
+    - for a new value, calls `qbService.addCategory(serverId, value, '')`, adds the value to `categories()`, and returns `true`.
+    - when `addCategory` rejects, returns `false` and leaves `categories()` unchanged.
+- `set-torrent-category.spec.ts`: `handleSubmit()` calls `ensureCategoryExists()` before `setTorrentCategory()`; if it returns `false`, `setTorrentCategory()` is not called and `saving` is reset to `false`.
+- `add-torrent.spec.ts`: same pattern - `handleSubmit()` calls `ensureCategoryExists()` first and aborts the submit if it returns `false`.
+
+---
+
+## File change summary
+
+| File                                                                                       | Change                                                     |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| `packages/app/src/app/components/tag-select/tag-select.html`                               | Add `[addTag]="addTag"`                                    |
+| `packages/app/src/app/components/tag-select/tag-select.ts`                                 | Add `addTag` identity fn                                   |
+| `packages/app/src/app/components/tag-select/tag-select.spec.ts`                            | Test `addTag`                                              |
+| `packages/app/src/app/components/category-select/category-select.html`                     | Add `[addTag]="addTag"`, popover line3 with warning icon   |
+| `packages/app/src/app/components/category-select/category-select.ts`                       | Add `addTag`, `ensureCategoryExists()`, FA icon imports    |
+| `packages/app/src/app/components/category-select/category-select.spec.ts`                  | Test `addTag` and `ensureCategoryExists()`                 |
+| `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts`      | Call `ensureCategoryExists()` in `handleSubmit()`          |
+| `packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts` | Test abort-on-failure                                      |
+| `packages/app/src/app/components/add-torrent/add-torrent.ts`                               | Call `ensureCategoryExists()` in `handleSubmit()`          |
+| `packages/app/src/app/components/add-torrent/add-torrent.spec.ts`                          | Test abort-on-failure                                      |
+| `public/i18n/us.json`                                                                      | Add `components.category-select.popover.description.line3` |
+| `public/i18n/hu.json`                                                                      | Add `components.category-select.popover.description.line3` |
+
+---
+
+## GitHub workflow
+
+- Open an issue using the **Enhancement** template (`02_enhancement.yml`).
+- Create feature branch `<issue-id>-tag-category-addtag-create`.
+- Do not push or open a PR yet.

--- a/docs/superpowers/specs/2026-06-10-tag-category-manage-hint.md
+++ b/docs/superpowers/specs/2026-06-10-tag-category-manage-hint.md
@@ -1,0 +1,83 @@
+# Tag/Category Select - Replace Footer Manage Button with Hint Link
+
+**Date:** 2026-06-10
+
+## Summary
+
+Replace the dropdown-footer "Manage tags"/"Manage categories" button in `TagSelect` and `CategorySelect` with a persistent link-style hint below the input. Clicking the hint opens the same manage modal as before.
+
+---
+
+## Goals
+
+- Remove the `ng-footer-tmp` button that currently only appears while the dropdown is open.
+- Add a small link-styled hint below each input, always visible, reading "Manage tags" / "Manage categories".
+- Clicking the hint opens the existing `ManageTags` / `ManageCategories` modal (same behavior as today's button).
+
+## Out of scope
+
+- Changes to `ManageTags` / `ManageCategories` modal contents or behavior.
+- New i18n strings - the existing `components.tag-select.manage` / `components.category-select.manage` keys are reused verbatim.
+- Changes to the `bb-popover` content.
+
+---
+
+## Changes
+
+Parallel changes to both `packages/app/src/app/components/tag-select/` and `packages/app/src/app/components/category-select/`.
+
+### `*.html`
+
+- Remove the `<ng-template ng-footer-tmp>` block entirely.
+- Below the closing `</div>` of `.form-floating` (still inside `col-11`), add:
+
+```html
+<div class="form-text">
+  <button
+    type="button"
+    class="btn btn-link btn-sm p-0 align-baseline"
+    data-testid="tag-select-manage"
+    (click)="openManageTags()"
+  >
+    {{ 'components.tag-select.manage' | translate }}
+  </button>
+</div>
+```
+
+(Use `category-select-manage` / `openManageCategories()` / `components.category-select.manage` for the category variant.)
+
+### `*.ts`
+
+- Remove `NgFooterTemplateDirective` from imports (both the import statement and the component `imports` array) - no longer used.
+- `openManageTags()` / `openManageCategories()` are unchanged.
+
+### `*.scss`
+
+- Both files are currently empty. Add styles only if visual verification shows the `bb-popover` icon (`col-1`, `align-items-center`) is misaligned now that the row is taller; otherwise leave empty.
+
+---
+
+## Testing
+
+- `tag-select.spec.ts` / `category-select.spec.ts`: add a test that finds the new `data-testid` button in the rendered DOM, dispatches a click, and asserts `openManageTags`/`openManageCategories` was invoked (in addition to the existing direct method-call tests).
+
+---
+
+## File change summary
+
+| File                                                                      | Change                                          |
+| ------------------------------------------------------------------------- | ----------------------------------------------- |
+| `packages/app/src/app/components/tag-select/tag-select.html`              | Remove footer template, add hint link           |
+| `packages/app/src/app/components/tag-select/tag-select.ts`                | Remove `NgFooterTemplateDirective` import/usage |
+| `packages/app/src/app/components/tag-select/tag-select.spec.ts`           | Add DOM click test for hint link                |
+| `packages/app/src/app/components/category-select/category-select.html`    | Remove footer template, add hint link           |
+| `packages/app/src/app/components/category-select/category-select.ts`      | Remove `NgFooterTemplateDirective` import/usage |
+| `packages/app/src/app/components/category-select/category-select.spec.ts` | Add DOM click test for hint link                |
+
+---
+
+## GitHub workflow
+
+- Open an issue using the **Enhancement** template (`02_enhancement.yml`).
+- Create feature branch `<issue-id>-tag-category-manage-hint`.
+- Do not push or open a PR yet.

--- a/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.spec.ts
@@ -58,6 +58,7 @@ describe('AddTorrent', () => {
             setFilePriority: vi.fn(),
             setShareLimits: vi.fn().mockResolvedValue(undefined),
             getAllCategories: vi.fn().mockResolvedValue({}),
+            addCategory: vi.fn().mockResolvedValue(undefined),
             getAllTags: vi.fn().mockResolvedValue([]),
             createTags: vi.fn().mockResolvedValue(undefined),
           },
@@ -176,6 +177,41 @@ describe('AddTorrent', () => {
     it('should not call setShareLimits when shareLimits is null', async () => {
       await (component as any).tryRenameContentAfterAdd('server-1', null);
       expect(mockQbService.setShareLimits).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubmit category creation', () => {
+    let mockQbService: any;
+    let torrentsAddSpy: any;
+
+    beforeEach(() => {
+      mockQbService = TestBed.inject(QbService) as any;
+      torrentsAddSpy = vi.spyOn(window.bitbutler.qb, 'torrentsAdd').mockClear();
+      (component as any).selectedTorrentFile.set({
+        name: 'test.torrent',
+        path: '/tmp/test.torrent',
+      });
+      component.addForm.controls.rename.setValue('test-torrent');
+    });
+
+    it('should create a typed category before adding the torrent', async () => {
+      component.addForm.controls.category.setValue('new-category');
+
+      await component.handleSubmit({ preventDefault: () => {} } as unknown as SubmitEvent);
+
+      expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'new-category', '');
+      expect(torrentsAddSpy).toHaveBeenCalled();
+    });
+
+    it('should abort without adding the torrent when category creation fails', async () => {
+      mockQbService.addCategory.mockRejectedValueOnce(new Error('failed'));
+      component.addForm.controls.category.setValue('bad-category');
+
+      await component.handleSubmit({ preventDefault: () => {} } as unknown as SubmitEvent);
+
+      expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'bad-category', '');
+      expect(torrentsAddSpy).not.toHaveBeenCalled();
+      expect(component.isSubmitting()).toBe(false);
     });
   });
 });

--- a/packages/app/src/app/components/add-torrent/add-torrent.ts
+++ b/packages/app/src/app/components/add-torrent/add-torrent.ts
@@ -7,6 +7,7 @@ import {
   effect,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -95,6 +96,8 @@ export class AddTorrent implements OnInit {
   private readonly qbService = inject(QbService);
   private readonly openFilesService = inject(OpenFilesService);
   private readonly translateService = inject(TranslateService);
+
+  private readonly categorySelect = viewChild(CategorySelect);
 
   public pending = this.openFilesService.pendingDrafts;
   public queueCount = computed(() => this.pending().length);
@@ -217,6 +220,10 @@ export class AddTorrent implements OnInit {
 
     if (!serverId) {
       this.addForm.setErrors({ noServerSelected: true });
+      return;
+    }
+
+    if (!(await this.categorySelect()?.ensureCategoryExists())) {
       return;
     }
 

--- a/packages/app/src/app/components/category-select/category-select.html
+++ b/packages/app/src/app/components/category-select/category-select.html
@@ -25,17 +25,6 @@
       ></bb-popover>
     </div>
   </div>
-
-  <div class="form-text">
-    <button
-      type="button"
-      class="btn btn-link btn-sm p-0 align-baseline"
-      data-testid="category-select-manage"
-      (click)="openManageCategories()"
-    >
-      {{ 'components.category-select.manage' | translate }}
-    </button>
-  </div>
 </div>
 
 <ng-template #categoryPopover>

--- a/packages/app/src/app/components/category-select/category-select.html
+++ b/packages/app/src/app/components/category-select/category-select.html
@@ -7,6 +7,7 @@
           [items]="categories()"
           [searchable]="true"
           [clearable]="true"
+          [addTag]="addTag"
           [formControl]="selectControl"
           [keyDownFn]="keyDownFn"
           [openOnEnter]="false"

--- a/packages/app/src/app/components/category-select/category-select.html
+++ b/packages/app/src/app/components/category-select/category-select.html
@@ -41,4 +41,8 @@
 <ng-template #categoryPopover>
   <p>{{ 'components.category-select.popover.description.line1' | translate }}</p>
   <p>{{ 'components.category-select.popover.description.line2' | translate }}</p>
+  <p class="text-warning mb-0">
+    <fa-icon [icon]="icons.faTriangleExclamation" class="me-1"></fa-icon>
+    {{ 'components.category-select.popover.description.line3' | translate }}
+  </p>
 </ng-template>

--- a/packages/app/src/app/components/category-select/category-select.html
+++ b/packages/app/src/app/components/category-select/category-select.html
@@ -11,19 +11,7 @@
           [keyDownFn]="keyDownFn"
           [openOnEnter]="false"
           #ngselect
-        >
-          <ng-template ng-footer-tmp>
-            <div class="px-3 py-2 border-top d-flex justify-content-end">
-              <button
-                type="button"
-                class="btn btn-secondary btn-sm"
-                (click)="openManageCategories()"
-              >
-                {{ 'components.category-select.manage' | translate }}
-              </button>
-            </div>
-          </ng-template>
-        </ng-select>
+        ></ng-select>
         <label>{{ 'components.category-select.label' | translate }}</label>
       </div>
     </div>
@@ -35,6 +23,17 @@
         placement="left"
       ></bb-popover>
     </div>
+  </div>
+
+  <div class="form-text">
+    <button
+      type="button"
+      class="btn btn-link btn-sm p-0 align-baseline"
+      data-testid="category-select-manage"
+      (click)="openManageCategories()"
+    >
+      {{ 'components.category-select.manage' | translate }}
+    </button>
   </div>
 </div>
 

--- a/packages/app/src/app/components/category-select/category-select.spec.ts
+++ b/packages/app/src/app/components/category-select/category-select.spec.ts
@@ -98,4 +98,17 @@ describe('CategorySelect', () => {
       expect(modalService.open).toHaveBeenCalled();
     });
   });
+
+  describe('manage hint link', () => {
+    it('should open the ManageCategories modal when clicked', () => {
+      const modalService = TestBed.inject(NgbModal);
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="category-select-manage"]',
+      ) as HTMLButtonElement;
+
+      button.click();
+
+      expect(modalService.open).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/app/src/app/components/category-select/category-select.spec.ts
+++ b/packages/app/src/app/components/category-select/category-select.spec.ts
@@ -1,6 +1,5 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
 import { CategorySelect } from './category-select';
@@ -21,12 +20,6 @@ describe('CategorySelect', () => {
       providers: [
         { provide: ServerStoreService, useValue: { currentServerId: signal('server-1') } },
         { provide: QbService, useValue: mockQbService },
-        {
-          provide: NgbModal,
-          useValue: {
-            open: vi.fn().mockReturnValue({ componentInstance: {}, result: Promise.resolve() }),
-          },
-        },
       ],
     }).compileComponents();
 
@@ -127,27 +120,6 @@ describe('CategorySelect', () => {
       component.registerOnChange(onChange);
       component.selectControl.setValue('movies');
       expect(onChange).toHaveBeenCalledWith('movies');
-    });
-  });
-
-  describe('openManageCategories', () => {
-    it('should open the ManageCategories modal', () => {
-      const modalService = TestBed.inject(NgbModal);
-      component.openManageCategories();
-      expect(modalService.open).toHaveBeenCalled();
-    });
-  });
-
-  describe('manage hint link', () => {
-    it('should open the ManageCategories modal when clicked', () => {
-      const modalService = TestBed.inject(NgbModal);
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="category-select-manage"]',
-      ) as HTMLButtonElement;
-
-      button.click();
-
-      expect(modalService.open).toHaveBeenCalled();
     });
   });
 });

--- a/packages/app/src/app/components/category-select/category-select.spec.ts
+++ b/packages/app/src/app/components/category-select/category-select.spec.ts
@@ -13,6 +13,7 @@ describe('CategorySelect', () => {
   beforeEach(async () => {
     mockQbService = {
       getAllCategories: vi.fn().mockResolvedValue({ movies: {}, tv: {} }),
+      addCategory: vi.fn().mockResolvedValue(undefined),
     };
 
     await TestBed.configureTestingModule({
@@ -72,6 +73,44 @@ describe('CategorySelect', () => {
     it('should return true for other keys', () => {
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
       expect(component.keyDownFn(event)).toBe(true);
+    });
+  });
+
+  describe('addTag', () => {
+    it('should return the trimmed term', () => {
+      expect(component.addTag('  New Category  ')).toBe('New Category');
+    });
+  });
+
+  describe('ensureCategoryExists', () => {
+    beforeEach(async () => {
+      await vi.waitUntil(() => component.categories().length > 0);
+    });
+
+    it('should return true and not call addCategory for an empty value', async () => {
+      component.selectControl.setValue('');
+      expect(await component.ensureCategoryExists()).toBe(true);
+      expect(mockQbService.addCategory).not.toHaveBeenCalled();
+    });
+
+    it('should return true and not call addCategory for an existing category', async () => {
+      component.selectControl.setValue('movies');
+      expect(await component.ensureCategoryExists()).toBe(true);
+      expect(mockQbService.addCategory).not.toHaveBeenCalled();
+    });
+
+    it('should create a new category and add it to the known list', async () => {
+      component.selectControl.setValue('new-category');
+      expect(await component.ensureCategoryExists()).toBe(true);
+      expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'new-category', '');
+      expect(component.categories()).toContain('new-category');
+    });
+
+    it('should return false when addCategory fails', async () => {
+      mockQbService.addCategory.mockRejectedValueOnce(new Error('failed'));
+      component.selectControl.setValue('bad-category');
+      expect(await component.ensureCategoryExists()).toBe(false);
+      expect(component.categories()).not.toContain('bad-category');
     });
   });
 

--- a/packages/app/src/app/components/category-select/category-select.ts
+++ b/packages/app/src/app/components/category-select/category-select.ts
@@ -16,6 +16,8 @@ import {
   NG_VALUE_ACCESSOR,
   ReactiveFormsModule,
 } from '@angular/forms';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -27,7 +29,14 @@ import { ManageCategories } from '../modals/manage-categories/manage-categories'
 @Component({
   selector: 'app-category-select',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, NgSelectComponent, TranslatePipe, BbPopover],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    NgSelectComponent,
+    FaIconComponent,
+    TranslatePipe,
+    BbPopover,
+  ],
   templateUrl: './category-select.html',
   styleUrls: ['./category-select.scss'],
   providers: [
@@ -46,6 +55,8 @@ export class CategorySelect implements ControlValueAccessor {
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly qbService = inject(QbService);
   private readonly modalService = inject(NgbModal);
+
+  public readonly icons = { faTriangleExclamation };
 
   public categories = signal<string[]>([]);
   public selectControl = new FormControl('');

--- a/packages/app/src/app/components/category-select/category-select.ts
+++ b/packages/app/src/app/components/category-select/category-select.ts
@@ -97,12 +97,33 @@ export class CategorySelect implements ControlValueAccessor {
     }
   }
 
+  addTag = (term: string): string => term.trim();
+
   keyDownFn(event: KeyboardEvent): boolean {
     if (event.key === 'Escape') {
       return false;
     }
 
     return true;
+  }
+
+  public async ensureCategoryExists(): Promise<boolean> {
+    const value = (this.selectControl.value ?? '').trim();
+    if (!value || this.categories().includes(value)) {
+      return true;
+    }
+
+    try {
+      await this.qbService.addCategory(
+        this.serverStoreService.currentServerId() as string,
+        value,
+        '',
+      );
+      this.categories.update((cats) => [...cats, value]);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   public openManageCategories(): void {

--- a/packages/app/src/app/components/category-select/category-select.ts
+++ b/packages/app/src/app/components/category-select/category-select.ts
@@ -18,13 +18,11 @@ import {
 } from '@angular/forms';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe } from '@ngx-translate/core';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
 import { BbPopover } from '../bb-popover/bb-popover';
-import { ManageCategories } from '../modals/manage-categories/manage-categories';
 
 @Component({
   selector: 'app-category-select',
@@ -54,7 +52,6 @@ export class CategorySelect implements ControlValueAccessor {
 
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly qbService = inject(QbService);
-  private readonly modalService = inject(NgbModal);
 
   public readonly icons = { faTriangleExclamation };
 
@@ -135,16 +132,5 @@ export class CategorySelect implements ControlValueAccessor {
     } catch {
       return false;
     }
-  }
-
-  public openManageCategories(): void {
-    this.ngselect.close();
-    const ref = this.modalService.open(ManageCategories, {
-      beforeDismiss: () => ref.componentInstance.canDeactivate(),
-    });
-    ref.result.then(
-      () => this.loadCategories(),
-      () => this.loadCategories(),
-    );
   }
 }

--- a/packages/app/src/app/components/category-select/category-select.ts
+++ b/packages/app/src/app/components/category-select/category-select.ts
@@ -17,7 +17,7 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { NgFooterTemplateDirective, NgSelectComponent } from '@ng-select/ng-select';
+import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe } from '@ngx-translate/core';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
@@ -27,14 +27,7 @@ import { ManageCategories } from '../modals/manage-categories/manage-categories'
 @Component({
   selector: 'app-category-select',
   standalone: true,
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    NgSelectComponent,
-    NgFooterTemplateDirective,
-    TranslatePipe,
-    BbPopover,
-  ],
+  imports: [CommonModule, ReactiveFormsModule, NgSelectComponent, TranslatePipe, BbPopover],
   templateUrl: './category-select.html',
   styleUrls: ['./category-select.scss'],
   providers: [

--- a/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts
+++ b/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.spec.ts
@@ -23,6 +23,7 @@ describe('SetTorrentCategory', () => {
           provide: QbService,
           useValue: {
             getAllCategories: vi.fn().mockResolvedValue({}),
+            addCategory: vi.fn().mockResolvedValue(undefined),
             setTorrentCategory: vi.fn().mockResolvedValue(undefined),
           },
         },
@@ -71,6 +72,33 @@ describe('SetTorrentCategory', () => {
       component.setTorrentCategoryForm.get('category')?.setValue('tv');
       await component.handleSubmit();
       expect(mockQbService.setTorrentCategory).toHaveBeenCalledWith('server-1', ['hash-1'], 'tv');
+    });
+
+    it('should create the category if it does not exist yet before saving', async () => {
+      const mockQbService = TestBed.inject(QbService) as unknown as {
+        addCategory: ReturnType<typeof vi.fn>;
+        setTorrentCategory: ReturnType<typeof vi.fn>;
+      };
+      component.setTorrentCategoryForm.get('category')?.setValue('new-category');
+      await component.handleSubmit();
+      expect(mockQbService.addCategory).toHaveBeenCalledWith('server-1', 'new-category', '');
+      expect(mockQbService.setTorrentCategory).toHaveBeenCalledWith(
+        'server-1',
+        ['hash-1'],
+        'new-category',
+      );
+    });
+
+    it('should abort the submit if the category cannot be created', async () => {
+      const mockQbService = TestBed.inject(QbService) as unknown as {
+        addCategory: ReturnType<typeof vi.fn>;
+        setTorrentCategory: ReturnType<typeof vi.fn>;
+      };
+      mockQbService.addCategory.mockRejectedValueOnce(new Error('failed'));
+      component.setTorrentCategoryForm.get('category')?.setValue('bad-category');
+      await component.handleSubmit();
+      expect(mockQbService.setTorrentCategory).not.toHaveBeenCalled();
+      expect(component.saving).toBe(false);
     });
   });
 });

--- a/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts
+++ b/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.ts
@@ -1,5 +1,13 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnInit, computed, inject, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -32,6 +40,8 @@ export class SetTorrentCategory implements OnInit {
   public readonly activeModal = inject(NgbActiveModal);
   public readonly qbService = inject(QbService);
 
+  private readonly categorySelect = viewChild(CategorySelect);
+
   public readonly selected = computed(() => this.hashes().length);
   public saving = false;
   public setTorrentCategoryForm = new FormGroup({
@@ -44,6 +54,11 @@ export class SetTorrentCategory implements OnInit {
 
   public async handleSubmit(): Promise<void> {
     this.saving = true;
+
+    if (!(await this.categorySelect()?.ensureCategoryExists())) {
+      this.saving = false;
+      return;
+    }
 
     const category = this.setTorrentCategoryForm.get('category')?.value || '';
     const serverId = this.serverStoreService.currentServerId() ?? '';

--- a/packages/app/src/app/components/tag-select/tag-select.html
+++ b/packages/app/src/app/components/tag-select/tag-select.html
@@ -10,6 +10,7 @@
           [searchable]="true"
           [clearable]="true"
           [clearSearchOnAdd]="true"
+          [addTag]="addTag"
           [formControl]="selectControl"
           [keyDownFn]="keyDownFn"
           [openOnEnter]="false"

--- a/packages/app/src/app/components/tag-select/tag-select.html
+++ b/packages/app/src/app/components/tag-select/tag-select.html
@@ -14,15 +14,7 @@
           [keyDownFn]="keyDownFn"
           [openOnEnter]="false"
           #ngselect
-        >
-          <ng-template ng-footer-tmp>
-            <div class="px-3 py-2 border-top d-flex justify-content-end">
-              <button type="button" class="btn btn-secondary btn-sm" (click)="openManageTags()">
-                {{ 'components.tag-select.manage' | translate }}
-              </button>
-            </div>
-          </ng-template>
-        </ng-select>
+        ></ng-select>
         <label>{{ 'components.tag-select.label' | translate }}</label>
       </div>
     </div>
@@ -34,6 +26,17 @@
         placement="left"
       ></bb-popover>
     </div>
+  </div>
+
+  <div class="form-text">
+    <button
+      type="button"
+      class="btn btn-link btn-sm p-0 align-baseline"
+      data-testid="tag-select-manage"
+      (click)="openManageTags()"
+    >
+      {{ 'components.tag-select.manage' | translate }}
+    </button>
   </div>
 </div>
 

--- a/packages/app/src/app/components/tag-select/tag-select.html
+++ b/packages/app/src/app/components/tag-select/tag-select.html
@@ -28,17 +28,6 @@
       ></bb-popover>
     </div>
   </div>
-
-  <div class="form-text">
-    <button
-      type="button"
-      class="btn btn-link btn-sm p-0 align-baseline"
-      data-testid="tag-select-manage"
-      (click)="openManageTags()"
-    >
-      {{ 'components.tag-select.manage' | translate }}
-    </button>
-  </div>
 </div>
 
 <ng-template #tagPopover>

--- a/packages/app/src/app/components/tag-select/tag-select.spec.ts
+++ b/packages/app/src/app/components/tag-select/tag-select.spec.ts
@@ -67,6 +67,12 @@ describe('TagSelect', () => {
     });
   });
 
+  describe('addTag', () => {
+    it('should return the trimmed term', () => {
+      expect(component.addTag('  new-tag  ')).toBe('new-tag');
+    });
+  });
+
   describe('initialization', () => {
     it('should load all tags on init', async () => {
       await vi.waitUntil(() => component.tags().length > 0);

--- a/packages/app/src/app/components/tag-select/tag-select.spec.ts
+++ b/packages/app/src/app/components/tag-select/tag-select.spec.ts
@@ -1,6 +1,5 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
 import { TagSelect } from './tag-select';
@@ -9,14 +8,10 @@ describe('TagSelect', () => {
   let component: TagSelect;
   let fixture: ComponentFixture<TagSelect>;
   let mockQbService: any;
-  let mockModalService: Partial<NgbModal>;
 
   beforeEach(async () => {
     mockQbService = {
       getAllTags: vi.fn().mockResolvedValue(['action', 'comedy']),
-    };
-    mockModalService = {
-      open: vi.fn().mockReturnValue({ componentInstance: {}, result: Promise.resolve() }),
     };
 
     await TestBed.configureTestingModule({
@@ -24,7 +19,6 @@ describe('TagSelect', () => {
       providers: [
         { provide: ServerStoreService, useValue: { currentServerId: signal('server-1') } },
         { provide: QbService, useValue: mockQbService },
-        { provide: NgbModal, useValue: mockModalService },
       ],
     }).compileComponents();
 
@@ -84,25 +78,6 @@ describe('TagSelect', () => {
       component.registerOnChange(onChange);
       component.selectControl.setValue(['action']);
       expect(onChange).toHaveBeenCalledWith(['action']);
-    });
-  });
-
-  describe('openManageTags', () => {
-    it('should open the ManageTags modal', () => {
-      component.openManageTags();
-      expect(mockModalService.open).toHaveBeenCalled();
-    });
-  });
-
-  describe('manage hint link', () => {
-    it('should open the ManageTags modal when clicked', () => {
-      const button = fixture.nativeElement.querySelector(
-        '[data-testid="tag-select-manage"]',
-      ) as HTMLButtonElement;
-
-      button.click();
-
-      expect(mockModalService.open).toHaveBeenCalled();
     });
   });
 });

--- a/packages/app/src/app/components/tag-select/tag-select.spec.ts
+++ b/packages/app/src/app/components/tag-select/tag-select.spec.ts
@@ -87,4 +87,16 @@ describe('TagSelect', () => {
       expect(mockModalService.open).toHaveBeenCalled();
     });
   });
+
+  describe('manage hint link', () => {
+    it('should open the ManageTags modal when clicked', () => {
+      const button = fixture.nativeElement.querySelector(
+        '[data-testid="tag-select-manage"]',
+      ) as HTMLButtonElement;
+
+      button.click();
+
+      expect(mockModalService.open).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/app/src/app/components/tag-select/tag-select.ts
+++ b/packages/app/src/app/components/tag-select/tag-select.ts
@@ -88,6 +88,8 @@ export class TagSelect implements ControlValueAccessor {
     }
   }
 
+  addTag = (term: string): string => term.trim();
+
   keyDownFn(event: KeyboardEvent): boolean {
     if (event.key === 'Escape') {
       return false;

--- a/packages/app/src/app/components/tag-select/tag-select.ts
+++ b/packages/app/src/app/components/tag-select/tag-select.ts
@@ -17,7 +17,7 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { NgFooterTemplateDirective, NgSelectComponent } from '@ng-select/ng-select';
+import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe } from '@ngx-translate/core';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
@@ -27,14 +27,7 @@ import { ManageTags } from '../modals/manage-tags/manage-tags';
 @Component({
   selector: 'app-tag-select',
   standalone: true,
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    NgSelectComponent,
-    NgFooterTemplateDirective,
-    TranslatePipe,
-    BbPopover,
-  ],
+  imports: [CommonModule, ReactiveFormsModule, NgSelectComponent, TranslatePipe, BbPopover],
   templateUrl: './tag-select.html',
   styleUrls: ['./tag-select.scss'],
   providers: [

--- a/packages/app/src/app/components/tag-select/tag-select.ts
+++ b/packages/app/src/app/components/tag-select/tag-select.ts
@@ -16,13 +16,11 @@ import {
   NG_VALUE_ACCESSOR,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe } from '@ngx-translate/core';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
 import { BbPopover } from '../bb-popover/bb-popover';
-import { ManageTags } from '../modals/manage-tags/manage-tags';
 
 @Component({
   selector: 'app-tag-select',
@@ -45,7 +43,6 @@ export class TagSelect implements ControlValueAccessor {
 
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly qbService = inject(QbService);
-  private readonly modalService = inject(NgbModal);
 
   public tags = signal<string[]>([]);
   public selectControl = new FormControl<string[]>([]);
@@ -96,15 +93,6 @@ export class TagSelect implements ControlValueAccessor {
     }
 
     return true;
-  }
-
-  public openManageTags(): void {
-    this.ngselect.close();
-    const ref = this.modalService.open(ManageTags);
-    ref.result.then(
-      () => this.loadAllTags(),
-      () => this.loadAllTags(),
-    );
   }
 
   private async loadAllTags(): Promise<void> {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -173,8 +173,7 @@
           "line2": "Ha az automatikus torrentkezelés (TMM) engedélyezve van, a kategória megváltoztatása automatikusan áthelyezheti a fájlokat.",
           "line3": "Az itt hozzáadott új kategória üres mentési útvonallal jön létre. Hogy ez hogyan befolyásolja a torrentek tárolási helyét, az a qBittorrent 'Alapértelmezett torrent kezelési mód' és 'Amikor a kategória mentési útvonala megváltozik' beállításaitól függ."
         }
-      },
-      "manage": "Kategóriák kezelése"
+      }
     },
     "datepicker-filter": {},
     "datepicker-range-filter": {
@@ -845,8 +844,7 @@
           "line1": "Egy vagy több címkét ad ehhez a torrenthez, rugalmas szűrési és csoportosítási lehetőségekért.",
           "line2": "A kategóriákkal ellentétben egy torrenthez több címke is rendelhető, és a címkék nem befolyásolják a mentési útvonalat."
         }
-      },
-      "manage": "Cimkék kezelése"
+      }
     },
     "save-path-select": {
       "label": "Mentési útvonal",

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -170,7 +170,8 @@
         "title": "Kategória",
         "description": {
           "line1": "Kategóriát rendel a torrenthez. A kategóriák hasznosak a letöltések rendszerezéséhez, és alapértelmezett mentési útvonalat is meghatározhatnak.",
-          "line2": "Ha az automatikus torrentkezelés (TMM) engedélyezve van, a kategória megváltoztatása automatikusan áthelyezheti a fájlokat."
+          "line2": "Ha az automatikus torrentkezelés (TMM) engedélyezve van, a kategória megváltoztatása automatikusan áthelyezheti a fájlokat.",
+          "line3": "Az itt hozzáadott új kategória üres mentési útvonallal jön létre. Hogy ez hogyan befolyásolja a torrentek tárolási helyét, az a qBittorrent 'Alapértelmezett torrent kezelési mód' és 'Amikor a kategória mentési útvonala megváltozik' beállításaitól függ."
         }
       },
       "manage": "Kategóriák kezelése"

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -173,8 +173,7 @@
           "line2": "If Auto TMM is enabled, changing the category may automatically move the files.",
           "line3": "Adding a new category here creates it with an empty save path. Whether this affects where your torrents are stored depends on the qBittorrent 'Default torrent management mode' and 'When category save path changes' settings."
         }
-      },
-      "manage": "Manage categories"
+      }
     },
     "datepicker-filter": {},
     "datepicker-range-filter": {
@@ -845,8 +844,7 @@
           "line1": "Adds one or more tags to this torrent for flexible filtering and grouping.",
           "line2": "Unlike categories, a torrent can have multiple tags, and tags do not affect the save path."
         }
-      },
-      "manage": "Manage tags"
+      }
     },
     "save-path-select": {
       "label": "Save Path",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -170,7 +170,8 @@
         "title": "Category",
         "description": {
           "line1": "Assigns the torrent to a category. Categories are useful for organizing your downloads and can also define a default save path.",
-          "line2": "If Auto TMM is enabled, changing the category may automatically move the files."
+          "line2": "If Auto TMM is enabled, changing the category may automatically move the files.",
+          "line3": "Adding a new category here creates it with an empty save path. Whether this affects where your torrents are stored depends on the qBittorrent 'Default torrent management mode' and 'When category save path changes' settings."
         }
       },
       "manage": "Manage categories"


### PR DESCRIPTION
## Issue ID

Fixes #143

## Description

- Add inline tag and category creation via `addTag` on `TagSelect` and `CategorySelect`, with `ensureCategoryExists` creating the category on the server when needed.
- Show an empty-save-path warning when adding a new category, since qBittorrent settings determine how that affects torrent storage.
- Create the category on submit when adding a torrent or setting a torrent's category if it doesn't exist yet.
- Remove the now-redundant "manage categories/tags" hint links and modals.