### PR TITLE
Use proper file and folder icons in the file tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "flag-icons": "^7.5.0",
         "form-data": "^4.0.5",
         "marked": "^16.4.2",
+        "mime": "^4.1.0",
         "ngx-markdown": "^20.1.0",
         "ngx-timeago": "^4.1.0",
         "parse-torrent": "^11.0.19",
@@ -10764,6 +10765,19 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/electron-publish/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/electron-publish/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -14211,16 +14225,18 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "flag-icons": "^7.5.0",
     "form-data": "^4.0.5",
     "marked": "^16.4.2",
+    "mime": "^4.1.0",
     "ngx-markdown": "^20.1.0",
     "ngx-timeago": "^4.1.0",
     "parse-torrent": "^11.0.19",

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.html
@@ -141,7 +141,10 @@
             />
           }
 
-          <span class="bb-icon">📁</span>
+          <fa-icon
+            class="bb-icon bb-icon--dir"
+            [icon]="isExpanded(node) ? icon.faFolderOpen : icon.faFolder"
+          ></fa-icon>
 
           @if (!editMode()) {
             <span class="bb-name">{{ node.name }}</span>
@@ -201,7 +204,7 @@
             }
           }
 
-          <span class="bb-icon">📄</span>
+          <fa-icon class="bb-icon bb-icon--file" [icon]="getFileIcon(node.name)"></fa-icon>
 
           @if (!editMode()) {
             <span

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.scss
@@ -179,12 +179,21 @@
 }
 
 .bb-icon {
-  font-size: 1.1rem;
+  font-size: 1rem;
+  line-height: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   width: 1.5rem;
+
+  &--dir {
+    color: var(--bb-accent);
+  }
+
+  &--file {
+    color: var(--bb-control-placeholder);
+  }
 }
 
 .bb-name {

--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -20,6 +20,8 @@ import {
   faCircleChevronUp,
   faCircleExclamation,
   faEdit,
+  faFolder,
+  faFolderOpen,
   faMagnifyingGlass,
   faX,
 } from '@fortawesome/free-solid-svg-icons';
@@ -30,6 +32,7 @@ import { TooltipOverflow } from '../../directives/tooltip-overflow';
 import { FilesizePipe } from '../../pipes/filesize-pipe';
 import { ConfirmService } from '../../services/confirm.service';
 import { BbProgress } from '../bb-progress/bb-progress';
+import { getFileIcon } from './file-icon';
 
 export type BbFileTreeNode = {
   name: string;
@@ -153,7 +156,11 @@ export class BbFileTree {
     faCircleChevronDown,
     faCircleChevronUp,
     faMagnifyingGlass,
+    faFolder,
+    faFolderOpen,
   };
+
+  public getFileIcon = getFileIcon;
 
   trackByPath = (_index: number, node: BbFileTreeNode): string => node.fullPath;
 

--- a/packages/app/src/app/components/bb-file-tree/file-icon.spec.ts
+++ b/packages/app/src/app/components/bb-file-tree/file-icon.spec.ts
@@ -1,0 +1,79 @@
+import {
+  faFile,
+  faFileAudio,
+  faFileCode,
+  faFileCsv,
+  faFileExcel,
+  faFileImage,
+  faFileLines,
+  faFilePdf,
+  faFilePowerpoint,
+  faFileVideo,
+  faFileWord,
+  faFileZipper,
+} from '@fortawesome/free-solid-svg-icons';
+import { getFileIcon } from './file-icon';
+
+describe('getFileIcon', () => {
+  it('returns the pdf icon for .pdf files', () => {
+    expect(getFileIcon('report.pdf')).toBe(faFilePdf);
+  });
+
+  it('returns the word icon for .docx files', () => {
+    expect(getFileIcon('letter.docx')).toBe(faFileWord);
+  });
+
+  it('returns the excel icon for .xlsx files', () => {
+    expect(getFileIcon('budget.xlsx')).toBe(faFileExcel);
+  });
+
+  it('returns the csv icon for .csv files', () => {
+    expect(getFileIcon('data.csv')).toBe(faFileCsv);
+  });
+
+  it('returns the powerpoint icon for .pptx files', () => {
+    expect(getFileIcon('slides.pptx')).toBe(faFilePowerpoint);
+  });
+
+  it('returns the zip icon for archive files', () => {
+    expect(getFileIcon('archive.zip')).toBe(faFileZipper);
+    expect(getFileIcon('archive.tar')).toBe(faFileZipper);
+    expect(getFileIcon('archive.7z')).toBe(faFileZipper);
+  });
+
+  it('returns the code icon for code/markup files', () => {
+    expect(getFileIcon('data.json')).toBe(faFileCode);
+    expect(getFileIcon('index.html')).toBe(faFileCode);
+    expect(getFileIcon('styles.css')).toBe(faFileCode);
+  });
+
+  it('returns the lines icon for markdown and plain text files', () => {
+    expect(getFileIcon('README.md')).toBe(faFileLines);
+    expect(getFileIcon('notes.txt')).toBe(faFileLines);
+  });
+
+  it('returns the image icon for image files', () => {
+    expect(getFileIcon('photo.jpg')).toBe(faFileImage);
+    expect(getFileIcon('icon.png')).toBe(faFileImage);
+  });
+
+  it('returns the audio icon for audio files', () => {
+    expect(getFileIcon('song.mp3')).toBe(faFileAudio);
+  });
+
+  it('returns the video icon for video files', () => {
+    expect(getFileIcon('movie.mp4')).toBe(faFileVideo);
+  });
+
+  it('returns the generic file icon for unknown extensions', () => {
+    expect(getFileIcon('binary.xyz123')).toBe(faFile);
+  });
+
+  it('returns the generic file icon for files without an extension', () => {
+    expect(getFileIcon('LICENSE')).toBe(faFile);
+  });
+
+  it('resolves the icon based on the file name regardless of its directory path', () => {
+    expect(getFileIcon('movies/2024/movie.mp4')).toBe(faFileVideo);
+  });
+});

--- a/packages/app/src/app/components/bb-file-tree/file-icon.ts
+++ b/packages/app/src/app/components/bb-file-tree/file-icon.ts
@@ -1,0 +1,75 @@
+import {
+  IconDefinition,
+  faFile,
+  faFileAudio,
+  faFileCode,
+  faFileCsv,
+  faFileExcel,
+  faFileImage,
+  faFileLines,
+  faFilePdf,
+  faFilePowerpoint,
+  faFileVideo,
+  faFileWord,
+  faFileZipper,
+} from '@fortawesome/free-solid-svg-icons';
+import mime from 'mime';
+
+const MIME_ICON_MAP: Record<string, IconDefinition> = {
+  // Documents
+  'application/pdf': faFilePdf,
+  'application/msword': faFileWord,
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': faFileWord,
+  'application/vnd.oasis.opendocument.text': faFileWord,
+
+  // Spreadsheets / data tables
+  'application/vnd.ms-excel': faFileExcel,
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': faFileExcel,
+  'application/vnd.oasis.opendocument.spreadsheet': faFileExcel,
+  'text/csv': faFileCsv,
+  'text/tab-separated-values': faFileCsv,
+
+  // Presentations
+  'application/vnd.ms-powerpoint': faFilePowerpoint,
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': faFilePowerpoint,
+  'application/vnd.oasis.opendocument.presentation': faFilePowerpoint,
+
+  // Archives / compressed files
+  'application/zip': faFileZipper,
+  'application/x-7z-compressed': faFileZipper,
+  'application/vnd.rar': faFileZipper,
+  'application/x-rar-compressed': faFileZipper,
+  'application/x-tar': faFileZipper,
+  'application/gzip': faFileZipper,
+  'application/x-gzip': faFileZipper,
+  'application/x-bzip2': faFileZipper,
+  'application/x-bittorrent': faFileZipper,
+
+  // Code / markup / config
+  'application/json': faFileCode,
+  'application/xml': faFileCode,
+  'application/javascript': faFileCode,
+  'text/javascript': faFileCode,
+  'text/html': faFileCode,
+  'text/css': faFileCode,
+  'text/markdown': faFileLines,
+
+  // Broad category fallbacks (e.g. image/jpeg, audio/mpeg, video/mp4, text/plain)
+  image: faFileImage,
+  audio: faFileAudio,
+  video: faFileVideo,
+  text: faFileLines,
+};
+
+/**
+ * Resolves a file name to its corresponding Font Awesome icon based on its MIME type.
+ */
+export function getFileIcon(fileName: string): IconDefinition {
+  const mimeType = mime.getType(fileName);
+  if (!mimeType) return faFile;
+
+  if (MIME_ICON_MAP[mimeType]) return MIME_ICON_MAP[mimeType];
+
+  const mainType = mimeType.split('/')[0];
+  return MIME_ICON_MAP[mainType] ?? faFile;
+}


### PR DESCRIPTION
## Issue ID

Fixes #155

## Description

Replaces the generic emoji placeholders in the file tree component with Font Awesome icons.

- Added `getFileIcon()` which maps a file's MIME type (via the `mime` package) to a Font Awesome solid icon, with broad category fallbacks (image, audio, video, text) and a generic file icon as the final fallback.
- Folder rows now show `faFolderOpen` when expanded and `faFolder` when collapsed, colored with the accent color.
- File rows show the MIME-mapped icon, colored with the muted control placeholder color.
- Added unit tests covering the MIME-to-icon mapping for documents, spreadsheets, presentations, archives, code/markup files, media files, and fallback cases.