### PR TITLE
Collapse the custom date-format token guide behind a toggle

### DIFF
--- a/packages/app/src/app/modals/settings/general/general.html
+++ b/packages/app/src/app/modals/settings/general/general.html
@@ -310,61 +310,79 @@
               </div>
             </div>
             <div class="row mb-3">
-              <div class="col-12 text-muted">
+              <div class="col-6 d-flex align-items-center text-muted">
                 {{
                   'pages.settings.tab.general.general-settings-form.date-format.preview'
                     | translate
                 }}: {{ customPatternPreview() }}
               </div>
-            </div>
-            <div class="row mb-2">
-              <div class="col-12 text-muted small">
-                {{
-                  'pages.settings.tab.general.general-settings-form.date-format.token-guide.hint'
-                    | translate
-                }}
+              <div class="col-6 d-flex justify-content-end">
+                <button
+                  type="button"
+                  class="btn btn-sm btn-link btn-split"
+                  (click)="toggleTokenGuide()"
+                >
+                  <bb-btn-content
+                    [icon]="tokenGuideExpanded() ? icons['faChevronUp'] : icons['faChevronDown']"
+                    [text]="
+                      'pages.settings.tab.general.general-settings-form.date-format.token-guide.toggle'
+                        | translate
+                    "
+                  ></bb-btn-content>
+                </button>
               </div>
             </div>
-            <div class="row mb-3">
-              <div class="col-12">
-                <table
-                  id="date-format-token-guide"
-                  class="table table-sm table-striped table-hover mb-0"
-                >
-                  <thead>
-                    <tr>
-                      <th>
-                        {{
-                          'pages.settings.tab.general.general-settings-form.date-format.token-guide.column-token'
-                            | translate
-                        }}
-                      </th>
-                      <th>
-                        {{
-                          'pages.settings.tab.general.general-settings-form.date-format.token-guide.column-description'
-                            | translate
-                        }}
-                      </th>
-                      <th>
-                        {{
-                          'pages.settings.tab.general.general-settings-form.date-format.token-guide.column-example'
-                            | translate
-                        }}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    @for (row of dateFormatTokenGuide(); track row.token) {
+
+            <div [ngbCollapse]="!tokenGuideExpanded()">
+              <div class="row mb-2">
+                <div class="col-12 text-muted small">
+                  {{
+                    'pages.settings.tab.general.general-settings-form.date-format.token-guide.hint'
+                      | translate
+                  }}
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col-12">
+                  <table
+                    id="date-format-token-guide"
+                    class="table table-sm table-striped table-hover mb-0"
+                  >
+                    <thead>
                       <tr>
-                        <td>
-                          <code>{{ row.token }}</code>
-                        </td>
-                        <td>{{ row.description }}</td>
-                        <td>{{ row.example }}</td>
+                        <th>
+                          {{
+                            'pages.settings.tab.general.general-settings-form.date-format.token-guide.column-token'
+                              | translate
+                          }}
+                        </th>
+                        <th>
+                          {{
+                            'pages.settings.tab.general.general-settings-form.date-format.token-guide.column-description'
+                              | translate
+                          }}
+                        </th>
+                        <th>
+                          {{
+                            'pages.settings.tab.general.general-settings-form.date-format.token-guide.column-example'
+                              | translate
+                          }}
+                        </th>
                       </tr>
-                    }
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      @for (row of dateFormatTokenGuide(); track row.token) {
+                        <tr>
+                          <td>
+                            <code>{{ row.token }}</code>
+                          </td>
+                          <td>{{ row.description }}</td>
+                          <td>{{ row.example }}</td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
               </div>
             </div>
           }

--- a/packages/app/src/app/modals/settings/general/general.ts
+++ b/packages/app/src/app/modals/settings/general/general.ts
@@ -13,10 +13,13 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import {
   IconDefinition,
   faArrowsRotate,
+  faChevronDown,
+  faChevronUp,
   faCircleQuestion,
   faRotateLeft,
   faTriangleExclamation,
 } from '@fortawesome/free-solid-svg-icons';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
 import {
   NgLabelTemplateDirective,
   NgOptionTemplateDirective,
@@ -107,6 +110,7 @@ const DATE_FORMAT_TOKENS = [
     TranslatePipe,
     SavePathSelect,
     BbBtnContent,
+    NgbCollapse,
   ],
   templateUrl: './general.html',
   styleUrl: './general.scss',
@@ -282,7 +286,15 @@ export class General implements SettingsTabComponent {
     faCircleQuestion,
     faArrowsRotate,
     faRotateLeft,
+    faChevronDown,
+    faChevronUp,
   };
+
+  public tokenGuideExpanded = signal(false);
+
+  public toggleTokenGuide(): void {
+    this.tokenGuideExpanded.update((v) => !v);
+  }
 
   public getFamilyLogo = getFamilyLogoUrl;
 

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -1363,6 +1363,7 @@
                 "custom": "Egyéni"
               },
               "token-guide": {
+                "toggle": "Jelölőútmutató",
                 "hint": "A szó szerinti szöveget aposztrófok közé zárva (pl. 'at') változatlanul jelenítheted meg.",
                 "column-token": "Jelölő",
                 "column-description": "Leírás",

--- a/public/i18n/us.json
+++ b/public/i18n/us.json
@@ -1363,6 +1363,7 @@
                 "custom": "Custom"
               },
               "token-guide": {
+                "toggle": "Token guide",
                 "hint": "Wrap literal text in single quotes, e.g. 'at', to include it as-is.",
                 "column-token": "Token",
                 "column-description": "Description",


### PR DESCRIPTION
## Issue ID

Fixes #213

## Description

The token guide table and its hint label were always visible when the Custom date-format preset was selected, adding permanent vertical space to the Date & Time settings section.

This hides the hint and table behind an `ngb-collapse`, toggled by a "Token guide" button (styled like the existing "Check for updates" button) placed next to the format preview. Collapsed by default, no state persistence.