### PR TITLE
Fix double scrollbar in import/export torrents modals

### DIFF
--- a/packages/app/src/app/services/ui-command-handler.service.ts
+++ b/packages/app/src/app/services/ui-command-handler.service.ts
@@ -420,7 +420,10 @@ export class UiCommandHandlerService {
           case 'UI_EXPORT_TORRENTS': {
             const { ExportTorrents } = await import('../modals/export-torrents/export-torrents');
             if (this.isModalOpen(ExportTorrents)) break;
-            const exportRef = this.modalService.open(ExportTorrents, { size: 'lg' });
+            const exportRef = this.modalService.open(ExportTorrents, {
+              size: 'lg',
+              scrollable: true,
+            });
             exportRef.result.catch(() => {});
             break;
           }
@@ -428,7 +431,10 @@ export class UiCommandHandlerService {
           case 'UI_IMPORT_TORRENTS': {
             const { ImportTorrents } = await import('../modals/import-torrents/import-torrents');
             if (this.isModalOpen(ImportTorrents)) break;
-            const importRef = this.modalService.open(ImportTorrents, { size: 'lg' });
+            const importRef = this.modalService.open(ImportTorrents, {
+              size: 'lg',
+              scrollable: true,
+            });
             if (command.bbePath) {
               setModalInput(importRef, 'initialBbePath', command.bbePath);
             }


### PR DESCRIPTION
## Issue ID

Fixes #226

## Description

The Import Torrents and Export Torrents modals were also opened without ng-bootstrap's `scrollable` option, the same root cause fixed for Manage Tags/Categories/Servers in #227. With enough dynamic content (path remap rows, category path mappings, connection info, progress panels), the modal body could grow past the viewport and the page gained a second, page-level scrollbar.

Added `scrollable: true` to the `ExportTorrents` and `ImportTorrents` `modalService.open()` calls in `ui-command-handler.service.ts`, matching the pattern already used by Settings, QbSettings, TorrentDetails, AddTorrent, and the Manage * modals.

Verified locally that lint and the existing `ui-command-handler.service.spec.ts` suite (25 tests) pass.