### PR TITLE
Fix stale progress bar color when torrent state changes without progress changing

### DIFF
--- a/packages/app/src/app/pages/main/grid/grid.lib.spec.ts
+++ b/packages/app/src/app/pages/main/grid/grid.lib.spec.ts
@@ -1,0 +1,18 @@
+import { getGridColDefs } from './grid.lib';
+
+describe('getGridColDefs', () => {
+  const translateServiceStub = { instant: (key: string) => key } as any;
+  const uiFormatServiceStub = {} as any;
+  const torrentStoreServiceStub = {} as any;
+
+  function getColDefs() {
+    return getGridColDefs(uiFormatServiceStub, translateServiceStub, torrentStoreServiceStub);
+  }
+
+  it('always treats the progress column value as changed, so state-driven color updates are not skipped', () => {
+    const progressColDef = getColDefs().find((c) => c.colId === 'progress');
+
+    expect(progressColDef?.equals).toBeDefined();
+    expect(progressColDef!.equals!(0.5, 0.5)).toBe(false);
+  });
+});

--- a/packages/app/src/app/pages/main/grid/grid.lib.ts
+++ b/packages/app/src/app/pages/main/grid/grid.lib.ts
@@ -81,6 +81,10 @@ export function getGridColDefs(
       headerTooltip: translateService.instant('pages.main.grid.grid-lib.col-def.progress'),
       width: 135,
       cellRenderer: ProgressCellRenderer,
+      // ProgressCellRenderer's color depends on row.state, not just this column's progress
+      // value - without this, ag-grid skips refresh() when progress is unchanged but state
+      // isn't, leaving the bar showing a stale color.
+      equals: () => false,
     },
     {
       colId: 'progress_percentage',


### PR DESCRIPTION
## Issue ID

Fixes #239

## Description

The progress bar in the grid's Progress column derives its color from the torrent's `state`, but ag-grid's `progress` column only tracks the `progress` field. Ag-grid's default value-change detection skips calling a cell renderer's `refresh()` when a column's own field value is unchanged - so when a torrent's `state` changes while `progress` stays the same (very common once a torrent reaches 100%, e.g. `uploading` <-> `forcedUP`/`pausedUP`/`stoppedUP`/`queuedUP`/`stalledUP`), the bar keeps showing a stale color.

Added `equals: () => false` to the `progress` colDef so the grid always treats it as changed and refreshes `ProgressCellRenderer`, which re-reads both `progress` and `state` on every refresh.

## Test plan

- [x] Added a unit test asserting the `progress` colDef's `equals` always returns `false`
- [x] `npm run lint`
- [x] `npm test --workspace=@bitbutler/app` (2054 tests passing)