### PR TITLE
Add keyboard shortcuts and debug menu improvements

### DIFF
--- a/packages/electron/src/menu.spec.ts
+++ b/packages/electron/src/menu.spec.ts
@@ -1,0 +1,268 @@
+import type { BrowserWindow, MenuItemConstructorOptions } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockBuildFromTemplate = vi.hoisted(() =>
+  vi.fn((template: MenuItemConstructorOptions[]) => template),
+);
+const mockSetApplicationMenu = vi.hoisted(() => vi.fn());
+const mockAppGetPath = vi.hoisted(() => vi.fn(() => '/fake/logs'));
+const mockShellOpenPath = vi.hoisted(() => vi.fn());
+const mockGetCookieJar = vi.hoisted(() => vi.fn(() => new Map<string, string>()));
+const mockGetActiveServerId = vi.hoisted(() => vi.fn<() => string | null>(() => null));
+const mockServerList = vi.hoisted(() =>
+  vi.fn(() => [] as { id: string; name: string; host: string }[]),
+);
+const mockGetMainWindow = vi.hoisted(() => vi.fn());
+const mockNotify = vi.hoisted(() => vi.fn());
+
+const appMock = vi.hoisted(() => ({ isPackaged: false, getPath: mockAppGetPath }));
+
+vi.mock('electron', () => ({
+  Menu: {
+    buildFromTemplate: mockBuildFromTemplate,
+    setApplicationMenu: mockSetApplicationMenu,
+  },
+  app: appMock,
+  shell: { openPath: mockShellOpenPath },
+}));
+
+vi.mock('./i18n.js', () => ({ t: (key: string) => key }));
+
+vi.mock('./ipc/qbittorrent.js', () => ({ getCookieJar: mockGetCookieJar }));
+
+vi.mock('./ipc/server.js', () => ({
+  getActiveServerId: mockGetActiveServerId,
+  serverList: mockServerList,
+}));
+
+vi.mock('./main.js', () => ({ getMainWindow: mockGetMainWindow }));
+
+vi.mock('./notification.js', () => ({ notify: mockNotify }));
+
+interface FakeWindow {
+  isDestroyed: () => boolean;
+  webContents: { send: ReturnType<typeof vi.fn>; openDevTools: ReturnType<typeof vi.fn> };
+}
+
+function createFakeWindow(): FakeWindow {
+  return {
+    isDestroyed: vi.fn(() => false),
+    webContents: { send: vi.fn(), openDevTools: vi.fn() },
+  };
+}
+
+function findItem(
+  items: MenuItemConstructorOptions[],
+  predicate: (item: MenuItemConstructorOptions) => boolean,
+): MenuItemConstructorOptions | undefined {
+  for (const item of items) {
+    if (predicate(item)) return item;
+    if (Array.isArray(item.submenu)) {
+      const found = findItem(item.submenu as MenuItemConstructorOptions[], predicate);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function byLabel(label: string) {
+  return (item: MenuItemConstructorOptions) => item.label === label;
+}
+
+describe('rebuildMenu', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    appMock.isPackaged = false;
+    mockGetCookieJar.mockReturnValue(new Map());
+    mockGetActiveServerId.mockReturnValue(null);
+    mockServerList.mockReturnValue([]);
+    mockGetMainWindow.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function buildMenu(mainWindow?: FakeWindow | null): Promise<MenuItemConstructorOptions[]> {
+    const { rebuildMenu } = await import('./menu.js');
+    rebuildMenu(mainWindow as unknown as BrowserWindow | null | undefined);
+    return mockBuildFromTemplate.mock.calls.at(-1)![0] as MenuItemConstructorOptions[];
+  }
+
+  it('builds and installs the application menu', async () => {
+    const template = await buildMenu();
+    expect(mockBuildFromTemplate).toHaveBeenCalledWith(template);
+    expect(mockSetApplicationMenu).toHaveBeenCalledWith(template);
+  });
+
+  describe('File menu', () => {
+    it('assigns the expected accelerators', async () => {
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.add-torrent'))?.accelerator).toBe(
+        'CmdOrCtrl+N',
+      );
+      expect(findItem(template, byLabel('electron.menu.export-torrents'))?.accelerator).toBe(
+        'CmdOrCtrl+E',
+      );
+      expect(findItem(template, byLabel('electron.menu.import-torrents'))?.accelerator).toBe(
+        'CmdOrCtrl+I',
+      );
+      expect(findItem(template, byLabel('electron.menu.disconnect'))?.accelerator).toBe(
+        'CmdOrCtrl+L',
+      );
+      expect(findItem(template, (i) => i.role === 'quit')?.accelerator).toBe('CmdOrCtrl+Q');
+    });
+
+    it('disables actions requiring a connection when logged out', async () => {
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.add-torrent'))?.enabled).toBe(false);
+      expect(findItem(template, byLabel('electron.menu.export-torrents'))?.enabled).toBe(false);
+      expect(findItem(template, byLabel('electron.menu.import-torrents'))?.enabled).toBe(false);
+      expect(findItem(template, byLabel('electron.menu.disconnect'))?.enabled).toBe(false);
+    });
+
+    it('enables actions requiring a connection when logged in', async () => {
+      mockGetCookieJar.mockReturnValue(new Map([['srv-1', 'SID=abc']]));
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.add-torrent'))?.enabled).toBe(true);
+    });
+
+    it('sends a menu:clicked action when clicked', async () => {
+      const mainWindow = createFakeWindow();
+      const template = await buildMenu(mainWindow);
+      const item = findItem(template, byLabel('electron.menu.add-torrent'))!;
+      (item.click as () => void)();
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith(
+        'menu:clicked',
+        expect.objectContaining({ action: 'file.addTorrent' }),
+      );
+    });
+
+    it('does not throw and does not send when the window is missing', async () => {
+      const template = await buildMenu(null);
+      const item = findItem(template, byLabel('electron.menu.add-torrent'))!;
+      expect(() => (item.click as () => void)()).not.toThrow();
+    });
+
+    it('does not send when the window has been destroyed', async () => {
+      const mainWindow = createFakeWindow();
+      mainWindow.isDestroyed.mockReturnValue(true);
+      const template = await buildMenu(mainWindow);
+      const item = findItem(template, byLabel('electron.menu.add-torrent'))!;
+      (item.click as () => void)();
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Settings menu', () => {
+    it('is hidden when logged out', async () => {
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.settings-menu'))).toBeUndefined();
+    });
+
+    it('is shown with the expected accelerators when logged in', async () => {
+      mockGetCookieJar.mockReturnValue(new Map([['srv-1', 'SID=abc']]));
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.app-settings'))?.accelerator).toBe(
+        'CmdOrCtrl+.',
+      );
+      expect(findItem(template, byLabel('electron.menu.qb-settings'))?.accelerator).toBe(
+        'CmdOrCtrl+,',
+      );
+      expect(findItem(template, byLabel('electron.menu.manage-servers'))?.accelerator).toBe(
+        'CmdOrCtrl+Shift+S',
+      );
+      expect(findItem(template, byLabel('electron.menu.manage-tags'))?.accelerator).toBe(
+        'CmdOrCtrl+Shift+T',
+      );
+      expect(findItem(template, byLabel('electron.menu.manage-categories'))?.accelerator).toBe(
+        'CmdOrCtrl+Shift+C',
+      );
+    });
+
+    it('omits the servers submenu when there are no servers', async () => {
+      mockGetCookieJar.mockReturnValue(new Map([['srv-1', 'SID=abc']]));
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.servers'))).toBeUndefined();
+    });
+
+    it('lists servers as radio items and marks the active one as checked', async () => {
+      mockGetCookieJar.mockReturnValue(new Map([['srv-1', 'SID=abc']]));
+      mockServerList.mockReturnValue([
+        { id: 'srv-1', name: 'Server One', host: 'host1' },
+        { id: 'srv-2', name: '', host: 'host2' },
+      ]);
+      mockGetActiveServerId.mockReturnValue('srv-2');
+      const template = await buildMenu();
+      const serversMenu = findItem(template, byLabel('electron.menu.servers'));
+      const items = serversMenu!.submenu as MenuItemConstructorOptions[];
+      expect(items[0]).toMatchObject({ label: 'Server One', type: 'radio', checked: false });
+      expect(items[1]).toMatchObject({ label: 'host2', type: 'radio', checked: true });
+    });
+
+    it('sends server.select with the server id when a server item is clicked', async () => {
+      mockGetCookieJar.mockReturnValue(new Map([['srv-1', 'SID=abc']]));
+      mockServerList.mockReturnValue([{ id: 'srv-1', name: 'Server One', host: 'host1' }]);
+      const mainWindow = createFakeWindow();
+      const template = await buildMenu(mainWindow);
+      const serversMenu = findItem(template, byLabel('electron.menu.servers'));
+      const items = serversMenu!.submenu as MenuItemConstructorOptions[];
+      (items[0].click as () => void)();
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith(
+        'menu:clicked',
+        expect.objectContaining({ action: 'server.select', serverId: 'srv-1' }),
+      );
+    });
+  });
+
+  describe('Help menu', () => {
+    it('assigns the expected accelerators', async () => {
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('electron.menu.check-for-updates'))?.accelerator).toBe(
+        'CmdOrCtrl+U',
+      );
+      expect(findItem(template, byLabel('electron.menu.about'))?.accelerator).toBe('F1');
+    });
+  });
+
+  describe('Debug menu', () => {
+    it('is omitted from packaged builds', async () => {
+      appMock.isPackaged = true;
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('Debug'))).toBeUndefined();
+    });
+
+    it('is present in dev builds', async () => {
+      const template = await buildMenu();
+      expect(findItem(template, byLabel('Debug'))).toBeDefined();
+    });
+
+    it('opens devtools on the main window when Open DevTools is clicked', async () => {
+      const mainWindow = createFakeWindow();
+      mockGetMainWindow.mockReturnValue(mainWindow);
+      const template = await buildMenu(mainWindow);
+      const item = findItem(template, byLabel('Open DevTools'))!;
+      expect(item.accelerator).toBe('F12');
+      (item.click as () => void)();
+      expect(mainWindow.webContents.openDevTools).toHaveBeenCalledWith({ mode: 'detach' });
+    });
+
+    it('opens the log folder when Open Log Path is clicked', async () => {
+      const template = await buildMenu();
+      const item = findItem(template, byLabel('Open Log Path'))!;
+      expect(item.accelerator).toBe('CmdOrCtrl+Alt+L');
+      (item.click as () => void)();
+      expect(mockAppGetPath).toHaveBeenCalledWith('logs');
+      expect(mockShellOpenPath).toHaveBeenCalledWith('/fake/logs');
+    });
+
+    it('reloads the window using the built-in reload role instead of an unhandled IPC action', async () => {
+      const template = await buildMenu();
+      const item = findItem(template, byLabel('Reload'))!;
+      expect(item.role).toBe('reload');
+      expect(item.accelerator).toBe('CmdOrCtrl+R');
+      expect(item.click).toBeUndefined();
+    });
+  });
+});

--- a/packages/electron/src/menu.ts
+++ b/packages/electron/src/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, app } from 'electron';
+import { Menu, app, shell } from 'electron';
 import { t } from './i18n.js';
 import { getCookieJar } from './ipc/qbittorrent.js';
 import { getActiveServerId, serverList } from './ipc/server.js';
@@ -45,23 +45,28 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
           submenu: [
             {
               label: t('electron.menu.app-settings'),
+              accelerator: 'CmdOrCtrl+.',
               click: () => sendMenuAction(mainWindow, 'settings.app'),
             },
             {
               label: t('electron.menu.qb-settings'),
+              accelerator: 'CmdOrCtrl+,',
               click: () => sendMenuAction(mainWindow, 'settings.qb'),
             },
             { type: 'separator' },
             {
               label: t('electron.menu.manage-servers'),
+              accelerator: 'CmdOrCtrl+Shift+S',
               click: () => sendMenuAction(mainWindow, 'server.manage'),
             },
             {
               label: t('electron.menu.manage-tags'),
+              accelerator: 'CmdOrCtrl+Shift+T',
               click: () => sendMenuAction(mainWindow, 'settings.manage-tags'),
             },
             {
               label: t('electron.menu.manage-categories'),
+              accelerator: 'CmdOrCtrl+Shift+C',
               click: () => sendMenuAction(mainWindow, 'settings.manage-categories'),
             },
           ],
@@ -76,7 +81,13 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
           submenu: [
             {
               label: 'Open DevTools',
+              accelerator: 'F12',
               click: () => getMainWindow()?.webContents.openDevTools({ mode: 'detach' }),
+            },
+            {
+              label: 'Open Log Path',
+              accelerator: 'CmdOrCtrl+Alt+L',
+              click: () => shell.openPath(app.getPath('logs')),
             },
             { type: 'separator' },
             {
@@ -136,7 +147,8 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
             { type: 'separator' },
             {
               label: 'Reload',
-              click: () => sendMenuAction(mainWindow, 'debug.reload'),
+              accelerator: 'CmdOrCtrl+R',
+              role: 'reload',
             },
           ],
         },
@@ -150,27 +162,31 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
         {
           label: t('electron.menu.add-torrent'),
           enabled: loggedIn,
+          accelerator: 'CmdOrCtrl+N',
           click: () => sendMenuAction(mainWindow, 'file.addTorrent'),
         },
         { type: 'separator' },
         {
           label: t('electron.menu.export-torrents'),
           enabled: loggedIn,
+          accelerator: 'CmdOrCtrl+E',
           click: () => sendMenuAction(mainWindow, 'file.exportTorrents'),
         },
         {
           label: t('electron.menu.import-torrents'),
           enabled: loggedIn,
+          accelerator: 'CmdOrCtrl+I',
           click: () => sendMenuAction(mainWindow, 'file.importTorrents'),
         },
         { type: 'separator' },
         {
           label: t('electron.menu.disconnect'),
           enabled: loggedIn,
+          accelerator: 'CmdOrCtrl+L',
           click: () => sendMenuAction(mainWindow, 'file.disconnect'),
         },
         { type: 'separator' },
-        { role: 'quit' },
+        { role: 'quit', accelerator: 'CmdOrCtrl+Q' },
       ],
     },
     ...loggedInItems,
@@ -179,11 +195,13 @@ export function rebuildMenu(mainWindowArg?: Electron.BrowserWindow | null): void
       submenu: [
         {
           label: t('electron.menu.check-for-updates'),
+          accelerator: 'CmdOrCtrl+U',
           click: () => sendMenuAction(mainWindow, 'help.checkForUpdates'),
         },
         { type: 'separator' },
         {
           label: t('electron.menu.about'),
+          accelerator: 'F1',
           click: () => sendMenuAction(mainWindow, 'help.about'),
         },
       ],


### PR DESCRIPTION
## Issue ID

Fixes #218

## Description

- Fixed the Debug menu "Reload" item, which was sending an IPC action that no renderer handler ever processed. It now uses Electron's built-in `reload` role.
- Added an "Open Log Path" item to the Debug menu that opens the app's log folder in the OS file browser.
- Added keyboard shortcuts (accelerators) to the File, Settings, Help, and Debug menu items.