### PR TITLE
Remove leftover Playwright test ids from templates

### DIFF
--- a/packages/app/src/app/components/add-torrent/add-torrent.html
+++ b/packages/app/src/app/components/add-torrent/add-torrent.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="add-torrent-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">{{ 'components.add-torrent.title' | translate }}</h5>
 
@@ -338,19 +338,13 @@
   <button
     type="button"
     class="btn btn-secondary"
-    data-testid="add-torrent-submit"
     (click)="handleSubmit($event)"
     [disabled]="!canSubmit()"
     [autofocus]="addForm.controls.file.value.length === 0"
   >
     {{ 'general.button.add' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    data-testid="add-torrent-cancel"
-    (click)="handleCancel()"
-  >
+  <button type="button" class="btn btn-link" (click)="handleCancel()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -33,7 +33,6 @@
           [ngbTooltip]="'general.button.edit' | translate"
           tooltipClass="single-line-tooltip"
           placement="top"
-          data-testid="file-tree-edit-button"
           (click)="enterEditMode()"
         >
           <fa-icon [icon]="icon.faEdit"></fa-icon>
@@ -45,7 +44,6 @@
           [ngbTooltip]="'general.button.save' | translate"
           tooltipClass="single-line-tooltip"
           placement="top"
-          data-testid="file-tree-save-button"
           (click)="saveEdit()"
         >
           <fa-icon [icon]="icon.faCheck"></fa-icon>
@@ -56,7 +54,6 @@
           [ngbTooltip]="'general.button.cancel' | translate"
           tooltipClass="single-line-tooltip"
           placement="top"
-          data-testid="file-tree-cancel-button"
           (click)="cancelEdit()"
         >
           <fa-icon [icon]="icon.faX"></fa-icon>
@@ -71,7 +68,6 @@
   [treeControl]="treeControl"
   [trackBy]="trackByPath"
   class="bb-file-tree"
-  data-testid="file-tree"
 >
   <cdk-nested-tree-node *cdkTreeNodeDef="let node; when: hasChild" class="bb-node">
     <div
@@ -147,7 +143,6 @@
       class="bb-row bb-row--file"
       [class.bb-row--skipped]="node.file?.priority === 0"
       [style.--node-depth]="getNodeDepth(node)"
-      [attr.data-testid]="'file-row-' + node.name"
     >
       <span class="bb-spacer"></span>
 
@@ -178,8 +173,6 @@
         <div class="bb-input-wrapper">
           <input
             class="bb-input"
-            data-testid="file-rename-input"
-            [attr.data-testid-file]="node.name"
             [class.bb-input--invalid]="getControl(node).invalid && getControl(node).dirty"
             [formControl]="getControl(node)"
             (keydown.enter)="onRenameEnter($event)"

--- a/packages/app/src/app/components/category-select/category-select.html
+++ b/packages/app/src/app/components/category-select/category-select.html
@@ -3,7 +3,6 @@
     <div class="col-11">
       <div class="form-floating">
         <ng-select
-          data-testid="category-select-input"
           [items]="categories()"
           [searchable]="true"
           [clearable]="true"

--- a/packages/app/src/app/components/modals/confirm/confirm.html
+++ b/packages/app/src/app/components/modals/confirm/confirm.html
@@ -1,4 +1,4 @@
-<div class="modal-header" data-testid="confirm-modal">
+<div class="modal-header">
   <h4 class="modal-title">{{ title() | translate: titleParams() }}</h4>
   <button
     type="button"
@@ -9,21 +9,10 @@
 </div>
 <div class="modal-body" [innerHTML]="message() | translate: messageParams()"></div>
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn btn-danger"
-    (click)="activeModal.close(true)"
-    autofocus
-    data-testid="confirm-ok-button"
-  >
+  <button type="button" class="btn btn-danger" (click)="activeModal.close(true)" autofocus>
     {{ btnOkText() | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    (click)="activeModal.close(false)"
-    data-testid="confirm-cancel-button"
-  >
+  <button type="button" class="btn btn-link" (click)="activeModal.close(false)">
     {{ btnCancelText() | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/modals/delete-torrent/delete-torrent.html
+++ b/packages/app/src/app/components/modals/delete-torrent/delete-torrent.html
@@ -1,4 +1,4 @@
-<div class="modal-header" data-testid="delete-torrent-modal">
+<div class="modal-header">
   <h4 class="modal-title text-danger">
     {{ 'components.modals.delete-torrent.title' | translate }}
   </h4>
@@ -20,7 +20,6 @@
         type="checkbox"
         id="remove-files"
         formControlName="removeFiles"
-        data-testid="delete-remove-files-checkbox"
       />
       <label class="form-check-label" for="remove-files">
         {{ 'components.modals.delete-torrent.delete-form.confirmation' | translate }}</label
@@ -38,21 +37,10 @@
 </div>
 
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn btn-danger"
-    (click)="closeModal()"
-    autofocus
-    data-testid="delete-confirm-button"
-  >
+  <button type="button" class="btn btn-danger" (click)="closeModal()" autofocus>
     {{ 'general.button.delete' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    (click)="dismissModal()"
-    data-testid="delete-cancel-button"
-  >
+  <button type="button" class="btn btn-link" (click)="dismissModal()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/modals/manage-categories/manage-categories.html
+++ b/packages/app/src/app/components/modals/manage-categories/manage-categories.html
@@ -1,4 +1,4 @@
-<div class="modal-header" data-testid="manage-categories-modal">
+<div class="modal-header">
   <h5 class="modal-title">{{ 'components.modals.manage-categories.title' | translate }}</h5>
   <button
     type="button"
@@ -20,7 +20,6 @@
           formControlName="name"
           (keydown.enter)="add()"
           autofocus
-          data-testid="category-name-input"
         />
         <label for="category-name">
           {{ 'components.modals.manage-categories.add-form.name' | translate }}
@@ -31,7 +30,6 @@
         type="button"
         (click)="add()"
         [disabled]="!(addForm.get('name')?.value ?? '').trim() || adding()"
-        data-testid="add-category-button"
       >
         {{ 'general.button.add' | translate }}
       </button>
@@ -115,10 +113,7 @@
             </div>
           </li>
         } @else {
-          <li
-            class="list-group-item d-flex align-items-center justify-content-between"
-            [attr.data-testid]="'category-item-' + item.name"
-          >
+          <li class="list-group-item d-flex align-items-center justify-content-between">
             <div class="overflow-hidden me-2">
               <div class="fw-semibold text-truncate" [ngbTooltip]="item.name" bbTooltipOverflow>
                 {{ item.name }}

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.html
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.html
@@ -68,8 +68,7 @@
               @if (!hideConnect()) {
                 <button
                   type="button"
-                  class="btn btn-link p-1"
-                  data-testid="connect-btn"
+                  class="btn btn-link p-1 connect-btn"
                   [ngbTooltip]="'components.modals.manage-servers.button.connect' | translate"
                   (click)="switchTo(server)"
                   [disabled]="busy()"

--- a/packages/app/src/app/components/modals/manage-servers/manage-servers.spec.ts
+++ b/packages/app/src/app/components/modals/manage-servers/manage-servers.spec.ts
@@ -58,7 +58,7 @@ describe('ManageServers', () => {
       serverStoreMock.currentServerId.set('other-id');
       fixture.componentRef.setInput('hideConnect', true);
       fixture.detectChanges();
-      const connectBtn = fixture.nativeElement.querySelector('[data-testid="connect-btn"]');
+      const connectBtn = fixture.nativeElement.querySelector('.connect-btn');
       expect(connectBtn).toBeNull();
     });
 
@@ -70,7 +70,7 @@ describe('ManageServers', () => {
       serverStoreMock.currentServerId.set('other-id');
       fixture.componentRef.setInput('hideConnect', false);
       fixture.detectChanges();
-      const connectBtn = fixture.nativeElement.querySelector('[data-testid="connect-btn"]');
+      const connectBtn = fixture.nativeElement.querySelector('.connect-btn');
       expect(connectBtn).not.toBeNull();
     });
   });

--- a/packages/app/src/app/components/modals/manage-tags/manage-tags.html
+++ b/packages/app/src/app/components/modals/manage-tags/manage-tags.html
@@ -1,4 +1,4 @@
-<div class="modal-header" data-testid="manage-tags-modal">
+<div class="modal-header">
   <h5 class="modal-title">{{ 'components.modals.manage-tags.title' | translate }}</h5>
   <button
     type="button"
@@ -19,7 +19,6 @@
         [formControl]="nameControl"
         (keydown.enter)="add()"
         autofocus
-        data-testid="tag-name-input"
       />
       <label for="tag-name">{{ 'components.modals.manage-tags.add-form.name' | translate }}</label>
     </div>
@@ -28,7 +27,6 @@
       type="button"
       (click)="add()"
       [disabled]="!(nameControl.value ?? '').trim() || adding()"
-      data-testid="add-tag-button"
     >
       {{ 'general.button.add' | translate }}
     </button>
@@ -67,10 +65,7 @@
   } @else if (filteredTags().length > 0) {
     <ul class="list-group">
       @for (tag of filteredTags(); track tag) {
-        <li
-          class="list-group-item d-flex align-items-center justify-content-between"
-          [attr.data-testid]="'tag-item-' + tag"
-        >
+        <li class="list-group-item d-flex align-items-center justify-content-between">
           <span class="text-truncate me-2" [ngbTooltip]="tag" bbTooltipOverflow>{{ tag }}</span>
           <button
             type="button"

--- a/packages/app/src/app/components/modals/rename-torrent/rename-torrent.html
+++ b/packages/app/src/app/components/modals/rename-torrent/rename-torrent.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="rename-torrent-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">
       {{ 'components.modals.rename-torrent.title' | translate }}
@@ -36,7 +36,6 @@
               placeholder="Name"
               formControlName="name"
               autofocus
-              data-testid="rename-torrent-input"
             />
             <label for="name">{{
               'components.modals.rename-torrent.rename-torrent-form.name' | translate
@@ -49,21 +48,10 @@
   </form>
 </div>
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn btn-primary"
-    (click)="handleSubmit()"
-    [disabled]="!canSave()"
-    data-testid="rename-torrent-save"
-  >
+  <button type="button" class="btn btn-primary" (click)="handleSubmit()" [disabled]="!canSave()">
     {{ 'general.button.save' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    (click)="activeModal.dismiss()"
-    data-testid="rename-torrent-cancel"
-  >
+  <button type="button" class="btn btn-link" (click)="activeModal.dismiss()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/modals/server-editor/server-editor.html
+++ b/packages/app/src/app/components/modals/server-editor/server-editor.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title" data-testid="modal-title">
+  <h4 class="modal-title">
     {{
       (editMode()
         ? 'components.modals.server-editor.title-edit'
@@ -7,13 +7,7 @@
       ) | translate
     }}
   </h4>
-  <button
-    type="button"
-    class="btn-close"
-    data-testid="close-button"
-    aria-label="Close"
-    (click)="close()"
-  ></button>
+  <button type="button" class="btn-close" aria-label="Close" (click)="close()"></button>
 </div>
 <div class="modal-body">
   <form [formGroup]="editorForm" (submit)="handleSave()">
@@ -26,7 +20,6 @@
               type="text"
               class="form-control"
               id="name"
-              data-testid="name-input"
               [placeholder]="
                 'components.modals.server-editor.editor-form.connection-name' | translate
               "
@@ -62,7 +55,6 @@
               type="text"
               class="form-control"
               id="host"
-              data-testid="host-input"
               [placeholder]="'components.modals.server-editor.editor-form.host' | translate"
               formControlName="host"
             />
@@ -77,7 +69,6 @@
               type="number"
               class="form-control"
               id="port"
-              data-testid="port-input"
               [placeholder]="'components.modals.server-editor.editor-form.port' | translate"
               formControlName="port"
               min="1"
@@ -96,7 +87,6 @@
               type="text"
               class="form-control"
               id="username"
-              data-testid="username-input"
               [placeholder]="'components.modals.server-editor.editor-form.username' | translate"
               formControlName="username"
             />
@@ -111,7 +101,6 @@
               type="password"
               class="form-control"
               id="password"
-              data-testid="password-input"
               [placeholder]="
                 hasSavedPassword()
                   ? ('components.modals.server-editor.editor-form.password-saved-hint' | translate)
@@ -156,7 +145,6 @@
   <button
     type="button"
     class="btn btn-secondary"
-    data-testid="save-button"
     (click)="handleSave()"
     [disabled]="!canSave() || processing()"
   >

--- a/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.html
+++ b/packages/app/src/app/components/modals/set-torrent-category/set-torrent-category.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="set-category-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">
       {{ 'components.modals.set-torrent-category.title' | translate }}
@@ -32,11 +32,7 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-12">
-          <app-category-select
-            formControlName="category"
-            [autofocus]="true"
-            data-testid="category-select"
-          ></app-category-select>
+          <app-category-select formControlName="category" [autofocus]="true"></app-category-select>
         </div>
       </div>
     </div>
@@ -44,21 +40,10 @@
   </form>
 </div>
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn btn-secondary"
-    (click)="handleSubmit()"
-    [disabled]="!canSave()"
-    data-testid="set-category-save"
-  >
+  <button type="button" class="btn btn-secondary" (click)="handleSubmit()" [disabled]="!canSave()">
     {{ 'general.button.save' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    (click)="activeModal.close()"
-    data-testid="set-category-cancel"
-  >
+  <button type="button" class="btn btn-link" (click)="activeModal.close()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.html
+++ b/packages/app/src/app/components/modals/set-torrent-location/set-torrent-location.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="set-location-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">
       {{ 'components.modals.set-torrent-location.title' | translate }}
@@ -44,21 +44,10 @@
   </form>
 </div>
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn btn-secondary"
-    (click)="handleSubmit()"
-    [disabled]="!canSave()"
-    data-testid="set-location-save"
-  >
+  <button type="button" class="btn btn-secondary" (click)="handleSubmit()" [disabled]="!canSave()">
     {{ 'general.button.save' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    (click)="activeModal.close()"
-    data-testid="set-location-cancel"
-  >
+  <button type="button" class="btn btn-link" (click)="activeModal.close()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.html
+++ b/packages/app/src/app/components/modals/set-torrent-tags/set-torrent-tags.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="set-torrent-tags-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">
       {{ 'components.modals.set-torrent-tags.title' | translate }}
@@ -40,21 +40,10 @@
   </form>
 </div>
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn btn-secondary"
-    data-testid="set-torrent-tags-save"
-    (click)="handleSubmit()"
-    [disabled]="!canSave()"
-  >
+  <button type="button" class="btn btn-secondary" (click)="handleSubmit()" [disabled]="!canSave()">
     {{ 'general.button.save' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    data-testid="set-torrent-tags-cancel"
-    (click)="activeModal.close()"
-  >
+  <button type="button" class="btn btn-link" (click)="activeModal.close()">
     {{ 'general.button.cancel' | translate }}
   </button>
 </div>

--- a/packages/app/src/app/components/modals/torrent-details/torrent-details.html
+++ b/packages/app/src/app/components/modals/torrent-details/torrent-details.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="torrent-details-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5
       #titleElement

--- a/packages/app/src/app/components/modals/torrent-exists/torrent-exists.html
+++ b/packages/app/src/app/components/modals/torrent-exists/torrent-exists.html
@@ -1,5 +1,5 @@
 @if (torrent(); as t) {
-  <div class="modal-header bb-modal-header" data-testid="torrent-exists-modal">
+  <div class="modal-header bb-modal-header">
     <div class="bb-modal-header__text">
       <h5 class="modal-title bb-title-clamp">
         {{ 'components.modals.torrent-exists.title' | translate }}

--- a/packages/app/src/app/components/save-path-select/save-path-select.html
+++ b/packages/app/src/app/components/save-path-select/save-path-select.html
@@ -32,7 +32,6 @@
         } @else {
           <div class="form-floating">
             <ng-select
-              data-testid="save-path-select-input"
               [items]="paths()"
               [addTag]="addTag"
               [searchable]="true"
@@ -86,7 +85,6 @@
   } @else {
     <div class="form-floating">
       <ng-select
-        data-testid="save-path-select-input"
         [items]="paths()"
         [addTag]="addTag"
         [searchable]="true"

--- a/packages/app/src/app/components/tag-select/tag-select.html
+++ b/packages/app/src/app/components/tag-select/tag-select.html
@@ -3,7 +3,6 @@
     <div class="col-11">
       <div class="form-floating">
         <ng-select
-          data-testid="tag-select-input"
           [items]="tags()"
           [multiple]="true"
           [hideSelected]="true"

--- a/packages/app/src/app/pages/login/login.html
+++ b/packages/app/src/app/pages/login/login.html
@@ -4,10 +4,7 @@
       <div class="hero-content">
         <div class="hero-logo-wrapper">
           <img [ngSrc]="logoUrl()" alt="BitButler logo" width="260" height="260" priority />
-          <span
-            class="hero-version-badge cursor-pointer user-select-none"
-            data-testid="version-badge"
-            (click)="goToRelease()"
+          <span class="hero-version-badge cursor-pointer user-select-none" (click)="goToRelease()"
             >v{{ version }}</span
           >
         </div>
@@ -36,7 +33,7 @@
     <div class="form-wrapper">
       @if (showHero()) {
         <div class="mb-4">
-          <h3 class="form-title" data-testid="brand-title">
+          <h3 class="form-title">
             {{ 'pages.login.form-title' | translate }}
           </h3>
           <p class="text-body-secondary small mb-0">
@@ -49,7 +46,6 @@
         <div class="form-floating">
           <ng-select
             id="server"
-            data-testid="server-select"
             bindLabel="name"
             bindValue="id"
             formControlName="server"
@@ -71,18 +67,12 @@
         <button
           type="button"
           class="btn btn-lg btn-primary"
-          data-testid="connect-button"
           (click)="connect()"
           [disabled]="!canConnect()"
         >
           {{ 'general.button.connect' | translate }}
         </button>
-        <button
-          type="button"
-          class="btn btn-lg btn-dashed-secondary"
-          data-testid="manage-servers-button"
-          (click)="openManageServers()"
-        >
+        <button type="button" class="btn btn-lg btn-dashed-secondary" (click)="openManageServers()">
           {{ 'general.button.manage-servers' | translate }}
         </button>
       </div>

--- a/packages/app/src/app/pages/main/button-bar/button-bar.html
+++ b/packages/app/src/app/pages/main/button-bar/button-bar.html
@@ -9,7 +9,6 @@
             type="button"
             class="bb-tool"
             [id]="'bb-dropdown-' + e.id"
-            [attr.data-testid]="'toolbar-btn-' + e.id"
             ngbDropdownToggle
             [disabled]="e.disabled"
             [class.bb-tool--primary]="e.variant === 'primary'"
@@ -44,7 +43,6 @@
               <button
                 ngbDropdownItem
                 type="button"
-                [attr.data-testid]="'toolbar-btn-' + item.id"
                 [disabled]="!!item.disabled"
                 (click)="onClick(item.id)"
                 [class.bb-dropdown-item--primary]="item.variant === 'primary'"
@@ -68,7 +66,6 @@
         <button
           type="button"
           class="bb-tool"
-          [attr.data-testid]="'toolbar-btn-' + e.id"
           [disabled]="e.disabled"
           [class.bb-tool--primary]="e.variant === 'primary'"
           [class.bb-tool--secondary]="e.variant === 'secondary'"

--- a/packages/app/src/app/pages/main/grid/context-menu/context-menu.html
+++ b/packages/app/src/app/pages/main/grid/context-menu/context-menu.html
@@ -12,7 +12,6 @@
       <button
         type="button"
         class="bb-item"
-        [attr.data-testid]="'ctx-' + entry.id"
         [class.bb-danger]="entry.variant === 'danger'"
         [class.bb-warning]="entry.variant === 'warning'"
         [class.bb-success]="entry.variant === 'success'"
@@ -38,7 +37,6 @@
       <button
         type="button"
         class="bb-item"
-        [attr.data-testid]="'ctx-' + entry.id"
         [class.bb-item--submenu-open]="activeSubmenuId() === entry.id"
         [class.bb-danger]="entry.variant === 'danger'"
         [class.bb-warning]="entry.variant === 'warning'"

--- a/packages/app/src/app/pages/main/main.html
+++ b/packages/app/src/app/pages/main/main.html
@@ -14,7 +14,7 @@
     </div>
 
     <div class="d-flex flex-row flex-grow-1 min-w-0">
-      <app-button-bar class="flex-grow-1 min-w-0" data-testid="button-bar"></app-button-bar>
+      <app-button-bar class="flex-grow-1 min-w-0"></app-button-bar>
     </div>
   </header>
 
@@ -27,10 +27,10 @@
 
     <main class="d-flex flex-column flex-grow-1 min-w-0 min-h-0">
       <div class="flex-grow-1 min-h-0 overflow-hidden">
-        <app-grid class="h-100 w-100" data-testid="torrent-grid"></app-grid>
+        <app-grid class="h-100 w-100"></app-grid>
       </div>
 
-      <footer class="flex-shrink-0 border-start" data-testid="status-bar">
+      <footer class="flex-shrink-0 border-start">
         <app-server-state [state]="serverState()"></app-server-state>
       </footer>
     </main>

--- a/packages/app/src/app/pages/settings/general/general.html
+++ b/packages/app/src/app/pages/settings/general/general.html
@@ -215,7 +215,6 @@
 
             <div class="col-6">
               <ng-select
-                data-testid="theme-family-select"
                 [items]="families"
                 [clearable]="false"
                 [openOnEnter]="false"

--- a/packages/app/src/app/pages/settings/settings.html
+++ b/packages/app/src/app/pages/settings/settings.html
@@ -1,4 +1,4 @@
-<div class="modal-header bb-modal-header" data-testid="settings-modal">
+<div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5 class="modal-title bb-title-clamp">{{ 'pages.settings.title' | translate }}</h5>
 
@@ -9,7 +9,6 @@
             class="nav-link"
             [class.active]="activeTabId() === tab.id"
             (click)="selectTab(tab.id)"
-            [attr.data-testid]="'settings-tab-' + tab.id"
           >
             {{ tab.label | translate }}
             @if (stateService.isDirtyMap()[tab.id]) {
@@ -54,17 +53,10 @@
     class="btn btn-secondary"
     [disabled]="!stateService.isDirty()"
     (click)="onSave()"
-    data-testid="settings-save"
   >
     {{ 'general.button.save' | translate }}
   </button>
-  <button
-    type="button"
-    class="btn btn-link"
-    (click)="activeModal.dismiss()"
-    autofocus
-    data-testid="settings-close"
-  >
+  <button type="button" class="btn btn-link" (click)="activeModal.dismiss()" autofocus>
     {{ 'general.button.close' | translate }}
   </button>
 </div>


### PR DESCRIPTION
## Issue ID

Fixes #144

## Description

Removes leftover `data-testid` / `[attr.data-testid]` attributes from component and page templates, since the project no longer has Playwright tests.

The `manage-servers` connect button used `data-testid="connect-btn"` in a unit test selector; replaced it with a `connect-btn` CSS class and updated the spec accordingly.