### PR TITLE
Fix fresh-install sqlite column count mismatch in servers migration

### DIFF
--- a/packages/electron/src/db.ts
+++ b/packages/electron/src/db.ts
@@ -56,7 +56,10 @@ if (pwCol?.notnull === 1) {
         created_at   TEXT NOT NULL
       )
     `);
-    db.exec(`INSERT INTO servers_new SELECT * FROM servers`);
+    db.exec(`
+      INSERT INTO servers_new (id, name, host, protocol, port, username, password, auto_login, created_at)
+      SELECT id, name, host, protocol, port, username, password, auto_login, created_at FROM servers
+    `);
     db.exec(`DROP TABLE servers`);
     db.exec(`ALTER TABLE servers_new RENAME TO servers`);
   })();


### PR DESCRIPTION
## Issue ID

Fixes #220

## Description

On a fresh install (no existing database), `servers` is created with 10 columns including `export_available`, but `password` is still declared `NOT NULL` in the base schema. That unconditionally triggers the older password-nullable migration, which builds `servers_new` with only 9 columns (missing `export_available`) and copies rows via `INSERT INTO servers_new SELECT * FROM servers`, pulling 10 values into a 9-column table:

```
SqliteError: table servers_new has 9 columns but 10 values were supplied
```

Root cause: `export_available` was added to the base `servers` schema (and to its own dedicated `ALTER TABLE` migration) without also updating the `servers_new` table used by the earlier password-nullable migration.

Fix: replace `SELECT *` with an explicit column list in the `INSERT INTO servers_new` statement, so the copy only touches the 9 columns both schemas are guaranteed to share, regardless of whether `export_available` exists on either side.

Verified with a standalone simulation (using Electron's bundled Node/better-sqlite3 runtime) covering:
- Fresh install (10-column source, no existing rows) - migrates cleanly.
- Legacy pre-migration database (9-column source with an existing row) - migrates cleanly, row data preserved, `export_available` added afterward as `NULL`.