### PR TITLE
Skip torrent store update on empty maindata poll delta

### DIFF
--- a/packages/app/src/app/services/torrent-store.service.spec.ts
+++ b/packages/app/src/app/services/torrent-store.service.spec.ts
@@ -212,6 +212,23 @@ describe('TorrentStoreService', () => {
     expect(finished[0].hash).toBe('abc');
   });
 
+  it('should not change the torrentsMap/torrentsArray reference on an empty incremental delta', () => {
+    service.applyMaindata(
+      makeMaindata({
+        full_update: true,
+        torrents: { abc: { name: 'A', state: 'downloading' } as TorrentDelta },
+      }),
+    );
+
+    const mapBefore = service.torrentsMap();
+    const arrayBefore = service.torrentsArray();
+
+    service.applyMaindata(makeMaindata({}));
+
+    expect(service.torrentsMap()).toBe(mapBefore);
+    expect(service.torrentsArray()).toBe(arrayBefore);
+  });
+
   it('should return delta from applyMaindata', () => {
     const delta = service.applyMaindata(
       makeMaindata({

--- a/packages/app/src/app/services/torrent-store.service.ts
+++ b/packages/app/src/app/services/torrent-store.service.ts
@@ -140,7 +140,12 @@ export class TorrentStoreService {
         }
       }
 
-      this._torrents.set(next);
+      // Skip the signal update on a no-op delta - setting an unchanged Map still creates a new
+      // reference, which would recompute torrentsArray and cascade into a full grid
+      // reconciliation on every poll tick even when nothing actually changed.
+      if (add.length || update.length || remove.length) {
+        this._torrents.set(next);
+      }
 
       this.ingestFinished(
         [...add, ...update],


### PR DESCRIPTION
## Issue ID

Fixes #240

## Description

`TorrentStoreService.applyMaindata()` always created a new `Map` and called `this._torrents.set(next)` on every incremental maindata poll, even when the delta contained no added/updated/removed torrents. Since `torrentsArray` is a `computed()` over that Map signal, a no-op poll still produced a brand-new array reference, which cascaded into `GridPinService`'s `effect()` calling `api.setGridOption('rowData', ...)` on every single poll tick (every 2s foreground / 5s background by default) - a full grid reconciliation even when nothing changed.

`applyMaindata` now only calls `this._torrents.set(next)` when the delta actually adds, updates, or removes at least one torrent.

## Test plan

- [x] Added a unit test asserting `torrentsMap()`/`torrentsArray()` keep the same reference across an empty incremental delta (confirmed it fails without the fix)
- [x] `npm run lint`
- [x] `npm test --workspace=@bitbutler/app` (2054 tests passing)