### PR TITLE
Filter field for content component

### DIFF
--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -18,7 +18,37 @@
       {{ 'components.bb-file-tree.stats.files' | translate }}
     </div>
   </div>
-  <div class="bb-tree-total-size ms-auto">
+  @if (allowEdit()) {
+    <div class="bb-tree-filter ms-auto">
+      <div class="input-group input-group-sm bb-search">
+        <span class="input-group-text bb-search__addon" aria-hidden="true">
+          <fa-icon [icon]="icon.faMagnifyingGlass"></fa-icon>
+        </span>
+        <input
+          #filterInput
+          type="text"
+          class="form-control bb-search__input"
+          [placeholder]="'components.bb-file-tree.filter.placeholder' | translate"
+          [value]="filterText()"
+          [disabled]="editMode()"
+          (input)="onFilterInput(filterInput.value)"
+        />
+        <button
+          type="button"
+          class="input-group-text bb-search__addon bb-search__clear"
+          [class.bb-search__clear--hidden]="!filterText()"
+          [disabled]="editMode()"
+          [ngbTooltip]="'general.button.clear' | translate"
+          tooltipClass="single-line-tooltip"
+          placement="top"
+          (click)="clearFilter()"
+        >
+          <fa-icon [icon]="icon.faX"></fa-icon>
+        </button>
+      </div>
+    </div>
+  }
+  <div class="bb-tree-total-size" [class.ms-auto]="!allowEdit()">
     <strong>{{ selectedSize() | fileSize }}</strong>
     @if (selectedSize() < totalSize()) {
       / {{ totalSize() | fileSize }}
@@ -26,6 +56,26 @@
   </div>
   @if (allowEdit()) {
     <div class="button-bar ms-2">
+      <button
+        type="button"
+        class="btn btn-sm btn-link text-secondary"
+        [ngbTooltip]="'components.bb-file-tree.toolbar.expand-all' | translate"
+        tooltipClass="single-line-tooltip"
+        placement="top"
+        (click)="expandAllNodes()"
+      >
+        <fa-icon [icon]="icon.faCircleChevronDown"></fa-icon>
+      </button>
+      <button
+        type="button"
+        class="btn btn-sm btn-link text-secondary"
+        [ngbTooltip]="'components.bb-file-tree.toolbar.collapse-all' | translate"
+        tooltipClass="single-line-tooltip"
+        placement="top"
+        (click)="collapseAllNodes()"
+      >
+        <fa-icon [icon]="icon.faCircleChevronUp"></fa-icon>
+      </button>
       @if (!editMode()) {
         <button
           type="button"
@@ -33,6 +83,7 @@
           [ngbTooltip]="'general.button.edit' | translate"
           tooltipClass="single-line-tooltip"
           placement="top"
+          [disabled]="hasNoMatches()"
           (click)="enterEditMode()"
         >
           <fa-icon [icon]="icon.faEdit"></fa-icon>
@@ -69,7 +120,11 @@
   [trackBy]="trackByPath"
   class="bb-file-tree"
 >
-  <cdk-nested-tree-node *cdkTreeNodeDef="let node; when: hasChild" class="bb-node">
+  <cdk-nested-tree-node
+    *cdkTreeNodeDef="let node; when: hasChild"
+    class="bb-node"
+    [class.bb-node--hidden]="!isVisible(node)"
+  >
     <div
       class="bb-row bb-row--dir cursor-pointer"
       [class.bb-row--skipped]="isFolderEmpty(node)"
@@ -138,7 +193,11 @@
     </div>
   </cdk-nested-tree-node>
 
-  <cdk-nested-tree-node *cdkTreeNodeDef="let node" class="bb-node">
+  <cdk-nested-tree-node
+    *cdkTreeNodeDef="let node"
+    class="bb-node"
+    [class.bb-node--hidden]="!isVisible(node)"
+  >
     <div
       class="bb-row bb-row--file"
       [class.bb-row--skipped]="node.file?.priority === 0"

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -18,37 +18,7 @@
       {{ 'components.bb-file-tree.stats.files' | translate }}
     </div>
   </div>
-  @if (allowEdit()) {
-    <div class="bb-tree-filter ms-auto">
-      <div class="input-group input-group-sm bb-search">
-        <span class="input-group-text bb-search__addon" aria-hidden="true">
-          <fa-icon [icon]="icon.faMagnifyingGlass"></fa-icon>
-        </span>
-        <input
-          #filterInput
-          type="text"
-          class="form-control bb-search__input"
-          [placeholder]="'components.bb-file-tree.filter.placeholder' | translate"
-          [value]="filterText()"
-          [disabled]="editMode()"
-          (input)="onFilterInput(filterInput.value)"
-        />
-        <button
-          type="button"
-          class="input-group-text bb-search__addon bb-search__clear"
-          [class.bb-search__clear--hidden]="!filterText()"
-          [disabled]="editMode()"
-          [ngbTooltip]="'general.button.clear' | translate"
-          tooltipClass="single-line-tooltip"
-          placement="top"
-          (click)="clearFilter()"
-        >
-          <fa-icon [icon]="icon.faX"></fa-icon>
-        </button>
-      </div>
-    </div>
-  }
-  <div class="bb-tree-total-size" [class.ms-auto]="!allowEdit()">
+  <div class="bb-tree-total-size ms-auto">
     <strong>{{ selectedSize() | fileSize }}</strong>
     @if (selectedSize() < totalSize()) {
       / {{ totalSize() | fileSize }}
@@ -110,6 +80,34 @@
           <fa-icon [icon]="icon.faX"></fa-icon>
         </button>
       }
+    </div>
+    <div class="bb-tree-filter">
+      <div class="input-group input-group-sm bb-search">
+        <span class="input-group-text bb-search__addon" aria-hidden="true">
+          <fa-icon [icon]="icon.faMagnifyingGlass"></fa-icon>
+        </span>
+        <input
+          #filterInput
+          type="text"
+          class="form-control bb-search__input"
+          [placeholder]="'components.bb-file-tree.filter.placeholder' | translate"
+          [value]="filterText()"
+          [disabled]="editMode()"
+          (input)="onFilterInput(filterInput.value)"
+        />
+        <button
+          type="button"
+          class="input-group-text bb-search__addon bb-search__clear"
+          [class.bb-search__clear--hidden]="!filterText()"
+          [disabled]="editMode()"
+          [ngbTooltip]="'general.button.clear' | translate"
+          tooltipClass="single-line-tooltip"
+          placement="top"
+          (click)="clearFilter()"
+        >
+          <fa-icon [icon]="icon.faX"></fa-icon>
+        </button>
+      </div>
     </div>
   }
 </div>

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -114,11 +114,18 @@
   }
 </div>
 
+@if (hasNoMatches()) {
+  <p class="bb-no-match">
+    {{ 'components.bb-file-tree.filter.no-match' | translate }}
+  </p>
+}
+
 <cdk-tree
   [dataSource]="data"
   [treeControl]="treeControl"
   [trackBy]="trackByPath"
   class="bb-file-tree"
+  [class.bb-file-tree--hidden]="hasNoMatches()"
 >
   <cdk-nested-tree-node
     *cdkTreeNodeDef="let node; when: hasChild"

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
@@ -6,8 +6,10 @@
 
 .bb-tree-header {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
+  row-gap: 0.5rem;
   padding: 0.75rem 1.25rem;
   margin-bottom: 0.75rem;
   background: var(--bb-control-bg);
@@ -47,8 +49,79 @@
   }
 }
 
+.bb-tree-filter {
+  flex: 0 1 240px;
+  min-width: 0;
+}
+
+.bb-search {
+  display: flex;
+  border: 1px solid var(--bb-control-border);
+  border-radius: var(--bb-control-radius);
+  background-color: var(--bb-control-bg);
+  overflow: hidden;
+  box-shadow: none;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+
+  &:focus-within {
+    border-color: var(--bb-control-focus-border);
+    box-shadow: 0 0 0 0.2rem var(--bb-control-focus-ring);
+  }
+
+  > .bb-search__addon,
+  > .bb-search__input {
+    border: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+
+  .bb-search__addon {
+    display: flex;
+    align-items: center;
+    color: var(--bb-control-placeholder);
+    padding-inline: 0.6rem;
+  }
+
+  .bb-search__input {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    padding-left: 0;
+    color: var(--bb-control-text);
+
+    &::placeholder {
+      color: var(--bb-control-placeholder);
+    }
+  }
+
+  .bb-search__clear {
+    color: var(--bs-secondary-color) !important;
+    cursor: pointer;
+
+    &--hidden {
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    &:hover {
+      color: var(--bs-body-color) !important;
+    }
+
+    &:disabled {
+      cursor: default;
+    }
+  }
+}
+
 .bb-file-tree {
   border: none;
+}
+
+.bb-node--hidden {
+  display: none;
 }
 
 .bb-row {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
@@ -9,7 +9,7 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
-  row-gap: 0.5rem;
+  gap: 0.5rem 0.75rem;
   padding: 0.75rem 1.25rem;
   margin-bottom: 0.75rem;
   background: var(--bb-control-bg);
@@ -118,6 +118,17 @@
 
 .bb-file-tree {
   border: none;
+
+  &--hidden {
+    display: none;
+  }
+}
+
+.bb-no-match {
+  padding: 1.5rem 1.25rem;
+  margin: 0;
+  text-align: center;
+  color: var(--bb-control-placeholder);
 }
 
 .bb-node--hidden {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
@@ -426,7 +426,7 @@ describe('BbFileTree', () => {
       expect(component.isVisible(otherNode)).toBe(false);
     });
 
-    it('should reveal the entire subtree when a folder name matches', () => {
+    it('should keep a matching folder visible without revealing non-matching children', () => {
       component.onFilterInput('dir');
       fixture.detectChanges();
 
@@ -435,8 +435,8 @@ describe('BbFileTree', () => {
       const betaNode = dirNode.children!.find((n) => n.name === 'beta.txt')!;
 
       expect(component.isVisible(dirNode)).toBe(true);
-      expect(component.isVisible(alphaNode)).toBe(true);
-      expect(component.isVisible(betaNode)).toBe(true);
+      expect(component.isVisible(alphaNode)).toBe(false);
+      expect(component.isVisible(betaNode)).toBe(false);
     });
 
     it('should match case-insensitively', () => {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
@@ -478,6 +478,33 @@ describe('BbFileTree', () => {
       expect(component.filterText()).toBe('');
       expect(component.isVisible(otherNode)).toBe(true);
     });
+
+    it('should not show a no-match message when there are matches', () => {
+      component.onFilterInput('alpha');
+      fixture.detectChanges();
+
+      const message = fixture.nativeElement.querySelector('.bb-no-match');
+      expect(message).toBeNull();
+    });
+
+    it('should show a no-match message when nothing matches the filter', () => {
+      component.onFilterInput('zzz');
+      fixture.detectChanges();
+
+      const message = fixture.nativeElement.querySelector('.bb-no-match');
+      expect(message).not.toBeNull();
+    });
+
+    it('should hide the no-match message once a match is found again', () => {
+      component.onFilterInput('zzz');
+      fixture.detectChanges();
+
+      component.onFilterInput('alpha');
+      fixture.detectChanges();
+
+      const message = fixture.nativeElement.querySelector('.bb-no-match');
+      expect(message).toBeNull();
+    });
   });
 
   describe('expandAllNodes / collapseAllNodes', () => {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.spec.ts
@@ -392,4 +392,117 @@ describe('BbFileTree', () => {
       expect(component.editMode()).toBe(true);
     });
   });
+
+  describe('file filtering', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('files', [
+        makeFile('dir/alpha.txt'),
+        makeFile('dir/beta.txt'),
+        makeFile('other/gamma.txt'),
+      ]);
+      fixture.detectChanges();
+    });
+
+    it('should mark all nodes visible when filter is empty', () => {
+      const dirNode = component.data.find((n) => n.name === 'dir')!;
+      const fileNode = dirNode.children!.find((n) => n.name === 'alpha.txt')!;
+
+      expect(component.isVisible(dirNode)).toBe(true);
+      expect(component.isVisible(fileNode)).toBe(true);
+    });
+
+    it('should show matching files and their parent folders, hiding the rest', () => {
+      component.onFilterInput('alpha');
+      fixture.detectChanges();
+
+      const dirNode = component.data.find((n) => n.name === 'dir')!;
+      const alphaNode = dirNode.children!.find((n) => n.name === 'alpha.txt')!;
+      const betaNode = dirNode.children!.find((n) => n.name === 'beta.txt')!;
+      const otherNode = component.data.find((n) => n.name === 'other')!;
+
+      expect(component.isVisible(dirNode)).toBe(true);
+      expect(component.isVisible(alphaNode)).toBe(true);
+      expect(component.isVisible(betaNode)).toBe(false);
+      expect(component.isVisible(otherNode)).toBe(false);
+    });
+
+    it('should reveal the entire subtree when a folder name matches', () => {
+      component.onFilterInput('dir');
+      fixture.detectChanges();
+
+      const dirNode = component.data.find((n) => n.name === 'dir')!;
+      const alphaNode = dirNode.children!.find((n) => n.name === 'alpha.txt')!;
+      const betaNode = dirNode.children!.find((n) => n.name === 'beta.txt')!;
+
+      expect(component.isVisible(dirNode)).toBe(true);
+      expect(component.isVisible(alphaNode)).toBe(true);
+      expect(component.isVisible(betaNode)).toBe(true);
+    });
+
+    it('should match case-insensitively', () => {
+      component.onFilterInput('ALPHA');
+      fixture.detectChanges();
+
+      const dirNode = component.data.find((n) => n.name === 'dir')!;
+      const alphaNode = dirNode.children!.find((n) => n.name === 'alpha.txt')!;
+
+      expect(component.isVisible(alphaNode)).toBe(true);
+    });
+
+    it('should report no matches when nothing matches the filter', () => {
+      component.onFilterInput('zzz');
+      fixture.detectChanges();
+
+      expect(component.hasNoMatches()).toBe(true);
+    });
+
+    it('should not report no matches when the filter is empty', () => {
+      expect(component.hasNoMatches()).toBe(false);
+    });
+
+    it('should not report no matches when there are matches', () => {
+      component.onFilterInput('alpha');
+      fixture.detectChanges();
+
+      expect(component.hasNoMatches()).toBe(false);
+    });
+
+    it('should restore full visibility when the filter is cleared', () => {
+      component.onFilterInput('alpha');
+      fixture.detectChanges();
+
+      component.clearFilter();
+      fixture.detectChanges();
+
+      const otherNode = component.data.find((n) => n.name === 'other')!;
+      expect(component.filterText()).toBe('');
+      expect(component.isVisible(otherNode)).toBe(true);
+    });
+  });
+
+  describe('expandAllNodes / collapseAllNodes', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('files', [makeFile('dir/a.txt'), makeFile('dir/b.txt')]);
+      fixture.detectChanges();
+    });
+
+    it('should expand all folder nodes', () => {
+      const dirNode = component.data.find((n) => n.name === 'dir')!;
+      expect(component.isExpanded(dirNode)).toBe(false);
+
+      component.expandAllNodes();
+
+      expect(component.isExpanded(dirNode)).toBe(true);
+    });
+
+    it('should collapse all expanded folder nodes', () => {
+      component.expandAllNodes();
+      const dirNode = component.data.find((n) => n.name === 'dir')!;
+      expect(component.isExpanded(dirNode)).toBe(true);
+
+      component.collapseAllNodes();
+
+      expect(component.isExpanded(dirNode)).toBe(false);
+    });
+  });
 });

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -574,21 +574,15 @@ function computeVisiblePaths(nodes: BbFileTreeNode[], query: string): Set<string
 function markVisible(node: BbFileTreeNode, query: string, visible: Set<string>): boolean {
   const selfMatches = node.name.toLowerCase().includes(query);
 
-  if (selfMatches) {
-    markSubtreeVisible(node, visible);
-    return true;
-  }
-
   let childVisible = false;
   for (const child of node.children ?? []) {
     if (markVisible(child, query, visible)) childVisible = true;
   }
 
-  if (childVisible) visible.add(node.fullPath);
-  return childVisible;
-}
+  if (selfMatches || childVisible) {
+    visible.add(node.fullPath);
+    return true;
+  }
 
-function markSubtreeVisible(node: BbFileTreeNode, visible: Set<string>): void {
-  visible.add(node.fullPath);
-  node.children?.forEach((child) => markSubtreeVisible(child, visible));
+  return false;
 }

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ViewChild,
+  computed,
   effect,
   inject,
   input,
@@ -13,7 +14,15 @@ import {
 import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TorrentFileEntry } from '@bitbutler/shared';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faCheck, faCircleExclamation, faEdit, faX } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCheck,
+  faCircleChevronDown,
+  faCircleChevronUp,
+  faCircleExclamation,
+  faEdit,
+  faMagnifyingGlass,
+  faX,
+} from '@fortawesome/free-solid-svg-icons';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -79,8 +88,23 @@ export class BbFileTree {
 
   public treeControl = new NestedTreeControl<BbFileTreeNode>((n) => n.children ?? []);
   public data: BbFileTreeNode[] = [];
+  private dataVersion = signal(0);
   private readonly translateService = inject(TranslateService);
   private readonly confirmService = inject(ConfirmService);
+
+  public filterText = signal('');
+
+  public visiblePaths = computed<Set<string> | null>(() => {
+    this.dataVersion();
+    const query = this.filterText().trim().toLowerCase();
+    if (!query) return null;
+    return computeVisiblePaths(this.data, query);
+  });
+
+  public hasNoMatches = computed(() => {
+    if (!this.filterText().trim()) return false;
+    return (this.visiblePaths()?.size ?? 0) === 0;
+  });
 
   public totalFiles = signal(0);
   public allFolders = signal(0);
@@ -104,7 +128,15 @@ export class BbFileTree {
     },
   ];
 
-  public icon = { faEdit, faCheck, faX, faCircleExclamation };
+  public icon = {
+    faEdit,
+    faCheck,
+    faX,
+    faCircleExclamation,
+    faCircleChevronDown,
+    faCircleChevronUp,
+    faMagnifyingGlass,
+  };
 
   trackByPath = (_index: number, node: BbFileTreeNode): string => node.fullPath;
 
@@ -124,6 +156,7 @@ export class BbFileTree {
         const updated = this.updateNodeFiles(this.data, fileMap);
         if (updated === files.length) {
           this.data = [...this.data];
+          this.dataVersion.update((v) => v + 1);
           this.totalFiles.set(files.length);
           this.calculateStats();
           this.tree?.renderNodeChanges(this.data);
@@ -133,6 +166,7 @@ export class BbFileTree {
 
       const result = buildTree(files);
       this.data = result.nodes;
+      this.dataVersion.update((v) => v + 1);
       this.totalFiles.set(files.length);
 
       this.calculateStats();
@@ -254,6 +288,7 @@ export class BbFileTree {
     this.treeControl.expansionModel.selected.forEach((n) => expandedPaths.add(n.fullPath));
     const result = buildTree(files);
     this.data = result.nodes;
+    this.dataVersion.update((v) => v + 1);
     this.totalFiles.set(files.length);
     this.calculateStats();
     if (this.expandAll()) this.expandAllNodes();
@@ -377,6 +412,19 @@ export class BbFileTree {
     await this.cancelEdit();
   }
 
+  onFilterInput(value: string): void {
+    this.filterText.set(value);
+  }
+
+  clearFilter(): void {
+    this.filterText.set('');
+  }
+
+  isVisible(node: BbFileTreeNode): boolean {
+    const visible = this.visiblePaths();
+    return !visible || visible.has(node.fullPath);
+  }
+
   hasChild = (_: number, node: BbFileTreeNode) => !!node.children?.length;
   toggle = (node: BbFileTreeNode) => this.treeControl.toggle(node);
   isExpanded = (node: BbFileTreeNode) => this.treeControl.isExpanded(node);
@@ -442,7 +490,7 @@ export class BbFileTree {
     return res;
   }
 
-  private expandAllNodes(): void {
+  expandAllNodes(): void {
     const stack = [...this.data];
     while (stack.length) {
       const n = stack.pop()!;
@@ -451,6 +499,10 @@ export class BbFileTree {
         stack.push(...n.children);
       }
     }
+  }
+
+  collapseAllNodes(): void {
+    this.treeControl.collapseAll();
   }
 
   private restoreExpansionState(nodes: BbFileTreeNode[], expandedPaths: Set<string>): void {
@@ -509,4 +561,34 @@ function sortTree(node: BbFileTreeNode): void {
     return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
   });
   node.children.forEach(sortTree);
+}
+
+function computeVisiblePaths(nodes: BbFileTreeNode[], query: string): Set<string> {
+  const visible = new Set<string>();
+  for (const node of nodes) {
+    markVisible(node, query, visible);
+  }
+  return visible;
+}
+
+function markVisible(node: BbFileTreeNode, query: string, visible: Set<string>): boolean {
+  const selfMatches = node.name.toLowerCase().includes(query);
+
+  if (selfMatches) {
+    markSubtreeVisible(node, visible);
+    return true;
+  }
+
+  let childVisible = false;
+  for (const child of node.children ?? []) {
+    if (markVisible(child, query, visible)) childVisible = true;
+  }
+
+  if (childVisible) visible.add(node.fullPath);
+  return childVisible;
+}
+
+function markSubtreeVisible(node: BbFileTreeNode, visible: Set<string>): void {
+  visible.add(node.fullPath);
+  node.children?.forEach((child) => markSubtreeVisible(child, visible));
 }

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -159,6 +159,13 @@
       "validation": {
         "required": "A név nem lehet üres",
         "pattern": "A név érvénytelen karaktereket tartalmaz (< > : \" / \\ | ? *)"
+      },
+      "filter": {
+        "placeholder": "Fájlok és mappák szűrése"
+      },
+      "toolbar": {
+        "expand-all": "Összes kibontása",
+        "collapse-all": "Összes összecsukása"
       }
     },
     "bb-popover": {},

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -161,7 +161,8 @@
         "pattern": "A név érvénytelen karaktereket tartalmaz (< > : \" / \\ | ? *)"
       },
       "filter": {
-        "placeholder": "Fájlok és mappák szűrése"
+        "placeholder": "Fájlok és mappák szűrése",
+        "no-match": "Egyetlen fájl vagy mappa sem felel meg a szűrőnek."
       },
       "toolbar": {
         "expand-all": "Összes kibontása",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -159,6 +159,13 @@
       "validation": {
         "required": "Name cannot be empty",
         "pattern": "Name contains invalid characters (< > : \" / \\ | ? *)"
+      },
+      "filter": {
+        "placeholder": "Filter files and folders"
+      },
+      "toolbar": {
+        "expand-all": "Expand all",
+        "collapse-all": "Collapse all"
       }
     },
     "bb-popover": {},

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -161,7 +161,8 @@
         "pattern": "Name contains invalid characters (< > : \" / \\ | ? *)"
       },
       "filter": {
-        "placeholder": "Filter files and folders"
+        "placeholder": "Filter files and folders",
+        "no-match": "No files or folders match your filter."
       },
       "toolbar": {
         "expand-all": "Expand all",


### PR DESCRIPTION
## Issue ID

Fixes #149

## Description

Adds a filter input to the file tree header to make it easier to navigate large torrents with many files.

- Filter input matches against both files and folders, case-insensitively.
- A folder stays visible if it matches itself or contains a matching descendant; non-matching children of a matched folder stay hidden.
- When the filter has no matches, the tree is hidden and a "no files or folders match your filter" message is shown instead.
- The Edit button is disabled when the filter has zero matches.
- The filter input is disabled while in edit mode, and edit mode shows only the currently filtered items.
- Adds "Expand all" / "Collapse all" toolbar buttons that expand or collapse the entire tree without preserving previous state.
- Header layout: read-only stats are grouped together, with the filter input as the rightmost control.
- Adds English and Hungarian translations for the new strings.