### PR TITLE
Fix Add Torrent modal flicker when the opened torrent already exists

### DIFF
--- a/packages/app/src/app/app.spec.ts
+++ b/packages/app/src/app/app.spec.ts
@@ -9,6 +9,7 @@ import { Maindata } from './models/torrent.model';
 import { CommandBusService } from './services/command-bus.service';
 import { OpenFilesService, PendingAddTorrent } from './services/open-files.service';
 import { TorrentStoreService } from './services/torrent-store.service';
+import { UiCommandHandlerService } from './services/ui-command-handler.service';
 
 const makeMaindata = (opts: Partial<Maindata>): Maindata =>
   ({
@@ -42,6 +43,11 @@ describe('App', () => {
         provideZonelessChangeDetection(),
         provideRouter([]),
         provideTimeago({ intl: { provide: TimeagoIntl, useClass: TimeagoIntl } }),
+        // Real UiCommandHandlerService would act on the commands emitted below (e.g. actually
+        // opening NgbModal), which doesn't work once the test environment tears down. App's own
+        // command-emitting logic is what these tests cover; modal-opening behavior for
+        // UI_ADD_TORRENT/UI_TORRENT_EXISTS is covered in ui-command-handler.service.spec.ts.
+        { provide: UiCommandHandlerService, useValue: { start: vi.fn() } },
       ],
     }).compileComponents();
   });

--- a/packages/app/src/app/app.spec.ts
+++ b/packages/app/src/app/app.spec.ts
@@ -5,6 +5,34 @@ import { NgSelectConfig } from '@ng-select/ng-select';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TimeagoIntl, provideTimeago } from 'ngx-timeago';
 import { App } from './app';
+import { Maindata } from './models/torrent.model';
+import { CommandBusService } from './services/command-bus.service';
+import { OpenFilesService, PendingAddTorrent } from './services/open-files.service';
+import { TorrentStoreService } from './services/torrent-store.service';
+
+const makeMaindata = (opts: Partial<Maindata>): Maindata =>
+  ({
+    rid: 1,
+    full_update: false,
+    torrents: {},
+    torrents_removed: [],
+    ...opts,
+  }) as Maindata;
+
+const makePendingDraft = (overrides: {
+  originalPath: string;
+  infoHashV1?: string;
+}): PendingAddTorrent => ({
+  draft: {
+    source: 'startup',
+    receivedAt: Date.now(),
+    originalPath: overrides.originalPath,
+    torrent: overrides.infoHashV1
+      ? { name: 'Movie', totalSize: 100, infoHashV1: overrides.infoHashV1, files: [] }
+      : undefined,
+  },
+  selected: { name: 'movie.torrent', path: overrides.originalPath },
+});
 
 describe('App', () => {
   beforeEach(async () => {
@@ -49,5 +77,104 @@ describe('App', () => {
     expect(instantSpy).toHaveBeenCalledWith('general.form.ng-select.loading');
     expect(instantSpy).toHaveBeenCalledWith('general.form.ng-select.not-found');
     expect(instantSpy).toHaveBeenCalledWith('general.form.ng-select.type-to-search');
+  });
+
+  describe('open files queue duplicate handling', () => {
+    it('should emit UI_TORRENT_EXISTS and consume the draft, without opening AddTorrent, when the front item is already in the list', () => {
+      const fixture = TestBed.createComponent(App);
+      const openFilesService = TestBed.inject(OpenFilesService);
+      const torrentStoreService = TestBed.inject(TorrentStoreService);
+      const commandBusService = TestBed.inject(CommandBusService);
+      const emitSpy = vi.spyOn(commandBusService, 'emit');
+
+      torrentStoreService.applyMaindata(
+        makeMaindata({ full_update: true, torrents: { abc123: { name: 'Movie' } as any } }),
+      );
+
+      openFilesService.pendingDrafts.set([
+        makePendingDraft({ originalPath: '/tmp/movie.torrent', infoHashV1: 'ABC123' }),
+      ]);
+
+      fixture.detectChanges();
+
+      expect(emitSpy).toHaveBeenCalledWith({
+        type: 'UI_TORRENT_EXISTS',
+        hash: 'abc123',
+        originalPath: '/tmp/movie.torrent',
+      });
+      expect(emitSpy).not.toHaveBeenCalledWith({ type: 'UI_ADD_TORRENT' });
+      expect(openFilesService.pendingDrafts()).toEqual([]);
+    });
+
+    it('should skip every leading duplicate and open AddTorrent once a new torrent is reached', () => {
+      const fixture = TestBed.createComponent(App);
+      const openFilesService = TestBed.inject(OpenFilesService);
+      const torrentStoreService = TestBed.inject(TorrentStoreService);
+      const commandBusService = TestBed.inject(CommandBusService);
+      const emitSpy = vi.spyOn(commandBusService, 'emit');
+
+      torrentStoreService.applyMaindata(
+        makeMaindata({
+          full_update: true,
+          torrents: { abc123: { name: 'A' } as any, def456: { name: 'B' } as any },
+        }),
+      );
+
+      const newDraft = makePendingDraft({ originalPath: '/tmp/c.torrent', infoHashV1: 'NEW789' });
+      openFilesService.pendingDrafts.set([
+        makePendingDraft({ originalPath: '/tmp/a.torrent', infoHashV1: 'ABC123' }),
+        makePendingDraft({ originalPath: '/tmp/b.torrent', infoHashV1: 'DEF456' }),
+        newDraft,
+      ]);
+
+      fixture.detectChanges();
+
+      expect(emitSpy).toHaveBeenCalledWith({
+        type: 'UI_TORRENT_EXISTS',
+        hash: 'abc123',
+        originalPath: '/tmp/a.torrent',
+      });
+      expect(emitSpy).toHaveBeenCalledWith({
+        type: 'UI_TORRENT_EXISTS',
+        hash: 'def456',
+        originalPath: '/tmp/b.torrent',
+      });
+      expect(emitSpy).toHaveBeenCalledWith({ type: 'UI_ADD_TORRENT' });
+      expect(openFilesService.pendingDrafts()).toEqual([newDraft]);
+    });
+
+    it('should emit UI_ADD_TORRENT directly when the front item is a new torrent', () => {
+      const fixture = TestBed.createComponent(App);
+      const openFilesService = TestBed.inject(OpenFilesService);
+      const torrentStoreService = TestBed.inject(TorrentStoreService);
+      const commandBusService = TestBed.inject(CommandBusService);
+      const emitSpy = vi.spyOn(commandBusService, 'emit');
+
+      torrentStoreService.applyMaindata(makeMaindata({ full_update: true }));
+
+      openFilesService.pendingDrafts.set([
+        makePendingDraft({ originalPath: '/tmp/new.torrent', infoHashV1: 'NEW789' }),
+      ]);
+
+      fixture.detectChanges();
+
+      expect(emitSpy).toHaveBeenCalledWith({ type: 'UI_ADD_TORRENT' });
+      expect(openFilesService.pendingDrafts().length).toBe(1);
+    });
+
+    it('should not emit anything until the torrent store is primed', () => {
+      const fixture = TestBed.createComponent(App);
+      const openFilesService = TestBed.inject(OpenFilesService);
+      const commandBusService = TestBed.inject(CommandBusService);
+      const emitSpy = vi.spyOn(commandBusService, 'emit');
+
+      openFilesService.pendingDrafts.set([
+        makePendingDraft({ originalPath: '/tmp/new.torrent', infoHashV1: 'NEW789' }),
+      ]);
+
+      fixture.detectChanges();
+
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/app/src/app/app.ts
+++ b/packages/app/src/app/app.ts
@@ -58,8 +58,20 @@ export class App {
 
   private readonly _openDraftsEffect = effect(() => {
     const items = this.openFilesService.pendingDrafts();
-    if (!items.length) return;
+    const first = items[0];
+    if (!first) return;
     if (!this.torrentStoreService.isPrimed()) return;
+
+    const hash = first.draft.torrent?.infoHashV1?.toLowerCase();
+    if (hash && this.torrentStoreService.torrentsMap().has(hash)) {
+      this.commandBusService.emit({
+        type: 'UI_TORRENT_EXISTS',
+        hash,
+        originalPath: first.draft.originalPath ?? null,
+      });
+      this.openFilesService.consumeCurrentDraft();
+      return;
+    }
 
     this.commandBusService.emit({ type: 'UI_ADD_TORRENT' });
   });

--- a/packages/app/src/app/modals/add-torrent/add-torrent.spec.ts
+++ b/packages/app/src/app/modals/add-torrent/add-torrent.spec.ts
@@ -1,21 +1,18 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { TorrentDraft } from '@bitbutler/shared';
-import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 import { FileTreeSaveEvent } from '../../components/bb-file-tree/bb-file-tree';
 import { DEFAULT_GENERAL_SETTINGS } from '../../models/general-settings.model';
 import { AddTorrentSettingsService } from '../../services/add-torrent-settings.service';
+import { CommandBusService } from '../../services/command-bus.service';
 import { ConfirmService } from '../../services/confirm.service';
 import { GeneralSettingsService } from '../../services/general-settings.service';
 import { OpenFilesService } from '../../services/open-files.service';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
-import { TorrentStoreService } from '../../services/torrent-store.service';
-import { TorrentExists } from '../torrent-exists/torrent-exists';
 import { AddTorrent } from './add-torrent';
-
-const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve));
 
 const draftWithFiles: TorrentDraft = {
   source: 'manual',
@@ -32,6 +29,7 @@ describe('AddTorrent', () => {
   let fixture: ComponentFixture<AddTorrent>;
   let mockActiveModal: Partial<NgbActiveModal>;
   let mockOpenFilesService: any;
+  let mockCommandBusService: any;
 
   beforeEach(async () => {
     mockActiveModal = { close: vi.fn(), dismiss: vi.fn() };
@@ -39,15 +37,15 @@ describe('AddTorrent', () => {
       pendingDrafts: signal([]),
       consumeCurrentDraft: vi.fn(),
     };
+    mockCommandBusService = { emit: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [AddTorrent],
       providers: [
         { provide: NgbActiveModal, useValue: mockActiveModal },
-        { provide: NgbModal, useValue: { open: vi.fn() } },
         { provide: ServerStoreService, useValue: { currentServerId: signal('server-1') } },
-        { provide: TorrentStoreService, useValue: { torrentsArray: signal([]) } },
         { provide: OpenFilesService, useValue: mockOpenFilesService },
+        { provide: CommandBusService, useValue: mockCommandBusService },
         {
           provide: AddTorrentSettingsService,
           useValue: {
@@ -629,12 +627,10 @@ describe('AddTorrent', () => {
       expect(mockOpenFilesService.consumeCurrentDraft).toHaveBeenCalled();
     });
 
-    it('should open the TorrentExists modal and consume the draft on a 409 conflict', async () => {
+    it('should emit UI_TORRENT_EXISTS and consume the draft on a 409 conflict', async () => {
       vi.spyOn(window.bitbutler.qb, 'torrentsAdd')
         .mockClear()
         .mockRejectedValue(new Error('Request failed: 409 {"name":"QbHttpError","status":409}'));
-      const modalService = TestBed.inject(NgbModal) as any;
-      modalService.open.mockReturnValue({ _contentRef: { componentRef: { setInput: vi.fn() } } });
 
       (component as any).selectedTorrentFile.set({
         name: 'test.torrent',
@@ -650,21 +646,19 @@ describe('AddTorrent', () => {
 
       await component.handleSubmit({ preventDefault: () => {} } as unknown as SubmitEvent);
 
-      expect(modalService.open).toHaveBeenCalledWith(TorrentExists, { centered: true });
+      expect(mockCommandBusService.emit).toHaveBeenCalledWith({
+        type: 'UI_TORRENT_EXISTS',
+        hash: 'abc123',
+        originalPath: null,
+      });
       expect(mockOpenFilesService.consumeCurrentDraft).toHaveBeenCalled();
       expect(component.addForm.errors).toBeNull();
     });
 
-    it('should pass the draft originalPath to TorrentExists on a 409 conflict', async () => {
+    it('should pass the draft originalPath in the UI_TORRENT_EXISTS command on a 409 conflict', async () => {
       vi.spyOn(window.bitbutler.qb, 'torrentsAdd')
         .mockClear()
         .mockRejectedValue(new Error('Request failed: 409 {"name":"QbHttpError","status":409}'));
-
-      const setInputMock = vi.fn();
-      const modalService = TestBed.inject(NgbModal) as any;
-      modalService.open.mockReturnValue({
-        _contentRef: { componentRef: { setInput: setInputMock } },
-      });
 
       (component as any).selectedTorrentFile.set({
         name: 'test.torrent',
@@ -681,7 +675,9 @@ describe('AddTorrent', () => {
 
       await component.handleSubmit({ preventDefault: () => {} } as unknown as SubmitEvent);
 
-      expect(setInputMock).toHaveBeenCalledWith('originalPath', '/tmp/test.torrent');
+      expect(mockCommandBusService.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ originalPath: '/tmp/test.torrent' }),
+      );
     });
 
     it('should set addFailed when torrentsAdd throws a non-conflict error', async () => {
@@ -829,56 +825,6 @@ describe('AddTorrent', () => {
 
       expect(component.addForm.controls.fileGroup.controls.rename.value).toBe('My Movie');
       expect(component.showTree()).toBe(false);
-    });
-
-    it('should open the TorrentExists modal and consume the draft when the torrent is already in the list', async () => {
-      const torrentStoreService = TestBed.inject(TorrentStoreService) as any;
-      torrentStoreService.torrentsArray.set([{ hash: 'ABC123' }]);
-
-      const modalService = TestBed.inject(NgbModal) as any;
-      modalService.open.mockReturnValue({ _contentRef: { componentRef: { setInput: vi.fn() } } });
-
-      const draft: TorrentDraft = {
-        source: 'manual',
-        receivedAt: Date.now(),
-        originalPath: '/tmp/movie.torrent',
-        torrent: { name: 'Movie', totalSize: 100, infoHashV1: 'abc123', files: [] },
-      };
-
-      mockOpenFilesService.pendingDrafts.set([
-        { draft, selected: { name: 'movie.torrent', path: '/tmp/movie.torrent' } },
-      ]);
-      fixture.detectChanges();
-      await flushPromises();
-
-      expect(modalService.open).toHaveBeenCalledWith(TorrentExists, { centered: true });
-      expect(mockOpenFilesService.consumeCurrentDraft).toHaveBeenCalled();
-    });
-
-    it('should pass the draft originalPath to TorrentExists when the torrent is already in the list', async () => {
-      const torrentStoreService = TestBed.inject(TorrentStoreService) as any;
-      torrentStoreService.torrentsArray.set([{ hash: 'abc123' }]);
-
-      const setInputMock = vi.fn();
-      const modalService = TestBed.inject(NgbModal) as any;
-      modalService.open.mockReturnValue({
-        _contentRef: { componentRef: { setInput: setInputMock } },
-      });
-
-      const draft: TorrentDraft = {
-        source: 'manual',
-        receivedAt: Date.now(),
-        originalPath: '/tmp/movie.torrent',
-        torrent: { name: 'Movie', totalSize: 100, infoHashV1: 'abc123', files: [] },
-      };
-
-      mockOpenFilesService.pendingDrafts.set([
-        { draft, selected: { name: 'movie.torrent', path: '/tmp/movie.torrent' } },
-      ]);
-      fixture.detectChanges();
-      await flushPromises();
-
-      expect(setInputMock).toHaveBeenCalledWith('originalPath', '/tmp/movie.torrent');
     });
 
     it('should track the queue size and close the modal once all pending drafts are consumed', () => {

--- a/packages/app/src/app/modals/add-torrent/add-torrent.ts
+++ b/packages/app/src/app/modals/add-torrent/add-torrent.ts
@@ -20,7 +20,7 @@ import {
   faTriangleExclamation,
   faXmark,
 } from '@fortawesome/free-solid-svg-icons';
-import { NgbActiveModal, NgbModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { merge, scan } from 'rxjs';
 import { INVALID_FILENAME_CHARS } from '../../app.const';
@@ -32,12 +32,11 @@ import { AutofocusDirective } from '../../directives/autofocus';
 import { AddTorrentFormGroup, RootFolderMode } from '../../models/add-torrent.model';
 import { HttpError } from '../../models/http.model';
 import { AddTorrentSettingsService } from '../../services/add-torrent-settings.service';
+import { CommandBusService } from '../../services/command-bus.service';
 import { GeneralSettingsService } from '../../services/general-settings.service';
 import { OpenFilesService, PendingAddTorrent } from '../../services/open-files.service';
 import { QbService } from '../../services/qb.service';
 import { ServerStoreService } from '../../services/server-store.service';
-import { TorrentStoreService } from '../../services/torrent-store.service';
-import { setModalInput } from '../../utils/modal-input';
 import { AddTorrentFiles } from './files/files';
 import { AddTorrentGeneral } from './general/general';
 import { AddTorrentLimits } from './limits/limits';
@@ -74,14 +73,13 @@ export class AddTorrent implements OnInit {
     this.handleCancel();
   }
   public readonly activeModal = inject(NgbActiveModal);
-  private readonly modalService = inject(NgbModal);
 
-  private readonly torrentStoreService = inject(TorrentStoreService);
   private readonly serverStoreService = inject(ServerStoreService);
   private readonly addTorrentSettings = inject(AddTorrentSettingsService);
   private readonly generalSettingsService = inject(GeneralSettingsService);
   private readonly qbService = inject(QbService);
   private readonly openFilesService = inject(OpenFilesService);
+  private readonly commandBusService = inject(CommandBusService);
   private readonly translateService = inject(TranslateService);
 
   private readonly generalTab = viewChild(AddTorrentGeneral);
@@ -375,10 +373,11 @@ export class AddTorrent implements OnInit {
       if (parsed.name === 'QbHttpError' && parsed.status === 409) {
         const draft = this.effectiveDraft();
         const hash = draft?.torrent?.infoHashV1?.toLowerCase() ?? null;
-        const { TorrentExists } = await import('../torrent-exists/torrent-exists');
-        const modalRef = this.modalService.open(TorrentExists, { centered: true });
-        setModalInput(modalRef, 'hash', hash);
-        setModalInput(modalRef, 'originalPath', draft?.originalPath ?? null);
+        this.commandBusService.emit({
+          type: 'UI_TORRENT_EXISTS',
+          hash,
+          originalPath: draft?.originalPath ?? null,
+        });
         this.openFilesService.consumeCurrentDraft();
       } else {
         console.error(AddTorrent.name, 'handleSubmit', '[AddTorrent] qb add failed', e);
@@ -454,14 +453,7 @@ export class AddTorrent implements OnInit {
     }
   }
 
-  private isAlreadyInList(draft: TorrentDraft): boolean {
-    const hash = draft?.torrent?.infoHashV1?.toLowerCase();
-    if (!hash) return false;
-
-    return this.torrentStoreService.torrentsArray().some((t) => t.hash?.toLowerCase() === hash);
-  }
-
-  private async loadDraft(pending: PendingAddTorrent, _source: 'input' | 'manual'): Promise<void> {
+  private loadDraft(pending: PendingAddTorrent, _source: 'input' | 'manual'): void {
     const draft = pending.draft;
     const identifier = draft.torrent?.infoHashV1 ?? draft.originalPath;
 
@@ -492,15 +484,6 @@ export class AddTorrent implements OnInit {
       this.addForm.controls.fileGroup.controls.file.setValue(draft.originalName, {
         emitEvent: false,
       });
-    }
-
-    if (this.isAlreadyInList(draft)) {
-      const { TorrentExists } = await import('../torrent-exists/torrent-exists');
-      const modalRef = this.modalService.open(TorrentExists, { centered: true });
-      setModalInput(modalRef, 'hash', draft.torrent?.infoHashV1?.toLowerCase() ?? null);
-      setModalInput(modalRef, 'originalPath', draft.originalPath ?? null);
-      this.openFilesService.consumeCurrentDraft();
-      return;
     }
 
     const suggested =

--- a/packages/app/src/app/models/command.model.ts
+++ b/packages/app/src/app/models/command.model.ts
@@ -37,7 +37,8 @@ export type UiCommand =
   | { type: 'UI_SERVER_SWITCH'; id: string }
   | { type: 'UI_EXPORT_TORRENTS' }
   | { type: 'UI_IMPORT_TORRENTS'; bbePath?: string }
-  | { type: 'UI_SCROLL_TO_TORRENT'; hash: string };
+  | { type: 'UI_SCROLL_TO_TORRENT'; hash: string }
+  | { type: 'UI_TORRENT_EXISTS'; hash: string | null; originalPath: string | null };
 
 export type TorrentCommand =
   | { type: 'TORRENT_DELETE_CONFIRM'; removeFiles: boolean; hashes?: string[] }

--- a/packages/app/src/app/services/ui-command-handler.service.spec.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.spec.ts
@@ -51,6 +51,7 @@ describe('UiCommandHandlerService', () => {
       import('../modals/manage-servers/manage-servers'),
       import('../modals/export-torrents/export-torrents'),
       import('../modals/import-torrents/import-torrents'),
+      import('../modals/torrent-exists/torrent-exists'),
     ]);
   });
 
@@ -219,6 +220,25 @@ describe('UiCommandHandlerService', () => {
   it('should open TorrentDetails when hash is provided for UI_OPEN_TORRENT_DETAILS', async () => {
     commands$.next({ type: 'UI_OPEN_TORRENT_DETAILS', hash: 'abc123' });
     await flushPromises();
+    expect(mockModalService.open).toHaveBeenCalled();
+  });
+
+  it('should open TorrentExists modal for UI_TORRENT_EXISTS', async () => {
+    commands$.next({ type: 'UI_TORRENT_EXISTS', hash: 'abc123', originalPath: '/tmp/a.torrent' });
+    await flushPromises();
+    expect(mockModalService.open).toHaveBeenCalled();
+    expect(setInputSpy).toHaveBeenCalledWith('hash', 'abc123');
+    expect(setInputSpy).toHaveBeenCalledWith('originalPath', '/tmp/a.torrent');
+  });
+
+  it('should open a new TorrentExists modal even if one is already open (no isModalOpen guard)', async () => {
+    commands$.next({ type: 'UI_TORRENT_EXISTS', hash: 'abc123', originalPath: null });
+    await flushPromises();
+    mockModalService.open.mockClear();
+
+    commands$.next({ type: 'UI_TORRENT_EXISTS', hash: 'def456', originalPath: null });
+    await flushPromises();
+
     expect(mockModalService.open).toHaveBeenCalled();
   });
 

--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -434,6 +434,17 @@ export class UiCommandHandlerService {
           case 'UI_SCROLL_TO_TORRENT':
             break;
 
+          case 'UI_TORRENT_EXISTS': {
+            const { TorrentExists } = await import('../modals/torrent-exists/torrent-exists');
+            const torrentExistsModalRef = this.modalService.open(TorrentExists, {
+              centered: true,
+            });
+            setModalInput(torrentExistsModalRef, 'hash', command.hash);
+            setModalInput(torrentExistsModalRef, 'originalPath', command.originalPath);
+            torrentExistsModalRef.result.catch(() => {});
+            break;
+          }
+
           default:
             console.warn(UiCommandHandlerService.name, 'start', 'Unhandled UI command', command);
         }


### PR DESCRIPTION
## Issue ID

Fixes #200

## Description

The Add Torrent modal used to open and then immediately close whenever the opened `.torrent` file was already in the list, flashing on screen before the Torrent Exists modal took over. This got worse when modal components were switched to lazy-loading, since the duplicate check now sat behind an `await import(...)`, giving the browser time to paint the Add Torrent modal before it closed. The behavior was also inconsistent: with a single queued file the modal closed once the duplicate was detected, but with multiple files queued it stayed open behind the Torrent Exists modal whenever more items remained.

This moves duplicate detection out of the Add Torrent modal and into the queue-drain effect in `app.ts`, which now peeks the front of the pending-drafts queue before ever opening Add Torrent. If the front item is already in the list, a new `UI_TORRENT_EXISTS` command (handled the same way as every other modal, via the command bus) opens the Torrent Exists modal and consumes the item - looping until a genuinely new torrent is found or the queue is empty. Add Torrent is now never opened for a duplicate, so there is no more flicker, and the behavior is identical whether one file or several are queued.

The 409-conflict fallback in Add Torrent's submit handler (a genuine race with the server) now emits the same `UI_TORRENT_EXISTS` command instead of duplicating the modal-opening code inline.