### PR TITLE
Fix double divider in torrent context menu on multi-select

### DIFF
--- a/packages/app/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
+++ b/packages/app/src/app/pages/main/grid/context-menu/grid-context-menu.service.ts
@@ -111,8 +111,8 @@ export class GridContextMenuService {
                   hash: data.row.hash,
                 }),
             },
+            { kind: 'divider' as const },
           ]),
-      { kind: 'divider' },
 
       {
         kind: 'submenu',


### PR DESCRIPTION
## Issue ID

Fixes #222

## Description

The Torrent Details item in the torrent context menu is hidden when multiple torrents are selected, since it only applies to a single torrent. It sat between two independent, always-rendered divider entries, so hiding it left two adjacent dividers when multi-selecting.

Moved the trailing divider inside the same single-selection conditional block so it only renders alongside the item it separates.