### PR TITLE
Fix missing tooltips on truncated modal fields

### DIFF
--- a/packages/app/src/app/modals/torrent-details/torrent-details.html
+++ b/packages/app/src/app/modals/torrent-details/torrent-details.html
@@ -1,16 +1,22 @@
 <div class="modal-header bb-modal-header">
   <div class="bb-modal-header__text">
     <h5
-      #titleElement
       class="modal-title bb-title-clamp"
-      [ngbTooltip]="titleElement.offsetWidth < titleElement.scrollWidth ? torrent()?.name : null"
+      [ngbTooltip]="torrent()?.name"
+      bbTooltipOverflow
       placement="bottom"
       tooltipClass="single-line-tooltip"
     >
       {{ torrent()?.name }}
     </h5>
 
-    <div class="small text-body-secondary mt-1 bb-hash-clamp">
+    <div
+      class="small text-body-secondary mt-1 bb-hash-clamp"
+      [ngbTooltip]="torrent()?.hash"
+      bbTooltipOverflow
+      placement="bottom"
+      tooltipClass="single-line-tooltip"
+    >
       {{ 'components.modals.torrent-details.hash' | translate }}: <code>{{ torrent()?.hash }}</code>
     </div>
 

--- a/packages/app/src/app/modals/torrent-details/torrent-details.ts
+++ b/packages/app/src/app/modals/torrent-details/torrent-details.ts
@@ -38,6 +38,7 @@ import { filter } from 'rxjs';
 import { BbBtnContent } from '../../components/bb-btn-content/bb-btn-content';
 import { BbSpinner } from '../../components/bb-spinner/bb-spinner';
 import { AutofocusDirective } from '../../directives/autofocus';
+import { TooltipOverflow } from '../../directives/tooltip-overflow';
 import { AppCommand, TorrentCommand } from '../../models/command.model';
 import { GuardableModal } from '../../models/guardable-modal.interface';
 import { Torrent } from '../../models/torrent.model';
@@ -57,6 +58,7 @@ import { Tab, TorrentDetailTabComponent, TorrentDetailTabId } from './torrent-de
     BbSpinner,
     NgComponentOutlet,
     AutofocusDirective,
+    TooltipOverflow,
     NgbTooltip,
     NgbDropdownModule,
     TranslatePipe,

--- a/packages/app/src/app/modals/torrent-exists/torrent-exists.html
+++ b/packages/app/src/app/modals/torrent-exists/torrent-exists.html
@@ -6,9 +6,9 @@
       </h5>
 
       <div
-        #element
         class="small text-body-secondary mt-1 bb-hash-clamp"
-        [ngbTooltip]="element.offsetWidth < element.scrollWidth ? t.name : null"
+        [ngbTooltip]="t.name"
+        bbTooltipOverflow
         tooltipClass="single-line-tooltip"
         placement="top"
       >
@@ -65,7 +65,13 @@
       <dt class="col-4 te-label">
         {{ 'components.modals.torrent-exists.label.added-on' | translate }}
       </dt>
-      <dd class="col-8">
+      <dd
+        class="col-8 text-truncate"
+        [ngbTooltip]="(t.added_on | localTimestamp) + ' (' + (t.added_on * 1000 | timeago) + ')'"
+        placement="top"
+        bbTooltipOverflow
+        tooltipClass="single-line-tooltip"
+      >
         {{ t.added_on | localTimestamp }}
         <span class="text-body-secondary ms-1">({{ t.added_on * 1000 | timeago }})</span>
       </dd>


### PR DESCRIPTION
## Issue ID

Fixes #237

## Description

Torrent Exists and Torrent Details modals used a fragile inline overflow check (`element.offsetWidth < element.scrollWidth`) evaluated directly in the template, instead of the app's existing `bbTooltipOverflow` directive. Under zoneless change detection this check doesn't reliably re-evaluate on hover, so the tooltip could silently fail to appear even when the text was actually truncated.

- Torrent Exists: torrent name subtitle now uses `bbTooltipOverflow` instead of the manual check.
- Torrent Exists: added a tooltip to the added-on field (now truncates to a single line, same as save path).
- Torrent Details: modal title (torrent name) now uses `bbTooltipOverflow` instead of the manual check.
- Torrent Details: added a tooltip to the hash line, which previously had none.

Audited every other modal header and the main grid - all other truncatable fields already use `bbTooltipOverflow` correctly, so no further changes were needed.