### PR TITLE
Set a Content Security Policy for the Electron renderer

### DIFF
--- a/packages/electron/src/main-window.ts
+++ b/packages/electron/src/main-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app } from 'electron';
+import { BrowserWindow, app, session } from 'electron';
 import fs from 'node:fs';
 import { join } from 'node:path';
 
@@ -11,7 +11,37 @@ function firstExistingPath(paths: string[]): string | null {
   return null;
 }
 
+let cspApplied = false;
+
+function applyContentSecurityPolicy(): void {
+  if (cspApplied) return;
+  cspApplied = true;
+
+  const csp = [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ');
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [csp],
+      },
+    });
+  });
+}
+
 export function createMainWindow(startMinimized = false): BrowserWindow {
+  applyContentSecurityPolicy();
+
   const appPath = app.getAppPath();
 
   const iconCandidates = [


### PR DESCRIPTION
## Issue ID

Fixes #265

## Description

Electron logs an "Insecure Content-Security-Policy" security warning on startup because the renderer had no Content-Security-Policy set at all.

Adds a CSP applied via `session.defaultSession.webRequest.onHeadersReceived` in the main process, so it covers both the dev server load (`localhost:4200`) and the packaged `file://` load. No `unsafe-eval` is used, and everything is scoped to `'self'` since the renderer never talks to remote hosts directly - all qBittorrent traffic goes through IPC to the main process. `style-src` allows `'unsafe-inline'` because Angular injects component styles as `<style>` tags at runtime.

Verified by running the full dev flow (Angular dev server + Electron) and confirming the warning no longer appears in the console.