### PR TITLE
Stop resetting all active filters when the torrent-exists modal opens

### DIFF
--- a/packages/app/src/app/modals/torrent-exists/torrent-exists.spec.ts
+++ b/packages/app/src/app/modals/torrent-exists/torrent-exists.spec.ts
@@ -88,7 +88,7 @@ describe('TorrentExists', () => {
         { provide: NgbActiveModal, useValue: mockActiveModal },
         { provide: TorrentStoreService, useValue: mockTorrentStore },
         { provide: SelectionStoreService, useValue: { setByHashes: vi.fn() } },
-        { provide: FilterService, useValue: { resetAll: vi.fn() } },
+        { provide: FilterService, useValue: { filtered: signal([{ hash: 'abc123' } as Torrent]) } },
         {
           provide: CommandBusService,
           useValue: { commands$: new Subject<any>().asObservable(), emit: vi.fn() },
@@ -222,6 +222,44 @@ describe('TorrentExists', () => {
         hash: 'abc123',
       });
     });
+
+    it('should not select or scroll, and should not touch active filters, when the torrent is hidden by the current filters', async () => {
+      await TestBed.resetTestingModule();
+      const mockSelectionStore = { setByHashes: vi.fn() };
+      const mockCommandBus = { commands$: new Subject<any>().asObservable(), emit: vi.fn() };
+
+      await TestBed.configureTestingModule({
+        imports: [TorrentExists],
+        providers: [
+          { provide: NgbActiveModal, useValue: { close: vi.fn(), dismiss: vi.fn() } },
+          { provide: TorrentStoreService, useValue: { torrentsMap: signal(new Map()) as any } },
+          { provide: SelectionStoreService, useValue: mockSelectionStore },
+          { provide: FilterService, useValue: { filtered: signal([]) } },
+          { provide: CommandBusService, useValue: mockCommandBus },
+          {
+            provide: GeneralSettingsService,
+            useValue: {
+              asObservable: vi.fn().mockReturnValue(
+                of({
+                  ...DEFAULT_GENERAL_SETTINGS,
+                  behavior: { ...DEFAULT_GENERAL_SETTINGS.behavior, deleteTorrentFile: true },
+                }),
+              ),
+            },
+          },
+          { provide: ToastService, useValue: { success: vi.fn(), danger: vi.fn() } },
+        ],
+      }).compileComponents();
+
+      const hiddenFixture = TestBed.createComponent(TorrentExists);
+      hiddenFixture.componentRef.setInput('hash', 'abc123');
+      hiddenFixture.detectChanges();
+
+      expect(mockSelectionStore.setByHashes).not.toHaveBeenCalled();
+      expect(mockCommandBus.emit).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'UI_SCROLL_TO_TORRENT' }),
+      );
+    });
   });
 
   describe('openDetails', () => {
@@ -257,7 +295,10 @@ describe('TorrentExists', () => {
           { provide: NgbActiveModal, useValue: { close: vi.fn(), dismiss: vi.fn() } },
           { provide: TorrentStoreService, useValue: mockTorrentStoreLocal },
           { provide: SelectionStoreService, useValue: { setByHashes: vi.fn() } },
-          { provide: FilterService, useValue: { resetAll: vi.fn() } },
+          {
+            provide: FilterService,
+            useValue: { filtered: signal([{ hash: 'abc123' } as Torrent]) },
+          },
           {
             provide: CommandBusService,
             useValue: { commands$: new Subject<any>().asObservable(), emit: vi.fn() },
@@ -318,7 +359,7 @@ describe('TorrentExists - showDeleteButton with deleteTorrentFile disabled', () 
         { provide: NgbActiveModal, useValue: { close: vi.fn(), dismiss: vi.fn() } },
         { provide: TorrentStoreService, useValue: { torrentsMap: signal(new Map()) as any } },
         { provide: SelectionStoreService, useValue: { setByHashes: vi.fn() } },
-        { provide: FilterService, useValue: { resetAll: vi.fn() } },
+        { provide: FilterService, useValue: { filtered: signal([{ hash: 'abc123' } as Torrent]) } },
         {
           provide: CommandBusService,
           useValue: { commands$: new Subject<any>().asObservable(), emit: vi.fn() },

--- a/packages/app/src/app/modals/torrent-exists/torrent-exists.ts
+++ b/packages/app/src/app/modals/torrent-exists/torrent-exists.ts
@@ -80,7 +80,10 @@ export class TorrentExists {
     effect(() => {
       const h = this.hash();
       if (!h) return;
-      this.filterService.resetAll();
+
+      const isVisible = this.filterService.filtered().some((t) => t.hash === h);
+      if (!isVisible) return;
+
       this.selectionStoreService.setByHashes([h]);
       this.commandBusService.emit({ type: 'UI_SCROLL_TO_TORRENT', hash: h });
     });


### PR DESCRIPTION
## Issue ID

Fixes #233

## Description

Adding a torrent that already exists in the list opened the "Torrent Already Exists" modal, but silently reset every active filter in the background: the left sidebar filters (state/category/tag/tracker/save path) visibly cleared, and the search bar's typed text stayed on screen while the underlying filtering was reset anyway (since the search box is a separate one-way-bound control that never reflects the filter service's state back).

The reset was intentional (added early in the project's history) to guarantee the conflicting torrent was visible and scrollable-to, but it wiped out the user's filters as a side effect just from encountering a duplicate-add attempt.

This now only selects and scrolls to the existing torrent if it's currently visible under the active filters; if it's hidden by a filter, the modal just opens with no selection/scroll side effect, and the active filters are left untouched either way.

## Test plan

- [x] Added a regression test covering the "torrent hidden by active filters" case (no selection, no scroll, filters untouched)
- [x] Full `@bitbutler/app` test suite passes (1954 tests)
- [x] `npm run lint` passes with zero warnings