### PR TITLE
Show torrent size and free disk space on the General tab

### DIFF
--- a/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
+++ b/packages/app/src/app/components/bb-file-tree/bb-file-tree.ts
@@ -48,6 +48,8 @@ export type FileTreeSaveEvent = {
   renames: { oldPath: string; newPath: string }[];
 };
 
+export type FileTreeStats = { totalSize: number; selectedSize: number };
+
 @Component({
   selector: 'app-bb-file-tree',
   standalone: true,
@@ -78,6 +80,7 @@ export class BbFileTree {
 
   readonly saved = output<FileTreeSaveEvent>();
   readonly editModeChange = output<boolean>();
+  readonly statsChange = output<FileTreeStats>();
 
   public editMode = signal(false);
   public nameControls = new Map<string, FormControl<string>>();
@@ -349,6 +352,7 @@ export class BbFileTree {
     this.downloadCount.set(files.filter((f) => f.priority !== 0).length);
     this.allFolders.set(this.countFolders(this.data));
     this.totalFolders.set(this.countActiveFolders(this.data));
+    this.statsChange.emit({ totalSize: this.totalSize(), selectedSize: this.selectedSize() });
   }
 
   private countFolders(nodes: BbFileTreeNode[]): number {

--- a/packages/app/src/app/modals/add-torrent/add-torrent.html
+++ b/packages/app/src/app/modals/add-torrent/add-torrent.html
@@ -55,6 +55,8 @@
         <app-add-torrent-general
           [form]="addForm"
           [inputMode]="inputMode()"
+          [fileStats]="fileStats()"
+          [freeSpace]="freeSpace()"
           (inputModeChange)="handleInputModeChange($event)"
           (fileSelected)="handleFileSelected($event)"
         ></app-add-torrent-general>
@@ -74,6 +76,7 @@
             [draft]="effectiveDraft()"
             (saved)="onTreeSaved($event)"
             (editModeChange)="treeInEditMode.set($event)"
+            (statsChange)="fileStats.set($event)"
           ></app-add-torrent-files>
         }
       </div>

--- a/packages/app/src/app/modals/add-torrent/add-torrent.spec.ts
+++ b/packages/app/src/app/modals/add-torrent/add-torrent.spec.ts
@@ -67,6 +67,9 @@ describe('AddTorrent', () => {
             app: {
               preferences: vi.fn().mockResolvedValue({ save_path: '/downloads' }),
             },
+            sync: {
+              maindata: vi.fn().mockResolvedValue({ server_state: {} }),
+            },
             torrents: {
               files: vi.fn().mockResolvedValue([]),
               renameFile: vi.fn(),

--- a/packages/app/src/app/modals/add-torrent/add-torrent.ts
+++ b/packages/app/src/app/modals/add-torrent/add-torrent.ts
@@ -25,7 +25,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { merge, scan } from 'rxjs';
 import { INVALID_FILENAME_CHARS } from '../../app.const';
 import { BbBtnContent } from '../../components/bb-btn-content/bb-btn-content';
-import { FileTreeSaveEvent } from '../../components/bb-file-tree/bb-file-tree';
+import { FileTreeSaveEvent, FileTreeStats } from '../../components/bb-file-tree/bb-file-tree';
 import { ShareLimitValue } from '../../components/share-limit/share-limit';
 import { TransferLimitValue } from '../../components/transfer-limit/transfer-limit';
 import { AutofocusDirective } from '../../directives/autofocus';
@@ -92,6 +92,8 @@ export class AddTorrent implements OnInit {
   public inputMode = signal<'file' | 'link'>('file');
   public showTree = signal(false);
   public treeInEditMode = signal(false);
+  public fileStats = signal<FileTreeStats | null>(null);
+  public freeSpace = signal<number>(0);
   private savedFileState: FileTreeSaveEvent | null = null;
 
   private selectedTorrentFile = signal<SelectedTorrentInput | null>(null);
@@ -224,6 +226,12 @@ export class AddTorrent implements OnInit {
           : this.addForm.controls.linkGroup.controls.rename;
       if (activeRename.invalid) {
         activeRename.markAsTouched();
+      }
+    });
+
+    effect(() => {
+      if (this.filesTabDisabled()) {
+        this.fileStats.set(null);
       }
     });
   }
@@ -495,6 +503,18 @@ export class AddTorrent implements OnInit {
     }
 
     this.showTree.set(!!draft.torrent?.files?.length);
+
+    const serverId = this.serverStoreService.currentServerId();
+    if (serverId) {
+      this.qbService.sync
+        .maindata(serverId, 0)
+        .then((data) => {
+          if (data.server_state?.free_space_on_disk != null) {
+            this.freeSpace.set(data.server_state.free_space_on_disk);
+          }
+        })
+        .catch(() => {});
+    }
   }
 
   private async tryRenameContentAfterAdd(

--- a/packages/app/src/app/modals/add-torrent/files/files.html
+++ b/packages/app/src/app/modals/add-torrent/files/files.html
@@ -7,5 +7,6 @@
     [hideProgress]="true"
     (saved)="saved.emit($event)"
     (editModeChange)="editModeChange.emit($event)"
+    (statsChange)="statsChange.emit($event)"
   ></app-bb-file-tree>
 }

--- a/packages/app/src/app/modals/add-torrent/files/files.ts
+++ b/packages/app/src/app/modals/add-torrent/files/files.ts
@@ -1,6 +1,10 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { TorrentDraft } from '@bitbutler/shared';
-import { BbFileTree, FileTreeSaveEvent } from '../../../components/bb-file-tree/bb-file-tree';
+import {
+  BbFileTree,
+  FileTreeSaveEvent,
+  FileTreeStats,
+} from '../../../components/bb-file-tree/bb-file-tree';
 
 @Component({
   selector: 'app-add-torrent-files',
@@ -13,4 +17,5 @@ export class AddTorrentFiles {
   public draft = input<TorrentDraft | null>(null);
   public saved = output<FileTreeSaveEvent>();
   public editModeChange = output<boolean>();
+  public statsChange = output<FileTreeStats>();
 }

--- a/packages/app/src/app/modals/add-torrent/general/general.html
+++ b/packages/app/src/app/modals/add-torrent/general/general.html
@@ -201,6 +201,58 @@
           ></bb-popover>
         </div>
 
+        @if (inputMode() === 'file' && fileStats() !== null) {
+          <div class="col-5">
+            <div class="form-floating mb-3">
+              <input
+                type="text"
+                class="form-control"
+                id="torrent_size"
+                [placeholder]="'components.add-torrent.add-form.size' | translate"
+                [value]="fileStats()!.selectedSize | fileSize"
+                readonly
+              />
+              <label for="torrent_size">{{
+                'components.add-torrent.add-form.size' | translate
+              }}</label>
+            </div>
+          </div>
+
+          <div class="col-1 d-flex align-items-center mb-3">
+            <bb-popover
+              class="mt-2"
+              [subject]="'components.add-torrent.popover.size.title' | translate"
+              [description]="sizePopover"
+              placement="left"
+            ></bb-popover>
+          </div>
+
+          <div class="col-5">
+            <div class="form-floating mb-3">
+              <input
+                type="text"
+                class="form-control"
+                id="free_space"
+                [placeholder]="'components.add-torrent.add-form.free-space' | translate"
+                [value]="freeSpace() | fileSize"
+                readonly
+              />
+              <label for="free_space">{{
+                'components.add-torrent.add-form.free-space' | translate
+              }}</label>
+            </div>
+          </div>
+
+          <div class="col-1 d-flex align-items-center mb-3">
+            <bb-popover
+              class="mt-2"
+              [subject]="'components.add-torrent.popover.free-space.title' | translate"
+              [description]="freeSpacePopover"
+              placement="left"
+            ></bb-popover>
+          </div>
+        }
+
         <div class="col-11">
           <div class="mb-3">
             <app-save-path-select
@@ -261,4 +313,14 @@
 <ng-template #savePathPopover>
   <p>{{ 'components.save-path-select.popover.description.line1' | translate }}</p>
   <p>{{ 'components.save-path-select.popover.description.line2' | translate }}</p>
+</ng-template>
+
+<ng-template #sizePopover>
+  <p>{{ 'components.add-torrent.popover.size.description.line1' | translate }}</p>
+  <p>{{ 'components.add-torrent.popover.size.description.line2' | translate }}</p>
+</ng-template>
+
+<ng-template #freeSpacePopover>
+  <p>{{ 'components.add-torrent.popover.free-space.description.line1' | translate }}</p>
+  <p>{{ 'components.add-torrent.popover.free-space.description.line2' | translate }}</p>
 </ng-template>

--- a/packages/app/src/app/modals/add-torrent/general/general.ts
+++ b/packages/app/src/app/modals/add-torrent/general/general.ts
@@ -11,12 +11,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { faFile, faFolderOpen, faLink } from '@fortawesome/free-solid-svg-icons';
 import { TranslatePipe } from '@ngx-translate/core';
 import { BbBtnContent } from '../../../components/bb-btn-content/bb-btn-content';
+import { FileTreeStats } from '../../../components/bb-file-tree/bb-file-tree';
 import { BbPopover } from '../../../components/bb-popover/bb-popover';
 import { CategorySelect } from '../../../components/category-select/category-select';
 import { SavePathSelect } from '../../../components/save-path-select/save-path-select';
 import { TagSelect } from '../../../components/tag-select/tag-select';
 import { AutofocusDirective } from '../../../directives/autofocus';
 import { AddTorrentFormGroup } from '../../../models/add-torrent.model';
+import { FilesizePipe } from '../../../pipes/filesize-pipe';
 import { QbService } from '../../../services/qb.service';
 import { ServerStoreService } from '../../../services/server-store.service';
 
@@ -31,6 +33,7 @@ import { ServerStoreService } from '../../../services/server-store.service';
     SavePathSelect,
     TagSelect,
     BbBtnContent,
+    FilesizePipe,
   ],
   templateUrl: './general.html',
   styleUrl: './general.scss',
@@ -41,6 +44,8 @@ export class AddTorrentGeneral {
 
   public form = input.required<AddTorrentFormGroup>();
   public inputMode = input.required<'file' | 'link'>();
+  public fileStats = input<FileTreeStats | null>(null);
+  public freeSpace = input<number>(0);
   public inputModeChange = output<'file' | 'link'>();
   public fileSelected = output<Event>();
 

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -58,7 +58,9 @@
         "first-last-piece-prio": "Első és utolsó szelet priorizálása",
         "ratio-limit": "Arány korlát",
         "seeding-time-limit": "Seedelési időkorlát",
-        "seeding-time-limit-unit": "perc"
+        "seeding-time-limit-unit": "perc",
+        "size": "Méret",
+        "free-space": "Szabad hely"
       },
       "label": {
         "transfer-rate-limits": "Átviteli sebesség korlátok",
@@ -130,6 +132,20 @@
           "description": {
             "line1": "Illessz be egy vagy több mágneslinket vagy közvetlen .torrent URL-t ide, soronként egyet.",
             "line2": "A mágneslinkkek magnet:?xt=urn:btih:… kezdetűek - a közvetlen .torrent URL-ekről a qBittorrent automatikusan letölti a fájlt."
+          }
+        },
+        "size": {
+          "title": "Méret",
+          "description": {
+            "line1": "A letöltésre kijelölt fájlok teljes mérete.",
+            "line2": "A letöltési méret csökkentéséhez töröld a kijelölést egyes fájloknál a Fájlok lapon - ez az érték élőben frissül a változtatások során."
+          }
+        },
+        "free-space": {
+          "title": "Szabad hely",
+          "description": {
+            "line1": "A qBittorrent által a torrent betöltésekor jelentett szabad lemezterület.",
+            "line2": "Hasonlítsd össze a torrent méretével, hogy ellenőrizd, elegendő-e a szabad hely a hozzáadás előtt."
           }
         },
         "input-mode": {

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -58,7 +58,9 @@
         "first-last-piece-prio": "Prioritize download first last piece",
         "ratio-limit": "Ratio Limit",
         "seeding-time-limit": "Seeding Time Limit",
-        "seeding-time-limit-unit": "minute"
+        "seeding-time-limit-unit": "minute",
+        "size": "Size",
+        "free-space": "Free Space"
       },
       "label": {
         "transfer-rate-limits": "Transfer Rate Limits",
@@ -130,6 +132,20 @@
           "description": {
             "line1": "Paste one or more magnet links or direct .torrent URLs here, one per line.",
             "line2": "Magnet links start with magnet:?xt=urn:btih:… - direct .torrent URLs point to a remote file that qBittorrent will fetch automatically."
+          }
+        },
+        "size": {
+          "title": "Size",
+          "description": {
+            "line1": "The total size of the files selected for download.",
+            "line2": "Deselect individual files in the Files tab to reduce the download size - this value updates live as you make changes."
+          }
+        },
+        "free-space": {
+          "title": "Free Space",
+          "description": {
+            "line1": "The free disk space reported by qBittorrent at the time this torrent was loaded.",
+            "line2": "Compare this against the torrent size to make sure you have enough room before adding."
           }
         },
         "input-mode": {


### PR DESCRIPTION
## Issue ID

Fixes #207

## Description

Adds a size / free-space indicator row to the **General** tab of the Add Torrent modal. The row is visible only when file input mode is active and a torrent with files has been parsed.

The row contains two read-only fields:

- **Size** - the total size of files currently selected for download; updates live as the user toggles files on the Files tab
- **Free Space** - free disk space reported by qBittorrent, refreshed on each new draft load

Each field has a popover explaining what it shows (both EN and HU translations included).

**Data flow:** `BbFileTree.calculateStats()` emits a `statsChange` output → passed through `AddTorrentFiles` → stored in a signal on `AddTorrent` → fed into `AddTorrentGeneral` as an input. The signal is reset to `null` (hiding the row) whenever the files tab is disabled. Free space is fetched via `qbService.sync.maindata()` inside `loadDraft()` so it stays current across a torrent queue.