### PR TITLE
Fix double scrollbar in manage tags/categories/servers modals

### DIFF
--- a/packages/app/src/app/modals/manage-categories/manage-categories.scss
+++ b/packages/app/src/app/modals/manage-categories/manage-categories.scss
@@ -1,8 +1,3 @@
-.list-group {
-  max-height: 400px;
-  overflow-y: auto;
-}
-
 .list-group-item {
   transition: background-color 0.15s ease-in-out;
 

--- a/packages/app/src/app/modals/manage-servers/manage-servers.scss
+++ b/packages/app/src/app/modals/manage-servers/manage-servers.scss
@@ -1,8 +1,3 @@
-.list-group {
-  max-height: 400px;
-  overflow-y: auto;
-}
-
 .list-group-item {
   transition: background-color 0.15s ease-in-out;
 

--- a/packages/app/src/app/modals/manage-tags/manage-tags.scss
+++ b/packages/app/src/app/modals/manage-tags/manage-tags.scss
@@ -1,8 +1,3 @@
-.list-group {
-  max-height: 400px;
-  overflow-y: auto;
-}
-
 .list-group-item {
   transition: background-color 0.15s ease-in-out;
 

--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -384,6 +384,7 @@ export class UiCommandHandlerService {
             const { ManageTags } = await import('../modals/manage-tags/manage-tags');
             if (this.isModalOpen(ManageTags)) break;
             const manageTagsModalRef = this.modalService.open(ManageTags, {
+              scrollable: true,
               beforeDismiss: () => manageTagsModalRef.componentInstance.canDeactivate(),
             });
             manageTagsModalRef.result.catch(() => {});
@@ -395,6 +396,7 @@ export class UiCommandHandlerService {
               await import('../modals/manage-categories/manage-categories');
             if (this.isModalOpen(ManageCategories)) break;
             const manageCategoriesModalRef = this.modalService.open(ManageCategories, {
+              scrollable: true,
               beforeDismiss: () => manageCategoriesModalRef.componentInstance.canDeactivate(),
             });
             manageCategoriesModalRef.result.catch(() => {});
@@ -404,7 +406,9 @@ export class UiCommandHandlerService {
           case 'UI_MANAGE_SERVERS': {
             const { ManageServers } = await import('../modals/manage-servers/manage-servers');
             if (this.isModalOpen(ManageServers)) break;
-            const manageServersModalRef = this.modalService.open(ManageServers);
+            const manageServersModalRef = this.modalService.open(ManageServers, {
+              scrollable: true,
+            });
             manageServersModalRef.result.catch(() => {});
             break;
           }


### PR DESCRIPTION
## Issue ID

Fixes #226

## Description

Manage Tags, Manage Categories, and Manage Servers were opened without ng-bootstrap's `scrollable` option, while each list had a hardcoded `max-height: 400px; overflow-y: auto`. With enough items, the list scrolled internally on its own fixed height while the modal could still grow past the viewport, giving a second, page-level scrollbar.

Added `scrollable: true` to the three `modalService.open()` calls (matching the pattern already used by Settings, QbSettings, TorrentDetails, and AddTorrent) and removed the hardcoded list `max-height`/`overflow-y`. The modal body now scrolls as a single unit and fills whatever space is available within the viewport.

Verified locally by opening Manage Categories against a real server with 80+ categories: the modal now stays within the viewport with a single internal scrollbar.