### PR TITLE
Fix server menu radio button not resetting after a failed server switch

### DIFF
--- a/packages/electron/src/ipc/server.spec.ts
+++ b/packages/electron/src/ipc/server.spec.ts
@@ -611,14 +611,14 @@ describe('server:set-active IPC event handler', () => {
     expect(mockRebuildTrayMenu).toHaveBeenCalled();
   });
 
-  it('does not rebuild menus when id has not changed', async () => {
+  it('rebuilds menus even when id has not changed, to correct a stale radio button after a failed switch', async () => {
     const { registerServerIpcHandlers, setActiveServerId } = await import('./server.js');
     setActiveServerId('same-id');
     registerServerIpcHandlers();
     const handler = ipcOnHandlers.get('server:set-active')!;
     handler(null, 'same-id');
-    expect(mockRebuildMenu).not.toHaveBeenCalled();
-    expect(mockRebuildTrayMenu).not.toHaveBeenCalled();
+    expect(mockRebuildMenu).toHaveBeenCalled();
+    expect(mockRebuildTrayMenu).toHaveBeenCalled();
   });
 });
 

--- a/packages/electron/src/ipc/server.ts
+++ b/packages/electron/src/ipc/server.ts
@@ -24,7 +24,6 @@ export function registerServerIpcHandlers(): void {
   );
 
   ipcMain.on('server:set-active', (_event, id: string | null) => {
-    if (activeServerId === id) return;
     activeServerId = id;
     rebuildMenu();
     rebuildTrayMenu();


### PR DESCRIPTION
## Issue ID

Fixes #253

## Description

When switching servers from the app menu and the connection fails, the Servers submenu's radio button stayed checked on the unreachable server instead of snapping back to the currently active one.

Root cause: `ipcMain.on('server:set-active', ...)` in `packages/electron/src/ipc/server.ts` early-returned when the incoming id matched the already-active id, skipping the menu rebuild. On a failed switch, `UiCommandHandlerService.handleServerSwitch` explicitly calls `setActive` with the current (unchanged) server id specifically to force a menu repaint - the guard was silently swallowing that call.

This is a regression: an earlier PR (#103) originally fixed this exact bug by always rebuilding on `setActive`, but a later commit in the same PR reintroduced the early-return guard as a "skip redundant rebuild" optimization, breaking the recovery path again. Since `setActive` is only ever called with an unchanged id from that one recovery call site, removing the guard restores the fix with no unnecessary rebuilds elsewhere.

## Test plan

- [x] Updated `server.spec.ts` to assert the menu and tray are rebuilt even when the id is unchanged; verified it fails against the old code and passes after the fix
- [x] `npx vitest run` in `packages/electron` - all 270 tests pass
- [x] `npm run lint` - clean
- [x] `npm run build:electron` - compiles